### PR TITLE
Fix for newer dart installs

### DIFF
--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -23,7 +23,7 @@ import 'package:ansi_styles/ansi_styles.dart';
 import '../command_runner.dart';
 import '../common/intellij_project.dart';
 import '../common/logger.dart';
-import '../common/utils.dart';
+import '../common/utils.dart' as utils;
 import '../common/workspace.dart';
 
 class BootstrapCommand extends Command {
@@ -46,7 +46,7 @@ class BootstrapCommand extends Command {
     var processExitCode = await currentWorkspace.execInMelosToolPath(
         currentWorkspace.isFlutterWorkspace
             ? ['flutter', ...pubGetArgs]
-            : [if (isPubSubcommand()) 'dart', ...pubGetArgs],
+            : [if (utils.isPubSubcommand()) 'dart', ...pubGetArgs],
         onlyOutputOnError: true);
     if (processExitCode > 0) {
       logger

--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -23,6 +23,7 @@ import 'package:ansi_styles/ansi_styles.dart';
 import '../command_runner.dart';
 import '../common/intellij_project.dart';
 import '../common/logger.dart';
+import '../common/utils.dart';
 import '../common/workspace.dart';
 
 class BootstrapCommand extends Command {
@@ -45,7 +46,7 @@ class BootstrapCommand extends Command {
     var processExitCode = await currentWorkspace.execInMelosToolPath(
         currentWorkspace.isFlutterWorkspace
             ? ['flutter', ...pubGetArgs]
-            : ['dart', ...pubGetArgs],
+            : [if (isPubSubcommand()) 'dart', ...pubGetArgs],
         onlyOutputOnError: true);
     if (processExitCode > 0) {
       logger

--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -45,7 +45,7 @@ class BootstrapCommand extends Command {
     var processExitCode = await currentWorkspace.execInMelosToolPath(
         currentWorkspace.isFlutterWorkspace
             ? ['flutter', ...pubGetArgs]
-            : pubGetArgs,
+            : ['dart', ...pubGetArgs],
         onlyOutputOnError: true);
     if (processExitCode > 0) {
       logger

--- a/packages/melos/lib/src/command/publish.dart
+++ b/packages/melos/lib/src/command/publish.dart
@@ -119,7 +119,12 @@ class PublishCommand extends Command {
         'Publishing ${unpublishedPackages.length} packages to registry:');
 
     // TODO flutter pub if flutter packages detected? May not be necessary
-    List<String> execArgs = ['dart', 'pub', '--verbosity=warning', 'publish'];
+    List<String> execArgs = [
+      if (isPubSubcommand()) 'dart',
+      'pub',
+      '--verbosity=warning',
+      'publish'
+    ];
     if (dryRun) {
       execArgs.add('--dry-run');
     } else {

--- a/packages/melos/lib/src/command/publish.dart
+++ b/packages/melos/lib/src/command/publish.dart
@@ -119,7 +119,7 @@ class PublishCommand extends Command {
         'Publishing ${unpublishedPackages.length} packages to registry:');
 
     // TODO flutter pub if flutter packages detected? May not be necessary
-    List<String> execArgs = ['pub', '--verbosity=warning', 'publish'];
+    List<String> execArgs = ['dart', 'pub', '--verbosity=warning', 'publish'];
     if (dryRun) {
       execArgs.add('--dry-run');
     } else {

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -275,3 +275,11 @@ Future<int> startProcess(List<String> execArgs,
 
   return exitCode;
 }
+
+bool isPubSubcommand() {
+  try {
+    return Process.runSync('pub', ['--version']).exitCode != 0;
+  } on ProcessException catch (e) {
+    return true;
+  }
+}

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -29,7 +29,6 @@ import '../pub/pub_deps_list.dart';
 import 'git.dart';
 import 'package.dart';
 import 'utils.dart' as utils;
-import 'utils.dart';
 import 'workspace_config.dart';
 import 'workspace_state.dart';
 
@@ -231,12 +230,12 @@ class MelosWorkspace {
     final pubListCommandOutput = await Process.run(
       isFlutterWorkspace
           ? 'flutter'
-          : isPubSubcommand()
+          : utils.isPubSubcommand()
               ? 'dart'
               : 'pub',
       isFlutterWorkspace
           ? ['pub', 'deps', '--', ...pubDepsExecArgs]
-          : [if (isPubSubcommand()) 'pub', 'deps', ...pubDepsExecArgs],
+          : [if (utils.isPubSubcommand()) 'pub', 'deps', ...pubDepsExecArgs],
       runInShell: true,
       workingDirectory: melosToolPath,
     );

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -29,6 +29,7 @@ import '../pub/pub_deps_list.dart';
 import 'git.dart';
 import 'package.dart';
 import 'utils.dart' as utils;
+import 'utils.dart';
 import 'workspace_config.dart';
 import 'workspace_state.dart';
 
@@ -228,10 +229,14 @@ class MelosWorkspace {
 
     List<String> pubDepsExecArgs = ['--style=list', '--dev'];
     final pubListCommandOutput = await Process.run(
-      isFlutterWorkspace ? 'flutter' : 'pub',
+      isFlutterWorkspace
+          ? 'flutter'
+          : isPubSubcommand()
+              ? 'dart'
+              : 'pub',
       isFlutterWorkspace
           ? ['pub', 'deps', '--', ...pubDepsExecArgs]
-          : ['deps', ...pubDepsExecArgs],
+          : [if (isPubSubcommand()) 'pub', 'deps', ...pubDepsExecArgs],
       runInShell: true,
       workingDirectory: melosToolPath,
     );


### PR DESCRIPTION
In newer installs of dart, pub is now a subcommand of dart rather than it's own executable. 
This causes several melos commands to fail if the user doesn't have the old pub command on their path, and only the new `dart pub` subcommand. I don't know everywhere you are using the old `pub` executable, but I've fixed the places that I have found, and verified it works with at least the `melos bootstrap` command in one of my workspaces.

Included is a new utility function to check if the user has the old `pub` executable available or not.