### PR TITLE
feat: add `flutter` package filter

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -283,3 +283,13 @@ Include only packages where a specific file exists in the package.
 # Only bootstrap packages with an README.md file
 melos bootstrap --file-exists="README.md"
 ```
+
+### --flutter
+
+Filter packages where the package depends on the Flutter SDK.
+
+```bash
+melos exec --flutter -- flutter test
+```
+
+Use `--no-flutter` to filter packages that do not depend on the Flutter SDK.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -293,3 +293,12 @@ melos exec --flutter -- flutter test
 ```
 
 Use `--no-flutter` to filter packages that do not depend on the Flutter SDK.
+
+### --depends-on
+
+Include only packages that depend on specific dependencies.
+
+```bash
+melos exec --depends-on="flutter" --depends-on="firebase_core" -- flutter test
+```
+Use `--no-depends-on` to filter packages that do not depend on the given dependencies.

--- a/packages/melos/lib/src/command/run.dart
+++ b/packages/melos/lib/src/command/run.dart
@@ -125,6 +125,7 @@ class RunCommand extends Command {
         since: script.selectPackageOptions[filterOptionSince] as String,
         skipPrivate: script.selectPackageOptions[filterOptionNoPrivate] as bool,
         published: script.selectPackageOptions[filterOptionPublished] as bool,
+        hasFlutter: script.selectPackageOptions[filterOptionFlutter] as bool,
       );
 
       var choices = currentWorkspace.packages

--- a/packages/melos/lib/src/command/run.dart
+++ b/packages/melos/lib/src/command/run.dart
@@ -126,6 +126,10 @@ class RunCommand extends Command {
         skipPrivate: script.selectPackageOptions[filterOptionNoPrivate] as bool,
         published: script.selectPackageOptions[filterOptionPublished] as bool,
         hasFlutter: script.selectPackageOptions[filterOptionFlutter] as bool,
+        dependsOn:
+            script.selectPackageOptions[filterOptionDependsOn] as List<String>,
+        noDependsOn: script.selectPackageOptions[filterOptionNoDependsOn]
+            as List<String>,
       );
 
       var choices = currentWorkspace.packages

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -110,6 +110,18 @@ class MelosCommandRunner extends CommandRunner {
           'Include only packages where a specific file exists in the package.',
     );
 
+    argParser.addMultiOption(
+      filterOptionDependsOn,
+      valueHelp: 'dependantPackageName',
+      help: 'Include only packages that depend on specific packages.',
+    );
+
+    argParser.addMultiOption(
+      filterOptionNoDependsOn,
+      valueHelp: 'noDependantPackageName',
+      help: 'Include only packages that *dont* depend on specific packages.',
+    );
+
     addCommand(ExecCommand());
     addCommand(BootstrapCommand());
     addCommand(CleanCommand());
@@ -173,6 +185,8 @@ class MelosCommandRunner extends CommandRunner {
         dirExists: argResults[filterOptionDirExists] as List<String>,
         fileExists: argResults[filterOptionFileExists] as List<String>,
         hasFlutter: argResults[filterOptionFlutter] as bool,
+        dependsOn: argResults[filterOptionDependsOn] as List<String>,
+        noDependsOn: argResults[filterOptionNoDependsOn] as List<String>,
       );
     }
 

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -67,6 +67,14 @@ class MelosCommandRunner extends CommandRunner {
           'Filter packages where the current local package version exists on pub.dev. Or "-no-published" to filter packages that have not had their current version published yet.',
     );
 
+    argParser.addFlag(
+      filterOptionFlutter,
+      negatable: true,
+      defaultsTo: null,
+      help:
+          'Filter packages where the package depends on the Flutter SDK. Or "-no-flutter" to filter packages that do not depend on the Flutter SDK.',
+    );
+
     argParser.addMultiOption(
       filterOptionScope,
       valueHelp: 'glob',
@@ -164,6 +172,7 @@ class MelosCommandRunner extends CommandRunner {
           ..addAll(currentWorkspace.config.ignore),
         dirExists: argResults[filterOptionDirExists] as List<String>,
         fileExists: argResults[filterOptionFileExists] as List<String>,
+        hasFlutter: argResults[filterOptionFlutter] as bool,
       );
     }
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -38,6 +38,8 @@ var filterOptionSince = 'since';
 var filterOptionNoPrivate = 'no-private';
 var filterOptionPublished = 'published';
 var filterOptionFlutter = 'flutter';
+var filterOptionDependsOn = 'depends-on';
+var filterOptionNoDependsOn = 'no-depends-on';
 var scriptOptionSelectPackage = 'select-package';
 
 // MELOS_PACKAGES environment variable is a comma delimited list of

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -37,6 +37,7 @@ var filterOptionFileExists = 'file-exists';
 var filterOptionSince = 'since';
 var filterOptionNoPrivate = 'no-private';
 var filterOptionPublished = 'published';
+var filterOptionFlutter = 'flutter';
 var scriptOptionSelectPackage = 'select-package';
 
 // MELOS_PACKAGES environment variable is a comma delimited list of

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -134,6 +134,8 @@ class MelosWorkspace {
     bool skipPrivate,
     bool published,
     bool hasFlutter,
+    List<String> dependsOn,
+    List<String> noDependsOn,
   }) async {
     if (packages != null) return Future.value(packages);
     final packagePatterns = config.packages;
@@ -248,9 +250,31 @@ class MelosWorkspace {
 
     // --flutter / --no-flutter
     if (hasFlutter != null) {
-      packages = packages
-          .where((package) => package.isFlutterPackage == hasFlutter)
-          .toList();
+      if (hasFlutter) {
+        dependsOn.add("flutter");
+      } else {
+        noDependsOn.add("flutter");
+      }
+    }
+
+    // --depends-on
+    if (dependsOn.isNotEmpty) {
+      packages = packages.where((package) {
+        return dependsOn.every((element) {
+          return package.dependencies.containsKey(element) ||
+              package.devDependencies.containsKey(element);
+        });
+      }).toList();
+    }
+
+    // --no-depends-on
+    if (noDependsOn.isNotEmpty) {
+      packages = packages.where((package) {
+        return noDependsOn.every((element) {
+          return !package.dependencies.containsKey(element) &&
+              !package.devDependencies.containsKey(element);
+        });
+      }).toList();
     }
 
     return packages;

--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -133,6 +133,7 @@ class MelosWorkspace {
     List<String> fileExists,
     bool skipPrivate,
     bool published,
+    bool hasFlutter,
   }) async {
     if (packages != null) return Future.value(packages);
     final packagePatterns = config.packages;
@@ -211,7 +212,6 @@ class MelosWorkspace {
       }).drain();
       packages = packagesFilteredWithPublishStatus;
     }
-
     // --since
     if (since != null) {
       var pool = Pool(10);
@@ -244,6 +244,13 @@ class MelosWorkspace {
       }).toList();
     } else {
       packagesNoScope = packages;
+    }
+
+    // --flutter / --no-flutter
+    if (hasFlutter != null) {
+      packages = packages
+          .where((package) => package.isFlutterPackage == hasFlutter)
+          .toList();
     }
 
     return packages;

--- a/packages/melos/lib/src/common/workspace_script.dart
+++ b/packages/melos/lib/src/common/workspace_script.dart
@@ -92,6 +92,12 @@ Map<String, dynamic> _validateSelectPackageOptions(
       selectPackageOptions[filterOptionPublished],
     );
   }
+  if (selectPackageOptions.containsKey(filterOptionFlutter)) {
+    result[filterOptionFlutter] = _asBool(
+      filterOptionFlutter,
+      selectPackageOptions[filterOptionFlutter],
+    );
+  }
 
   return result;
 }

--- a/packages/melos/lib/src/common/workspace_script.dart
+++ b/packages/melos/lib/src/common/workspace_script.dart
@@ -70,6 +70,14 @@ Map<String, dynamic> _validateSelectPackageOptions(
     filterOptionFileExists,
     selectPackageOptions[filterOptionFileExists],
   );
+  result[filterOptionDependsOn] = _asStringList(
+    filterOptionDependsOn,
+    selectPackageOptions[filterOptionDependsOn],
+  );
+  result[filterOptionNoDependsOn] = _asStringList(
+    filterOptionNoDependsOn,
+    selectPackageOptions[filterOptionNoDependsOn],
+  );
 
   // String
   if (selectPackageOptions.containsKey(filterOptionSince)) {


### PR DESCRIPTION
Exposes a `flutter` package filter to the CLI and yaml config.

My specific use case is running tests `flutter test`/`dart test`