### PR TITLE
feat: add "ignore" support on "melos.yaml" configuration

### DIFF
--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -160,7 +160,8 @@ class MelosCommandRunner extends CommandRunner {
         since: since,
         skipPrivate: argResults[filterOptionNoPrivate] as bool,
         published: argResults[filterOptionPublished] as bool,
-        ignore: argResults[filterOptionIgnore] as List<String>,
+        ignore: (argResults[filterOptionIgnore] as List<String>)
+          ..addAll(currentWorkspace.config.ignore),
         dirExists: argResults[filterOptionDirExists] as List<String>,
         fileExists: argResults[filterOptionFileExists] as List<String>,
       );

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -96,7 +96,7 @@ class MelosWorkspace {
   Future<List<MelosPackage>> loadPackagesWithNames(
       List<String> packageNames) async {
     if (packages != null) return Future.value(packages);
-    final packageGlobs = config.packages;
+    final packagePatterns = config.packages;
 
     var filterResult =
         Directory(path).list(recursive: true, followLinks: false).where((file) {
@@ -104,9 +104,9 @@ class MelosWorkspace {
     }).where((file) {
       // Filter matching 'packages' config from melos.yaml
       // No 'package' glob patterns in 'melos.yaml' so skip all packages.
-      if (packageGlobs.isEmpty) return false;
-      final matchedPattern = packageGlobs.firstWhere((pattern) {
-        return pattern.matches(file.path);
+      if (packagePatterns.isEmpty) return false;
+      final matchedPattern = packagePatterns.firstWhere((pattern) {
+        return Glob(pattern).matches(file.path);
       }, orElse: () => null);
       return matchedPattern != null;
     }).asyncMap((entity) {
@@ -135,7 +135,7 @@ class MelosWorkspace {
     bool published,
   }) async {
     if (packages != null) return Future.value(packages);
-    final packageGlobs = config.packages;
+    final packagePatterns = config.packages;
 
     var filterResult =
         Directory(path).list(recursive: true, followLinks: false).where((file) {
@@ -143,9 +143,9 @@ class MelosWorkspace {
     }).where((file) {
       // Filter matching 'packages' config from melos.yaml
       // No 'package' glob patterns in 'melos.yaml' so skip all packages.
-      if (packageGlobs.isEmpty) return false;
-      final matchedPattern = packageGlobs.firstWhere((pattern) {
-        return pattern.matches(file.path);
+      if (packagePatterns.isEmpty) return false;
+      final matchedPattern = packagePatterns.firstWhere((pattern) {
+        return Glob(pattern).matches(file.path);
       }, orElse: () => null);
       return matchedPattern != null;
     }).asyncMap((entity) {

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -63,10 +63,18 @@ class MelosWorkspaceConfig {
 
   MelosWorkspaceConfig._(this._name, this._path, this._yamlContents);
 
-  List<Glob> get packages {
-    final globs = _yamlContents['packages'] as YamlList;
-    if (globs == null) return <Glob>[];
-    return globs.map((globString) => Glob(globString as String)).toList();
+  List<String> get packages {
+    final patterns = _yamlContents['packages'] as YamlList;
+    if (patterns == null) return <String>[];
+    return List<String>.from(patterns);
+  }
+
+  /// Glob patterns defined in "melos.yaml" ignore of packages to always exclude
+  /// regardless of any custom CLI filter options.
+  List<String> get ignore {
+    final patterns = _yamlContents['ignore'] as YamlList;
+    if (patterns == null) return <String>[];
+    return List<String>.from(patterns);
   }
 
   static Future<MelosWorkspaceConfig> fromDirectory(Directory directory) async {

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -17,7 +17,6 @@
 
 import 'dart:io';
 
-import 'package:glob/glob.dart';
 import 'package:path/path.dart';
 import 'package:yaml/yaml.dart';
 


### PR DESCRIPTION
Adds support for specifying default "ignore" patterns inside the "melos.yaml" configuration file.

**Example:**

```yaml
name: MyWorkspace
packages:
  - packages/**
  - "*"

ignore:
  - "not_me*"
```


Additionally refactored  `MelosWorkspaceConfig.patterns` to not depend on Glob.