### PR TITLE
chore: switch to new GitHub action path syntax

### DIFF
--- a/.github/workflows/scripts/install-flutter.sh
+++ b/.github/workflows/scripts/install-flutter.sh
@@ -4,7 +4,7 @@ BRANCH=$1
 
 cd $HOME
 git clone https://github.com/flutter/flutter.git --depth 1 -b $BRANCH _flutter
-echo "::add-path::$HOME/_flutter/bin"
-echo "::add-path::$HOME/.pub-cache/bin"
-echo "::add-path::$HOME/_flutter/.pub-cache/bin"
-echo "::add-path::$HOME/_flutter/bin/cache/dart-sdk/bin"
+echo "$HOME/_flutter/bin" >> $GITHUB_PATH
+echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
+echo "$HOME/_flutter/.pub-cache/bin" >> $GITHUB_PATH
+echo "$HOME/_flutter/bin/cache/dart-sdk/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Fixes current CI by remove deprecated GitHub action syntax.