### PR TITLE
refactor: Improve styling of command usage

### DIFF
--- a/packages/melos/lib/src/command/base.dart
+++ b/packages/melos/lib/src/command/base.dart
@@ -1,0 +1,12 @@
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+
+import '../common/utils.dart';
+
+abstract class MelosCommand extends Command {
+  /// Overridden to support line wrapping when printing usage.
+  @override
+  ArgParser get argParser =>
+      _argParser ??= ArgParser(usageLineLength: terminalWidth);
+  ArgParser _argParser;
+}

--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -20,7 +20,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:ansi_styles/ansi_styles.dart';
-import 'package:args/command_runner.dart' show Command;
 import 'package:path/path.dart';
 import 'package:pool/pool.dart';
 import 'package:yamlicious/yamlicious.dart';
@@ -31,8 +30,9 @@ import '../common/logger.dart';
 import '../common/package.dart';
 import '../common/utils.dart' as utils;
 import '../common/workspace.dart';
+import 'base.dart';
 
-class BootstrapCommand extends Command {
+class BootstrapCommand extends MelosCommand {
   @override
   final String name = 'bootstrap';
 

--- a/packages/melos/lib/src/command/clean.dart
+++ b/packages/melos/lib/src/command/clean.dart
@@ -15,14 +15,13 @@
  *
  */
 
-import 'package:args/command_runner.dart' show Command;
-
 import '../command_runner.dart';
 import '../common/intellij_project.dart';
 import '../common/logger.dart';
 import '../common/workspace.dart';
+import 'base.dart';
 
-class CleanCommand extends Command {
+class CleanCommand extends MelosCommand {
   @override
   final String name = 'clean';
 

--- a/packages/melos/lib/src/command/exec.dart
+++ b/packages/melos/lib/src/command/exec.dart
@@ -17,16 +17,16 @@
 
 import 'dart:io';
 
-import 'package:args/command_runner.dart' show Command;
-import 'package:pool/pool.dart' show Pool;
 import 'package:ansi_styles/ansi_styles.dart';
+import 'package:pool/pool.dart' show Pool;
 
 import '../common/logger.dart';
 import '../common/package.dart';
 import '../common/utils.dart';
 import '../common/workspace.dart';
+import 'base.dart';
 
-class ExecCommand extends Command {
+class ExecCommand extends MelosCommand {
   ExecCommand() {
     argParser.addOption('concurrency', defaultsTo: '5', abbr: 'c');
     argParser.addFlag('fail-fast',

--- a/packages/melos/lib/src/command/list.dart
+++ b/packages/melos/lib/src/command/list.dart
@@ -19,15 +19,15 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:ansi_styles/ansi_styles.dart';
-import 'package:args/command_runner.dart' show Command;
 import 'package:path/path.dart' show dirname;
 
 import '../common/logger.dart';
 import '../common/package.dart';
 import '../common/utils.dart';
 import '../common/workspace.dart';
+import 'base.dart';
 
-class ListCommand extends Command {
+class ListCommand extends MelosCommand {
   ListCommand() {
     argParser.addFlag('long',
         abbr: 'l', negatable: false, help: 'Show extended information.');

--- a/packages/melos/lib/src/command/publish.dart
+++ b/packages/melos/lib/src/command/publish.dart
@@ -18,7 +18,6 @@
 import 'dart:io';
 
 import 'package:ansi_styles/ansi_styles.dart';
-import 'package:args/command_runner.dart' show Command;
 import 'package:pool/pool.dart' show Pool;
 
 import '../common/git.dart';
@@ -26,9 +25,10 @@ import '../common/logger.dart';
 import '../common/package.dart';
 import '../common/utils.dart';
 import '../common/workspace.dart';
+import 'base.dart';
 import 'exec.dart';
 
-class PublishCommand extends Command {
+class PublishCommand extends MelosCommand {
   PublishCommand() {
     argParser.addFlag('dry-run',
         abbr: 'n',

--- a/packages/melos/lib/src/command/run.dart
+++ b/packages/melos/lib/src/command/run.dart
@@ -17,15 +17,15 @@
 
 import 'dart:io';
 
-import 'package:args/command_runner.dart' show Command;
-import 'package:prompts/prompts.dart' as prompts;
 import 'package:ansi_styles/ansi_styles.dart';
+import 'package:prompts/prompts.dart' as prompts;
 
 import '../common/logger.dart';
 import '../common/utils.dart';
 import '../common/workspace.dart';
+import 'base.dart';
 
-class RunCommand extends Command {
+class RunCommand extends MelosCommand {
   RunCommand() {
     argParser.addFlag(
       'no-select',

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -18,7 +18,6 @@
 import 'dart:io';
 
 import 'package:ansi_styles/ansi_styles.dart';
-import 'package:args/command_runner.dart' show Command;
 import 'package:conventional_commit/conventional_commit.dart';
 import 'package:pool/pool.dart' show Pool;
 import 'package:pub_semver/pub_semver.dart';
@@ -32,8 +31,9 @@ import '../common/pending_package_update.dart';
 import '../common/utils.dart';
 import '../common/versioning.dart' as versioning;
 import '../common/workspace.dart';
+import 'base.dart';
 
-class VersionCommand extends Command {
+class VersionCommand extends MelosCommand {
   VersionCommand() {
     argParser.addFlag(
       'prerelease',

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -116,11 +116,11 @@ class VersionCommand extends MelosCommand {
       'Automatically version and generate changelogs based on the Conventional Commits specification. Supports all package filtering options.';
 
   @override
-  final String invocation = ''
-      'melos version\n'
-      '         - version packages automatically using the Conventional Commits specification.\n'
-      '       melos version <packageName> <newVersion>\n'
-      '         - manually set a specific packages version and update all packages that depend on it.';
+  // ignore: leading_newlines_in_multiline_strings
+  final String invocation = ' ${AnsiStyles.bold('melos version')}\n'
+      '          Version packages automatically using the Conventional Commits specification.\n\n'
+      '        ${AnsiStyles.bold('melos version')} <package name> <new version>\n'
+      '          Manually set a package to a specific version, and update all packages that depend on it.\n';
 
   Future<void> applyUserSpecifiedVersion() async {
     logger.stdout(


### PR DESCRIPTION
Big thing here is line wrapping — previously the command runner was configured to wrap at a certain line length, but its commands were not.

Unlike CommandRunner, where you can easily supply a wrapping line length to its constructor, Command requires that you override a property.

I introduced a base class (MelosCommand) that does this (I think the class may come in handy for other formatting needs), and had all of the existing commands inherit from it. Works great!

Additionally, I gave a bit of styling love to the `versions` usage string. Nothing fancy, but it's more readable.

Fixes #70

<img width="1432" alt="Screen Shot 2021-03-25 at 2 46 02 AM" src="https://user-images.githubusercontent.com/42326/112430272-49166980-8d14-11eb-9ce0-096060d02e29.png">
