### PR TITLE
refactor: Clean up workspace code in preparation for command config implementation

### DIFF
--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -119,7 +119,10 @@ Map loadYamlFileSync(String path) {
 Future<Map> loadYamlFile(String path) async {
   final file = File(path);
   if (file.existsSync()) {
-    return loadYaml(await file.readAsString()) as Map;
+    return loadYaml(
+      await file.readAsString(),
+      sourceUrl: file.uri,
+    ) as Map;
   }
   return null;
 }

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -36,6 +36,19 @@ packages:
 class MelosWorkspaceConfig {
   MelosWorkspaceConfig._(this._name, this._path, this._yamlContents);
 
+  /// Constructs a workspace config from a [YamlMap] representation of
+  /// `melos.yaml`.
+  factory MelosWorkspaceConfig.fromYaml(YamlMap yamlMap) {
+    final melosYamlPath = yamlMap.span?.sourceUrl?.toFilePath();
+    assert(
+      melosYamlPath != null,
+      'Config yaml does not have an associated path. Was it loaded from disk?',
+    );
+
+    return MelosWorkspaceConfig._(
+        yamlMap['name'] as String, dirname(melosYamlPath), yamlMap);
+  }
+
   final Map _yamlContents;
 
   /// The name of the workspace.
@@ -97,7 +110,6 @@ class MelosWorkspaceConfig {
       return null;
     }
 
-    return MelosWorkspaceConfig._(
-        yamlContents['name'] as String, directory.path, yamlContents);
+    return MelosWorkspaceConfig.fromYaml(yamlContents);
   }
 }

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -46,8 +46,6 @@ class MelosWorkspaceConfig {
   String get path => _path;
   final String _path;
 
-  String get version => _yamlContents['version'] as String;
-
   /// `true` if this workspace is configured to generate an IntelliJ IDE
   /// project via `melos bootstrap`.
   bool get generateIntellijIdeFiles {

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -31,47 +31,54 @@ packages:
 ''';
 }
 
-// TODO document & cleanup class members.
 // TODO validation of config e.g. name should be alphanumeric dasherized/underscored
+/// Represents the contents of `melos.yaml`.
 class MelosWorkspaceConfig {
   MelosWorkspaceConfig._(this._name, this._path, this._yamlContents);
 
+  final Map _yamlContents;
+
+  /// The name of the workspace.
+  String get name => _name;
   final String _name;
 
-  String get name => _name;
-
-  final String _path;
-
+  /// The path to the root of this workspace.
   String get path => _path;
-
-  MelosWorkspaceScripts get scripts =>
-      MelosWorkspaceScripts(_yamlContents['scripts'] as Map ?? {});
+  final String _path;
 
   String get version => _yamlContents['version'] as String;
 
+  /// `true` if this workspace is configured to generate an IntelliJ IDE
+  /// project via `melos bootstrap`.
   bool get generateIntellijIdeFiles {
     final ide = _yamlContents['ide'] as Map ?? {};
-    if (ide['intellij'] == false) return false;
-    if (ide['intellij'] == true) return true;
-    return true;
+    return ide['intellij'] is bool ? ide['intellij'] : true;
   }
 
-  final Map _yamlContents;
-
+  /// A list of glob patterns indicating the locations of this workspace's
+  /// packages.
   List<String> get packages {
     final patterns = _yamlContents['packages'] as YamlList;
     if (patterns == null) return <String>[];
     return List<String>.from(patterns);
   }
 
-  /// Glob patterns defined in "melos.yaml" ignore of packages to always exclude
-  /// regardless of any custom CLI filter options.
+  /// A list of glob patterns that should be ignored when determining the
+  /// workspace's packages.
   List<String> get ignore {
     final patterns = _yamlContents['ignore'] as YamlList;
     if (patterns == null) return <String>[];
     return List<String>.from(patterns);
   }
 
+  /// Scripts defined by the workspace.
+  MelosWorkspaceScripts get scripts =>
+      MelosWorkspaceScripts(_yamlContents['scripts'] as Map ?? {});
+
+  /// Creates a new configuration from a [directory].
+  ///
+  /// If no `melos.yaml` is found, but [directory] contains a `packages/`
+  /// sub-directory, a configuration for those packages will be returned.
   static Future<MelosWorkspaceConfig> fromDirectory(Directory directory) async {
     if (!isWorkspaceDirectory(directory)) {
       // Allow melos to use a project without a `melos.yaml` file if a `packages`


### PR DESCRIPTION
This is a collection of smaller changes in preparation for the melos.yaml command config implementation.

* Added comments throughout
* Reorganized members of `MelosWorkspaceConfig`
* Removed the version field (unused, undocumented — feels safe)
* Added `MelosWorkspaceConfig.fromYaml` constructor, for testability (I have tests in the next PR)