### PR TITLE
docs: Add project using Melos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ The following projects are using Melos:
 - [FirebaseExtended/flutterfire](https://github.com/FirebaseExtended/flutterfire)
 - [aws-amplify/amplify-flutter](https://github.com/aws-amplify/amplify-flutter)
 - [fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)
+- [GetStream/stream-chat-flutter](https://github.com/GetStream/stream-chat-flutter)
 
 > [Submit a PR](https://github.com/invertase/melos/edit/master/docs/README.md) to add your project to the list.
 


### PR DESCRIPTION
Add project GetStream/stream-chat-flutter to the projects using Melos
You can check it out at this link https://github.com/GetStream/stream-chat-flutter