### PR TITLE
feat: allow private packages to be versioned

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,7 @@
 title: Commands
 description: Descriptions and examples of the available Melos CLI commands
 ---
+
 # Commands
 
 Commands can be run from the root of a project using Melos.
@@ -33,7 +34,7 @@ executed, you'll need to rerun the `bootstrap` command again for Melos to work.
 
 ## exec
 
-Execute an arbitrary command in each package. 
+Execute an arbitrary command in each package.
 
 ```bash
 melos exec
@@ -204,6 +205,15 @@ melos version -t
 
 Use `--no-git-tag-version` to disable.
 
+### --all (-a)
+
+Version private packages that are skipped by default.
+
+```bash
+melos version --all
+melos version -a
+```
+
 ## Global options
 
 Each Melos command can be used alongside the following global commands:
@@ -305,4 +315,5 @@ Include only packages that depend on specific dependencies.
 ```bash
 melos exec --depends-on="flutter" --depends-on="firebase_core" -- flutter test
 ```
+
 Use `--no-depends-on` to filter packages that do not depend on the given dependencies.

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -307,7 +307,6 @@ class VersionCommand extends Command {
       return gitCommitsForPackage(
         package,
         since: globalResults['since'] as String,
-        versionAll: versionAll,
       ).then((commits) {
         packageCommits[package.name] = commits
             .map((commit) => ConventionalCommit.parse(commit.message))
@@ -385,7 +384,7 @@ class VersionCommand extends Command {
       logger.stdout(AnsiStyles.gray(
           'Hint: try running "melos list" with the same filtering options to see a list of packages that were included.'));
       logger.stdout(AnsiStyles.gray(
-          'Hint: try running "melos version --all" to include private packages'));
+          'Hint: try running "melos version --all" to include private packages.'));
       return;
     }
 

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -137,9 +137,13 @@ Future<void> gitCommit(String message, {String workingDirectory}) async {
 /// Returns a list of [GitCommit]s for a Melos package.
 /// Optionally specify [since] to start after a specified commit or tag. Defaults
 /// to the latest release tag.
-Future<List<GitCommit>> gitCommitsForPackage(MelosPackage package,
-    {String since, String preid = 'dev'}) async {
-  if (package.isPrivate) {
+Future<List<GitCommit>> gitCommitsForPackage(
+  MelosPackage package, {
+  String since,
+  String preid = 'dev',
+  bool versionAll,
+}) async {
+  if (!versionAll && package.isPrivate) {
     return [];
   }
   var sinceOrLatestTag = since;

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -137,15 +137,8 @@ Future<void> gitCommit(String message, {String workingDirectory}) async {
 /// Returns a list of [GitCommit]s for a Melos package.
 /// Optionally specify [since] to start after a specified commit or tag. Defaults
 /// to the latest release tag.
-Future<List<GitCommit>> gitCommitsForPackage(
-  MelosPackage package, {
-  String since,
-  String preid = 'dev',
-  bool versionAll,
-}) async {
-  if (!versionAll && package.isPrivate) {
-    return [];
-  }
+Future<List<GitCommit>> gitCommitsForPackage(MelosPackage package,
+    {String since, String preid = 'dev'}) async {
   var sinceOrLatestTag = since;
   if (sinceOrLatestTag != null && sinceOrLatestTag.isEmpty) {
     sinceOrLatestTag = null;


### PR DESCRIPTION
PR for feature request: #44 

Private packages can now be versioned by including the `--all [-a]` flag when running the `version` command.
Also added documentation for this new flag.