### PR TITLE
chore(ci): update github actions dependency versions

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -1,5 +1,4 @@
-name: pr_title
-
+name: 'PR Title is Conventional'
 on:
   pull_request_target:
     types:
@@ -8,9 +7,9 @@ on:
       - synchronize
 
 jobs:
-  validate:
+  main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v1.2.0
+      - uses: amannn/action-semantic-pull-request@v2.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
@@ -48,7 +48,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
@@ -60,7 +60,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Install Flutter"
         run: .\.github\workflows\scripts\install-flutter.bat stable
       - name: "Install Tools"


### PR DESCRIPTION

I was just in this area for react-native-firebase, so I looked at the actions here and thought I would reverse some entropy for you

checkout was v2 in one place, v1 in others, semantic PR title
was updated - I harmonized it with react-native-firebase version
since that was tested and working post-upgrade

Note:
- I don't have access to invertase/melos.git so couldn't make an in-repo branch, but I don't mind a fork workflow :-)
- the `.github/workflow/scripts` should really be github actions, those are general purpose "install dart", "install flutter" items, I'm surprised they are not? This one looks popular https://github.com/marketplace/actions/flutter-action