### PR TITLE
fix: use source field in pubspec

### DIFF
--- a/lib/src/pub/pub_file_pubspec_lock.dart
+++ b/lib/src/pub/pub_file_pubspec_lock.dart
@@ -73,7 +73,7 @@ class PubspecLockPubFile extends PubFile {
 
       if (pluginPackage['description'] != null &&
           pluginPackage['description'].runtimeType != String &&
-          pluginPackage['description']['path'] != null) {
+          pluginPackage['source'] == 'path') {
         var path = pluginPackage['description']['path'] as String;
         var relative = pluginPackage['description']['relative'] as bool;
 


### PR DESCRIPTION
the path is set to "." when we use a git referenece so to avoid this it's better to check the source instead of the path.

fix #14 