### PR TITLE
feat: Support configurable commit messages in version command

### DIFF
--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -33,6 +33,9 @@ import '../common/utils.dart';
 import '../common/versioning.dart' as versioning;
 import '../common/workspace.dart';
 
+/// The default commit message subject used when versioning.
+const defaultCommitMessageSubject = 'chore(release): publish packages';
+
 class VersionCommand extends Command {
   VersionCommand() {
     argParser.addFlag(
@@ -85,6 +88,12 @@ class VersionCommand extends Command {
           'and tag the release. Pass --no-git-tag-version to disable the behavior. '
           'Applies only to Conventional Commits based versioning.',
     );
+    argParser.addOption('message',
+        abbr: 'm',
+        valueHelp: 'msg',
+        help: "Use the given <msg> as the release's commit message subject.\n"
+            'If not provided, this will default to a subject of '
+            '"$defaultCommitMessageSubject".');
     argParser.addFlag(
       'yes',
       negatable: false,
@@ -250,6 +259,7 @@ class VersionCommand extends Command {
     final changelog = argResults['changelog'] as bool;
     var graduate = argResults['graduate'] as bool;
     final tag = argResults['git-tag-version'] as bool;
+    final commitMessageSubject = argResults['message'] as String;
     final prerelease = argResults['prerelease'] as bool;
     final updateDependentConstraints =
         argResults['dependent-constraints'] as bool;
@@ -529,10 +539,11 @@ class VersionCommand extends Command {
           })
           .map((e) => ' - ${e.package.name}@${e.nextVersion.toString()}')
           .join('\n');
-      // TODO commit message customization support would go here.
-      // TODO this is currently blocking git submodules support (if we decide to support it later) for packages as commit is only ran at the root.
-      await gitCommit(
-          'chore(release): publish packages\n\n$publishedPackagesMessage',
+
+      // TODO this is currently blocking git submodules support (if we decide to
+      // support it later) for packages as commit is only ran at the root.
+      final commitSubject = commitMessageSubject ?? defaultCommitMessageSubject;
+      await gitCommit('$commitSubject\n\n$publishedPackagesMessage',
           workingDirectory: currentWorkspace.path);
 
       // // 3) Tag changes:

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -95,7 +95,7 @@ class VersionCommand extends Command {
       'all',
       abbr: 'a',
       negatable: false,
-      help: 'Verion private packages that are skipped by default.',
+      help: 'Version private packages that are skipped by default.',
     );
     argParser.addOption(
       'preid',

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   glob: ^1.2.0
   http: ^0.12.2
   meta: ^1.1.8
+  mustache_template: ^2.0.0
   path: ^1.7.0
   pool: ^1.4.0
   prompts: ^1.3.1


### PR DESCRIPTION
The `version` command's `--message` option can be optionally supplied to set a custom commit message when updating versions. If not provided, the previous default is used.

The option's value is treated as a template with a single template var, `{new_package_versions}`, which is replaced with the list of newly versioned packages. Additionally, escaped newlines are evaluated as proper newlines, making it easier to supply a multiline string to the option.

Example
```sh
melos version --message='chore(emergency_release): Hotfix is getting deployed now!\n\n{new_package_versions}'
```

I decided to include a template library to perform the substitution, and picked one that appears to be well-built and small — `mustache_templates`. I could've written something quick and dirty instead, but it didn't feel right to have it live here.

The option is only a first step — we could go further with this, and support defaults in the `melos.yaml` file (like Lerna does with their config), but the options seems like a good first step.

Related to #69 