### PR TITLE
feat: Add `--yes` flag to `melos version` for ci support.

### DIFF
--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -62,6 +62,9 @@ class VersionCommand extends Command {
         negatable: true,
         help:
             'By default, melos version will commit changes to pubspec.yaml files and tag the release. Pass --no-git-tag-version to disable the behavior.');
+    argParser.addFlag('yes',
+       defaultsTo: false,
+       help: 'Skips the Y/N prompt');
   }
 
   @override
@@ -73,6 +76,7 @@ class VersionCommand extends Command {
     bool graduate = argResults['graduate'] as bool;
     bool tag = argResults['git-tag-version'] as bool;
     bool prerelease = argResults['prerelease'] as bool;
+    bool skipPrompt = argResults['yes'] as bool;
     Set<MelosPackage> packagesToVersion = <MelosPackage>{};
     Map<String, List<ConventionalCommit>> packageCommits = {};
     Set<MelosPackage> dependentPackagesToVersion = <MelosPackage>{};
@@ -210,8 +214,7 @@ class VersionCommand extends Command {
       }),
     ], paddingSize: 3));
 
-    // TODO prompt skip support for CI environments (--yes)
-    bool shouldContinue = promptBool();
+    bool shouldContinue = skipPrompt || promptBool();
     if (!shouldContinue) {
       logger.stdout(AnsiStyles.red('Operation was canceled.'));
       exitCode = 1;

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -63,8 +63,8 @@ class VersionCommand extends Command {
         help:
             'By default, melos version will commit changes to pubspec.yaml files and tag the release. Pass --no-git-tag-version to disable the behavior.');
     argParser.addFlag('yes',
-       defaultsTo: false,
-       help: 'Skips the Y/N prompt at the beginning of the command');
+        defaultsTo: false,
+        help: 'Skips the Y/N prompt at the beginning of the command');
   }
 
   @override

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -64,7 +64,7 @@ class VersionCommand extends Command {
             'By default, melos version will commit changes to pubspec.yaml files and tag the release. Pass --no-git-tag-version to disable the behavior.');
     argParser.addFlag('yes',
        defaultsTo: false,
-       help: 'Skips the Y/N prompt');
+       help: 'Skips the Y/N prompt at the beginning of the command');
   }
 
   @override

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -228,7 +228,11 @@ class MelosWorkspace {
 
     List<String> pubDepsExecArgs = ['--style=list', '--dev'];
     final pubListCommandOutput = await Process.run(
-      isFlutterWorkspace ? 'flutter' : utils.isPubSubcommand() ? 'dart' : 'pub',
+      isFlutterWorkspace
+          ? 'flutter'
+          : utils.isPubSubcommand()
+              ? 'dart'
+              : 'pub',
       isFlutterWorkspace
           ? ['pub', 'deps', '--', ...pubDepsExecArgs]
           : [if (utils.isPubSubcommand()) 'pub', 'deps', ...pubDepsExecArgs],


### PR DESCRIPTION
The version command requires a prompt which blocks it to be run on CI.
This PR adds a `yes` flag so the prompt can be skipped.

This also fixed a format issue.