### PR TITLE
fix(version): non-nullsafety pre-major prerelease should also bump it's minor version

### DIFF
--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -188,6 +188,13 @@ Version nextVersion(
     // then use the current version and don't major version bump it.
     if (currentVersion.preRelease[0] == 'nullsafety') {
       baseVersion = currentVersion;
+    } else if (currentVersion.major == 0) {
+      // Bump the 'major' version again if the preids changed (e.g. dev to nullsafety)
+      // and the current version is not yet full semver (>= 1.0.0), e.g.:
+      // `0.1.0-dev.5` should become `0.2.0-1.0.nullsafety.0`
+      // and not `0.1.0-1.0.nullsafety.0`.
+      // >=1.0.0 is already handled by [nextStableVersion].
+      baseVersion = nextStableVersion(baseVersion, SemverReleaseType.major);
     }
 
     return Version(baseVersion.major, baseVersion.minor, baseVersion.patch,

--- a/packages/melos/test/melos_test.dart
+++ b/packages/melos/test/melos_test.dart
@@ -157,6 +157,8 @@ const _versioningTestCases = [
   // Non-nullsafety prerelease to a nullsafety prerelease.
   NullSafetyTestCase(
       '1.0.0-dev.3', '2.0.0-1.0.nullsafety.0', SemverReleaseType.patch),
+  NullSafetyTestCase(
+      '0.1.0-dev.5', '0.2.0-1.0.nullsafety.0', SemverReleaseType.patch),
 ];
 
 void main() {


### PR DESCRIPTION
E.g. we expect `0.1.0-dev.5` to be bumped to `0.2.0-1.0.nullsafety.0` and not `0.1.0-1.0.nullsafety.0` like the previous behavior. This matches the current behaviour of versions being bumped that are already >=1.0.0.