### PR TITLE
docs: Add gql-dart/gql as a user of melos

### DIFF
--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -92,6 +92,7 @@ The following projects are using Melos:
 - [FirebaseExtended/flutterfire](https://github.com/FirebaseExtended/flutterfire)
 - [aws-amplify/amplify-flutter](https://github.com/aws-amplify/amplify-flutter)
 - [fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)
+- [gql-dart/gql](https://github.com/gql-dart/gql)
 
 > [Submit a PR](https://github.com/invertase/melos/edit/master/packages/melos/README.md) if you'd like to add your project to the list.
 > You can also add a [readme badge](#readme-badge) to your projects readme to let others know about Melos 💙.


### PR DESCRIPTION
`gql-dart/gql` is in the process of adopting melos.

Should be merged after the following PR is finalized
https://github.com/gql-dart/gql/pull/192