### PR TITLE
feat: version `--preid` support

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -22,9 +22,9 @@ ide:
 
 scripts:
   analyze: melos exec -c 1 --ignore="*monorepo*" -- "dartanalyzer . --options=\$MELOS_ROOT_PATH/analysis_options.yaml"
-  format: dartfmt -w .
+  format: dart format -o write .
   test: melos exec -c 1 --file-exists="test/\$MELOS_PACKAGE_NAME_test.dart" -- "pub run test test/\$MELOS_PACKAGE_NAME_test.dart"
-  version: dart scripts/generate_version.dart
+  version: dart run scripts/generate_version.dart
 
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -17,10 +17,10 @@
 
 import 'dart:io';
 
-import 'package:args/command_runner.dart' show Command;
-import 'package:pool/pool.dart' show Pool;
 import 'package:ansi_styles/ansi_styles.dart';
+import 'package:args/command_runner.dart' show Command;
 import 'package:conventional_commit/conventional_commit.dart';
+import 'package:pool/pool.dart' show Pool;
 
 import '../command_runner.dart';
 import '../common/git.dart';
@@ -50,7 +50,7 @@ class VersionCommand extends Command {
         defaultsTo: false,
         negatable: false,
         help:
-            'Graduate current prerelease versioned packages to stable versions, e.g. "0.10.0-dev.1" becomes "0.10.0". Cannot be combined with prerelease flag.');
+            'Graduate current prerelease versioned packages to stable versions, e.g. "0.10.0-dev.1" would become "0.10.0". Cannot be combined with prerelease flag.');
     argParser.addFlag('changelog',
         abbr: 'c',
         defaultsTo: true,
@@ -66,6 +66,10 @@ class VersionCommand extends Command {
         defaultsTo: false,
         negatable: false,
         help: 'Skips the Y/N prompt at the beginning of the command');
+    argParser.addOption('preid',
+        defaultsTo: 'dev',
+        help:
+            'When run with this option, melos version will increment prerelease versions using the specified prerelease identifier, e.g. using a "nullsafety" preid along with the --prerelease flag would result in a version in the format "1.0.0-nullsafety.0".');
   }
 
   @override
@@ -78,6 +82,8 @@ class VersionCommand extends Command {
     bool tag = argResults['git-tag-version'] as bool;
     bool prerelease = argResults['prerelease'] as bool;
     bool skipPrompt = argResults['yes'] as bool;
+    String preid = argResults['preid'] as String;
+
     Set<MelosPackage> packagesToVersion = <MelosPackage>{};
     Map<String, List<ConventionalCommit>> packageCommits = {};
     Set<MelosPackage> dependentPackagesToVersion = <MelosPackage>{};
@@ -99,6 +105,7 @@ class VersionCommand extends Command {
             PackageUpdateReason.graduate,
             graduate: graduate,
             prerelease: prerelease,
+            preid: preid,
           ));
           MelosPackage packageUnscoped = currentWorkspace.packagesNoScope
               .firstWhere((element) => element.name == package.name);
@@ -147,10 +154,15 @@ class VersionCommand extends Command {
       }
     });
 
-    pendingPackageUpdates.addAll(packagesToVersion.map((package) =>
-        MelosPendingPackageUpdate(
-            package, packageCommits[package.name], PackageUpdateReason.commit,
-            graduate: graduate, prerelease: prerelease)));
+    pendingPackageUpdates
+        .addAll(packagesToVersion.map((package) => MelosPendingPackageUpdate(
+              package,
+              packageCommits[package.name],
+              PackageUpdateReason.commit,
+              graduate: graduate,
+              prerelease: prerelease,
+              preid: preid,
+            )));
 
     dependentPackagesToVersion.forEach((package) {
       if (graduate && package.version.isFirstPreRelease) return;
@@ -161,6 +173,9 @@ class VersionCommand extends Command {
           PackageUpdateReason.dependency,
           graduate: graduate,
           prerelease: prerelease,
+          // TODO Should dependent packages also get the same preid, can we expose this as an option?
+          // TODO In the case of "nullsafety" it doesn't make sense for dependent packages to also become nullsafety preid versions.
+          // preid: preid,
         ));
       }
     });

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -123,16 +123,6 @@ class MelosWorkspace {
       });
     }
 
-    if (ignore.isNotEmpty) {
-      // Ignore packages filter.
-      filterResult = filterResult.where((package) {
-        final matchedPattern = ignore.firstWhere((pattern) {
-          return Glob(pattern).matches(package.name);
-        }, orElse: () => null);
-        return matchedPattern == null;
-      });
-    }
-
     if (dirExists.isNotEmpty) {
       // Directory exists packages filter, multiple filters behaviour is 'AND'.
       filterResult = filterResult.where((package) {
@@ -183,7 +173,7 @@ class MelosWorkspace {
       _packages = packagesFilteredWithPublishStatus;
     }
 
-    // --scope
+    // --since
     if (since != null) {
       var pool = Pool(10);
       var packagesFilteredWithGitCommitsSince = <MelosPackage>[];

--- a/packages/melos/lib/src/common/workspace_state.dart
+++ b/packages/melos/lib/src/common/workspace_state.dart
@@ -28,6 +28,9 @@ var _header = '''# This file tracks workspace state.
 # This file should be version controlled and should not be manually edited.
 ''';
 
+// TODO MelosWorkspaceState currently not in use.
+// TODO MelosWorkspaceState currently not in use.
+// TODO MelosWorkspaceState currently not in use.
 class MelosWorkspaceState {
   final File _stateFile;
   final Map _currentState;


### PR DESCRIPTION
Supporting package owners releasing `nullsafety` preid versions, by adding the `--preid` option to allow specifying a custom preid string.

Closes #29.

**Example**:

```sh
melos version --prerelease --preid=nullsafety --scope="*storage*"
```
![image](https://user-images.githubusercontent.com/5347038/99884964-96c97b00-2c29-11eb-83a1-cc8707c1f37b.png)
