### PR TITLE
feat: rework versioning with tests to support nullsafety prerelease versioning

### DIFF
--- a/.github/workflows/scripts/install-tools.bat
+++ b/.github/workflows/scripts/install-tools.bat
@@ -1,4 +1,2 @@
-CD packages\melos\
-CMD /K dart pub global activate --source=path .
-CD /D %GITHUB_WORKSPACE%
+CMD /K dart pub global activate --source=path . --executable=melos
 melos bootstrap

--- a/.github/workflows/scripts/install-tools.sh
+++ b/.github/workflows/scripts/install-tools.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-cd packages/melos
-dart pub get
-dart pub global activate --source=path .
-cd ../..
+dart pub global activate --source="path" . --executable="melos"
 melos bootstrap

--- a/melos.yaml
+++ b/melos.yaml
@@ -30,7 +30,8 @@ scripts:
 
   test:
     description: Run tests in a specific package.
-    run: melos exec -c 1 -- "dart pub run test test/\$MELOS_PACKAGE_NAME_test.dart"
+    # TODO(Salakar) 'dart pub get' is necessary for the 'melos' package as we're using it on itself
+    run: melos exec -c 1 -- "dart pub get && dart pub run test test/\$MELOS_PACKAGE_NAME_test.dart"
     select-package:
       file-exists:
         - "test/$MELOS_PACKAGE_NAME_test.dart"

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -85,7 +85,7 @@ class MelosChangelog extends Changelog {
         header += '\n\n> Note: This release has breaking changes.';
       }
 
-      final commits = List.from(update.commits
+      final commits = List<ConventionalCommit>.from(update.commits
           .where((ConventionalCommit commit) => !commit.isMergeCommit)
           .toList());
 

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -175,7 +175,7 @@ class MelosPendingPackageUpdate {
   SemverReleaseType get semverReleaseType {
     if (reason == PackageUpdateReason.dependency) {
       // Version bumps for dependencies should be patches.
-      // If the dependencies had breaking changes then this package would have had commits to update it separately.
+      // If the dependencies had breaking changes then this package should have had commits to update it separately.
       return SemverReleaseType.patch;
     }
 

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -22,6 +22,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'changelog.dart';
 import 'package.dart';
+import 'versioning.dart' as versioning;
 
 /// Enum representing why the version has been changed when running 'version' command.
 enum PackageUpdateReason {
@@ -75,100 +76,10 @@ class MelosPendingPackageUpdate {
     return package.version;
   }
 
-  /// Returns the next stable version based on the commits in this
-  Version get nextStableRelease {
-    // For simplicity's sake, we avoid using + after the version reaches 1.0.0.
-    if (currentVersion.major > 0) {
-      switch (semverReleaseType) {
-        case SemverReleaseType.major:
-          return currentVersion.nextBreaking;
-        case SemverReleaseType.minor:
-          return currentVersion.nextMinor;
-        case SemverReleaseType.patch:
-        default:
-          return currentVersion.nextPatch;
-      }
-    } else {
-      // Although semantic versioning doesn't promise any compatibility between versions prior to 1.0.0,
-      // the Dart community convention is to treat those versions semantically as well. The interpretation
-      // of each number is just shifted down one slot:
-      //   - going from 0.1.2 to 0.2.0 indicates a breaking change
-      //   - going to 0.1.3 indicates a new feature
-      //   - going to 0.1.2+1 indicates a change that doesn't affect the public API
-      switch (semverReleaseType) {
-        case SemverReleaseType.major:
-          return currentVersion.nextMinor;
-        case SemverReleaseType.minor:
-          return currentVersion.nextPatch;
-        case SemverReleaseType.patch:
-        default:
-          // Bump the build number, or set it if it does not exist.
-          final currentBuild = currentVersion.build.length == 1
-              ? currentVersion.build[0] as int
-              : 0;
-          return Version(
-            currentVersion.major,
-            currentVersion.minor,
-            currentVersion.patch,
-            build: (currentBuild + 1).toString(),
-          );
-      }
-    }
-  }
-
-  Version get nextPreRelease {
-    if (currentVersion.isPreRelease) {
-      final currentPre = currentVersion.preRelease.length == 2
-          ? currentVersion.preRelease[1] as int
-          : -1;
-      // Note we preserve the current prereleases preid if no preid option specified.
-      // So 1.0.0-nullsafety.0 would become ...-nullsafety.X rather than use the default preid "dev".
-      var nextPreidInt = currentPre + 1;
-      final nextPreidName = preid ?? currentVersion.preRelease[0] as String;
-
-      // Reset the preid int if preid name has changed,
-      // e.g. was "...dev.3" and is now a "nullsafety" preid so the next
-      // prerelease version becomes "...nullsafety.0" instead of "...nullsafety.4".
-      if (nextPreidName != currentVersion.preRelease[0]) {
-        nextPreidInt = 0;
-      }
-
-      return Version(
-        currentVersion.major,
-        currentVersion.minor,
-        currentVersion.patch,
-        pre: '$nextPreidName.$nextPreidInt',
-      );
-    }
-
-    final nextVersion = nextStableRelease;
-    return Version(
-      nextVersion.major,
-      nextVersion.minor,
-      nextVersion.patch,
-      pre: '${preid ?? 'dev'}.0',
-    );
-  }
-
   /// Next pub version that will occur as part of this package update.
   Version get nextVersion {
-    if (reason == PackageUpdateReason.graduate) {
-      return Version(
-        currentVersion.major,
-        currentVersion.minor,
-        currentVersion.patch,
-      );
-    }
-
-    if (currentVersion.isPreRelease && graduate) {
-      return nextStableRelease;
-    } else if (currentVersion.isPreRelease) {
-      return nextPreRelease;
-    } else if (prerelease) {
-      return nextPreRelease;
-    }
-
-    return nextStableRelease;
+    return versioning.nextVersion(currentVersion, semverReleaseType,
+        graduate: graduate, preid: preid, prerelease: prerelease);
   }
 
   /// Taking into account all the commits in this update, what is the highest [SemverReleaseType].

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'package:conventional_commit/conventional_commit.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+Version nextStableVersion(
+    Version currentVersion, SemverReleaseType releaseType) {
+  // For simplicity's sake, we avoid using + after the version reaches 1.0.0.
+  if (currentVersion.major > 0) {
+    switch (releaseType) {
+      case SemverReleaseType.major:
+        return currentVersion.nextBreaking;
+      case SemverReleaseType.minor:
+        return currentVersion.nextMinor;
+      case SemverReleaseType.patch:
+      default:
+        return currentVersion.nextPatch;
+    }
+  }
+
+  // Although semantic versioning doesn't promise any compatibility between versions prior to 1.0.0,
+  // the Dart community convention is to treat those versions semantically as well. The interpretation
+  // of each number is just shifted down one slot:
+  //   - going from 0.1.2 to 0.2.0 indicates a breaking change
+  //   - going to 0.1.3 indicates a new feature
+  //   - going to 0.1.2+1 indicates a change that doesn't affect the public API
+  switch (releaseType) {
+    case SemverReleaseType.major:
+      return currentVersion.nextMinor;
+    case SemverReleaseType.minor:
+      return currentVersion.nextPatch;
+    case SemverReleaseType.patch:
+    default:
+      // Bump the build number, or set it if it does not exist.
+      final currentBuild =
+          currentVersion.build.length == 1 ? currentVersion.build[0] as int : 0;
+      return Version(
+        currentVersion.major,
+        currentVersion.minor,
+        currentVersion.patch,
+        build: (currentBuild + 1).toString(),
+      );
+  }
+}
+
+Version nextPrereleaseVersion(
+    Version currentVersion, SemverReleaseType releaseType, String preid) {
+  if (currentVersion.isPreRelease) {
+    final currentPre = currentVersion.preRelease.length == 2
+        ? currentVersion.preRelease[1] as int
+        : -1;
+    // Note we preserve the current prereleases preid if no preid option specified.
+    // So 1.0.0-nullsafety.0 would become ...-nullsafety.X rather than use the default preid "dev".
+    var nextPreidInt = currentPre + 1;
+    final nextPreidName = preid ?? currentVersion.preRelease[0] as String;
+
+    // Reset the preid int if preid name has changed,
+    // e.g. was "...dev.3" and is now a "nullsafety" preid so the next
+    // prerelease version becomes "...nullsafety.0" instead of "...nullsafety.4".
+    if (nextPreidName != currentVersion.preRelease[0]) {
+      nextPreidInt = 0;
+    }
+
+    return Version(
+      currentVersion.major,
+      currentVersion.minor,
+      currentVersion.patch,
+      pre: '$nextPreidName.$nextPreidInt',
+    );
+  }
+
+  final nextVersion = nextStableVersion(currentVersion, releaseType);
+  return Version(nextVersion.major, nextVersion.minor, nextVersion.patch,
+      pre: '$preid.0',
+      build: nextVersion.build.isNotEmpty ? nextVersion.build.join('.') : null);
+}
+
+Version nextVersion(
+  Version currentVersion,
+  SemverReleaseType releaseType, {
+  bool graduate = false,
+  bool prerelease = false,
+  String preid,
+}) {
+  var requestedPreidOrDefault = preid ?? 'dev';
+  final shouldGraduate = graduate ?? false;
+  var shouldMakePreRelease = prerelease ?? false;
+  if (currentVersion.preRelease.isNotEmpty) {
+    // If the current version then we should make a prerelease, unless graduating
+    // the version is explicitly requested.
+    shouldMakePreRelease = !shouldGraduate;
+    // Extract the existing preid from prerelease list if no preid provided.
+    // We do this to preserve the current preid so it's not overridden with the
+    // default 'dev' preid.
+    if (preid == null) {
+      //  - Versions in the format `0.8.0-nullsafety.1` have 2 pre release items, so we extract 'nullsafety' preid.
+      //  - Versions in the format `0.2.0-1.2.nullsafety.4` have 2 pre release items, so we extract 'nullsafety' preid.
+      requestedPreidOrDefault = currentVersion.preRelease.length == 2
+          ? currentVersion.preRelease[0]
+          : currentVersion.preRelease[2];
+    }
+  }
+
+  // Prerelease graduating to stable. Includes nullsafety graduation.
+  if (currentVersion.isPreRelease && shouldGraduate) {
+    return Version(
+        currentVersion.major, currentVersion.minor, currentVersion.patch,
+        build: currentVersion.build.isNotEmpty
+            ? currentVersion.build.join('.')
+            : null);
+  }
+
+  // Non-prerelease to non-prerelease versioning.
+  if (!currentVersion.isPreRelease && !shouldMakePreRelease) {
+    return nextStableVersion(currentVersion, releaseType);
+  }
+
+  // Non-prerelease to prerelease versioning (excluding nullsafety).
+  if (!currentVersion.isPreRelease &&
+      shouldMakePreRelease &&
+      requestedPreidOrDefault != 'nullsafety') {
+    return nextPrereleaseVersion(
+        currentVersion, releaseType, requestedPreidOrDefault);
+  }
+
+  // Prerelease to prerelease versioning (excluding nullsafety).
+  if (currentVersion.isPreRelease &&
+      shouldMakePreRelease &&
+      requestedPreidOrDefault != 'nullsafety') {
+    return nextPrereleaseVersion(
+        currentVersion, releaseType, requestedPreidOrDefault);
+  }
+
+  // Nullsafety
+  // Non-prerelease version to a first time nullsafety release.
+  if (!currentVersion.isPreRelease &&
+      shouldMakePreRelease &&
+      requestedPreidOrDefault == 'nullsafety') {
+    // Going from non-null to a first nullsafety release then the convention here
+    // is that a major version is created regardless of the requested release type.
+    final nextMajorStable =
+        nextStableVersion(currentVersion, SemverReleaseType.major);
+    return Version(
+        nextMajorStable.major, nextMajorStable.minor, nextMajorStable.patch,
+        pre: '1.0.nullsafety.0',
+        build: nextMajorStable.build.isNotEmpty
+            ? nextMajorStable.build.join('.')
+            : null);
+  }
+
+  // Non-nullsafety prerelease (or a nullsafety prerelease in the format
+  // '0.8.0-nullsafety.1`) to a nullsafety prerelease.
+  // Versions in the format `0.8.0-nullsafety.1` have 2 pre release items.
+  if (currentVersion.isPreRelease &&
+      currentVersion.preRelease.length == 2 &&
+      shouldMakePreRelease &&
+      requestedPreidOrDefault == 'nullsafety') {
+    // Going from non-nullsafety prerelease to a first nullsafety release then
+    // the convention here is that a major version is created regardless of the
+    // requested release type.
+    var baseVersion =
+        nextStableVersion(currentVersion, SemverReleaseType.major);
+    // Otherwise if it's already an old format nullsafety preprelease version
+    // then use the current version and don't major version bump it.
+    if (currentVersion.preRelease[0] == 'nullsafety') {
+      baseVersion = currentVersion;
+    }
+
+    return Version(baseVersion.major, baseVersion.minor, baseVersion.patch,
+        pre: '1.0.nullsafety.0',
+        build:
+            baseVersion.build.isNotEmpty ? baseVersion.build.join('.') : null);
+  }
+
+  // Nullsafety prerelease to another nullsafety prerelease.
+  // Existing nullsafety prerelease version is expected to be in the format
+  // `0.2.0-1.2.nullsafety.4` - versions in this format have 4 prerelease items.
+  if (currentVersion.isPreRelease &&
+      currentVersion.preRelease.length == 4 &&
+      currentVersion.preRelease[2] == 'nullsafety' &&
+      requestedPreidOrDefault == 'nullsafety') {
+    // e.g. for 0.2.0-1.2.nullsafety.4 then currentVersion.preRelease is in the format:
+    // [1, 2, nullsafety, 4] so this equates to [major, minor, preid, patch].
+    var nextPreMajor = currentVersion.preRelease[0] as int;
+    var nextPreMinor = currentVersion.preRelease[1] as int;
+    var nextPrePatch = currentVersion.preRelease[3] as int;
+    switch (releaseType) {
+      case SemverReleaseType.major:
+        nextPreMajor++;
+        nextPreMinor = 0;
+        nextPrePatch = 0;
+        break;
+      case SemverReleaseType.minor:
+        nextPreMinor++;
+        nextPrePatch = 0;
+        break;
+      case SemverReleaseType.patch:
+      default:
+        nextPrePatch++;
+        break;
+    }
+    return Version(
+        currentVersion.major, currentVersion.minor, currentVersion.patch,
+        pre:
+            '$nextPreMajor.$nextPreMinor.$requestedPreidOrDefault.$nextPrePatch',
+        build: currentVersion.build.isNotEmpty
+            ? currentVersion.build.join('.')
+            : null);
+  }
+
+  // Unhandled versioning behaviour.
+  throw UnsupportedError(
+      'Incrementing the version $currentVersion with the following options '
+      '(graduate: $graduate, preid: $preid, prerelease: $prerelease, releaseType: $releaseType) '
+      'is not supported by Melos, please raise an issue on GitHub if this is unexpected behaviour.');
+}

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   string_scanner: ^1.0.5
   yaml: ^2.2.1
   yamlicious: ^0.1.0
-
+dev_dependencies:
+  test: any
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/packages/melos/test/melos_test.dart
+++ b/packages/melos/test/melos_test.dart
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'package:conventional_commit/conventional_commit.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+class TestCase {
+  const TestCase(
+    this.currentVersion,
+    this.expectedVersion,
+    this.requestedReleaseType, {
+    this.requestedPreId,
+    this.shouldMakeGraduateVersion,
+    this.shouldMakePrereleaseVersion,
+  });
+
+  final String currentVersion;
+
+  final String expectedVersion;
+
+  final String requestedPreId;
+
+  final SemverReleaseType requestedReleaseType;
+
+  final bool shouldMakePrereleaseVersion;
+
+  final bool shouldMakeGraduateVersion;
+
+  @override
+  String toString() {
+    return 'TestCase[$currentVersion => $expectedVersion ($requestedReleaseType)]\n  { '
+        'shouldMakePrereleaseVersion:$shouldMakePrereleaseVersion, '
+        'shouldMakeGraduateVersion:$shouldMakeGraduateVersion, '
+        'requestedPreId:$requestedPreId, '
+        '};';
+  }
+}
+
+class NullSafetyTestCase extends TestCase {
+  const NullSafetyTestCase(String currentVersion, String expectedVersion,
+      SemverReleaseType requestedReleaseType)
+      : super(
+          currentVersion,
+          expectedVersion,
+          requestedReleaseType,
+          requestedPreId: 'nullsafety',
+          shouldMakePrereleaseVersion: true,
+        );
+}
+
+const testCases = [
+  // Semantic versioning compatible.
+  TestCase('1.0.0', '2.0.0', SemverReleaseType.major),
+  TestCase('1.0.0', '1.1.0', SemverReleaseType.minor),
+  TestCase('1.0.0', '1.0.1', SemverReleaseType.patch),
+  TestCase('1.1.1', '2.0.0', SemverReleaseType.major),
+  TestCase('1.1.1', '1.2.0', SemverReleaseType.minor),
+  TestCase('1.1.1', '1.1.2', SemverReleaseType.patch),
+
+  // Although semantic versioning doesn't promise any compatibility between versions prior to 1.0.0,
+  // the Dart community convention is to treat those versions semantically as well. The interpretation
+  // of each number is just shifted down one slot
+  TestCase('0.1.0', '0.2.0', SemverReleaseType.major),
+  TestCase('0.1.0', '0.1.1', SemverReleaseType.minor),
+  TestCase('0.1.0', '0.1.0+1', SemverReleaseType.patch),
+  TestCase('0.1.1+1', '0.2.0', SemverReleaseType.major),
+  TestCase('0.1.1+1', '0.1.2', SemverReleaseType.minor),
+  TestCase('0.1.1+1', '0.1.1+2', SemverReleaseType.patch),
+
+  // Ensure that we reset the preid int if preid name has changed,
+  // e.g. was "...dev.3" and is now a "beta" preid so the next
+  // prerelease version becomes "...beta.0" instead of "...beta.4".
+  TestCase('1.0.0-dev.3', '1.0.0-beta.0', SemverReleaseType.patch,
+      requestedPreId: 'beta', shouldMakePrereleaseVersion: true),
+
+  // Check that we preserve prerelease status, e.g. if already a prerelease
+  // then it should stay as a prerelease and not graduate to a non-prerelease version.
+  TestCase('1.0.0-dev.1', '1.0.0-dev.2', SemverReleaseType.patch),
+  // It should however graduate if it was specifically requested.
+  TestCase('1.0.0-dev.1', '1.0.0', SemverReleaseType.patch,
+      shouldMakeGraduateVersion: true),
+
+  // Check that we preserve any current prerelease preid if no preid option specified.
+  // So 1.0.0-beta.0 would become ...-beta.X rather than use the default preid "dev".
+  TestCase('1.0.0-beta.3', '1.0.0-beta.4', SemverReleaseType.patch),
+
+  // Nullsafety
+  //  - Going from non-null to a first nullsafety release.
+  //  - Convention here is that a major version is created regardless of the
+  //    underlying change/release type.
+  NullSafetyTestCase(
+      '1.0.0', '2.0.0-1.0.nullsafety.0', SemverReleaseType.major),
+  NullSafetyTestCase(
+      '1.1.0', '2.0.0-1.0.nullsafety.0', SemverReleaseType.minor),
+  NullSafetyTestCase(
+      '1.0.1', '2.0.0-1.0.nullsafety.0', SemverReleaseType.patch),
+  // Semantic versioning compatibility between versions prior to 1.0.0,
+  NullSafetyTestCase(
+      '0.1.0', '0.2.0-1.0.nullsafety.0', SemverReleaseType.major),
+  NullSafetyTestCase(
+      '0.1.1', '0.2.0-1.0.nullsafety.0', SemverReleaseType.minor),
+  NullSafetyTestCase(
+      '0.1.0+1', '0.2.0-1.0.nullsafety.0', SemverReleaseType.patch),
+
+  // Nullsafety
+  // - Here we're going from an already nullsafe version to another one.
+  NullSafetyTestCase('2.0.0-1.2.nullsafety.0', '2.0.0-2.0.nullsafety.0',
+      SemverReleaseType.major),
+  NullSafetyTestCase('2.0.0-1.2.nullsafety.3', '2.0.0-1.3.nullsafety.0',
+      SemverReleaseType.minor),
+  NullSafetyTestCase('2.0.0-1.2.nullsafety.3', '2.0.0-1.2.nullsafety.4',
+      SemverReleaseType.patch),
+  // Semantic versioning compatibility between versions prior to 1.0.0,
+  NullSafetyTestCase('0.2.0-1.2.nullsafety.3', '0.2.0-2.0.nullsafety.0',
+      SemverReleaseType.major),
+  NullSafetyTestCase('0.2.0-1.2.nullsafety.3', '0.2.0-1.3.nullsafety.0',
+      SemverReleaseType.minor),
+  NullSafetyTestCase('0.2.0-1.2.nullsafety.3', '0.2.0-1.2.nullsafety.4',
+      SemverReleaseType.patch),
+];
+
+void main() {
+  test('TODO', () {
+    final constraintGteLt = VersionConstraint.parse(
+        '>=2.0.0-2.0.nullsafety.0 <2.0.0-3.0.nullsafety.0');
+    print(constraintGteLt
+        .allows(Version.parse('2.0.0-3.0.nullsafety.0'))); // false
+    print(constraintGteLt
+        .allows(Version.parse('2.0.0-2.1.nullsafety.0'))); // true
+    print(constraintGteLt
+        .allows(Version.parse('2.0.0-2.0.nullsafety.2'))); // true
+    print(constraintGteLt
+        .allows(Version.parse('2.0.0-1.0.nullsafety.0'))); // false
+    print(constraintGteLt
+        .allows(Version.parse('2.1.0-2.0.nullsafety.0'))); // false
+
+    final constraintCarret = VersionConstraint.parse('^2.0.0-2.0.nullsafety.0');
+    print(constraintCarret
+        .allows(Version.parse('2.0.0-3.0.nullsafety.0'))); // true
+    print(constraintCarret
+        .allows(Version.parse('2.0.0-2.1.nullsafety.0'))); // true
+    print(constraintCarret
+        .allows(Version.parse('2.0.0-2.0.nullsafety.2'))); // true
+    print(constraintCarret
+        .allows(Version.parse('2.0.0-1.0.nullsafety.0'))); // false
+    print(constraintCarret
+        .allows(Version.parse('2.1.0-2.0.nullsafety.0'))); // true
+
+    // for (final testCase in testCases) {
+    //   // ignore: avoid_print
+    //   print(testCase);
+    // }
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,8 @@ executables:
   melos: melos_dev
 
 dev_dependencies:
-  melos: ^0.4.0+1
+  melos:
+    path: ./packages/melos
   path: ^1.7.0
   yaml: ^2.2.1
 


### PR DESCRIPTION
This PR extracts existing versioning behaviour to be more testable and adds tests for all previously expected behaviours.

Additionally this adds support for nullsafety prerelease versioning and generally follows the standard conventions, e.g. a package getting it's first nullsafety release should get a major version bump also.