### PR TITLE
feat: Add underpinnings of melos.yaml-driven command configuration (and version --message support)

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -31,10 +31,10 @@ scripts:
   test:
     description: Run tests in a specific package.
     # TODO(Salakar) 'dart pub get' is necessary for the 'melos' package as we're using it on itself
-    run: melos exec -c 1 -- "dart pub get && dart pub run test test/\$MELOS_PACKAGE_NAME_test.dart"
+    run: melos exec --concurrency=1 -- "dart pub get && dart pub run test --reporter expanded"
     select-package:
-      file-exists:
-        - "test/$MELOS_PACKAGE_NAME_test.dart"
+      dir-exists:
+        - "test/"
 
   format: dart format -o write .
   version: dart run scripts/generate_version.dart

--- a/packages/melos/lib/src/command/base.dart
+++ b/packages/melos/lib/src/command/base.dart
@@ -2,8 +2,17 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
 import '../common/utils.dart';
+import '../common/workspace.dart';
+import '../common/workspace_command_config.dart';
 
 abstract class MelosCommand extends Command {
+  /// The `melos.yaml` configuration for this command.
+  ///
+  /// This is the configuration under the `melos.yaml`'s `command.{name}` field.
+  /// If none exists, a configuration object with no contents is returned.
+  MelosCommandConfig get commandConfig =>
+      currentWorkspace.config.commands.configForCommandNamed(name);
+
   /// Overridden to support line wrapping when printing usage.
   @override
   ArgParser get argParser =>

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -147,6 +147,7 @@ class VersionCommand extends MelosCommand {
   // as a convenience.
   String get _commitMessage =>
       argResults['message']?.replaceAll(r'\n', '\n') as String ??
+      commandConfig.getString('message') ??
       defaultCommitMessage;
 
   Future<void> applyUserSpecifiedVersion() async {

--- a/packages/melos/lib/src/common/workspace_command_config.dart
+++ b/packages/melos/lib/src/common/workspace_command_config.dart
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'package:yaml/yaml.dart';
+
+import 'workspace_config.dart';
+
+/// Command-specific configuration information, as represented in the
+/// `melos.yaml`'s `command` section.
+class MelosWorkspaceCommandConfigs {
+  /// Constructs a new command config map from a mapping of command names to
+  /// their associated config maps.
+  MelosWorkspaceCommandConfigs([
+    Map<String, Map<String, dynamic>> configsByCommandName,
+  ]) : _configsByCommandName = (configsByCommandName ?? const {})
+            .map((key, value) => MapEntry(key, MelosCommandConfig(key, value)));
+
+  /// Constructs a new command config map from a [YamlMap] representation of the
+  /// `melos.yaml` `command` section.
+  ///
+  /// [yamlConfigsByCommandName] is expected to be a YamlMap of YamlMaps, or
+  /// `null`.
+  factory MelosWorkspaceCommandConfigs.fromYaml(
+    YamlMap yamlConfigsByCommandName,
+  ) {
+    if (yamlConfigsByCommandName == null) {
+      return MelosWorkspaceCommandConfigs({});
+    }
+
+    // Validate the YAML's shape, and massage it into the typing we want.
+    final configsByCommandName = yamlConfigsByCommandName.map(
+      (commandName, commandConfig) {
+        if (commandConfig is! YamlMap) {
+          throw MelosConfigException(
+              'command.$commandName section must contain a map');
+        }
+
+        return MapEntry(
+          commandName.toString(),
+          (commandConfig as Map).cast<String, dynamic>(),
+        );
+      },
+    );
+    return MelosWorkspaceCommandConfigs(configsByCommandName);
+  }
+
+  final Map<String, MelosCommandConfig> _configsByCommandName;
+
+  /// Returns the `melos.yaml` configuration for the command named [name].
+  ///
+  /// If no config exists, an empty config will be returned.
+  MelosCommandConfig configForCommandNamed(String name) {
+    return _configsByCommandName[name] ??= MelosCommandConfig(name, const {});
+  }
+}
+
+/// The `melos.yaml` configuration information for a single command.
+class MelosCommandConfig {
+  MelosCommandConfig(this.commandName, Map<String, dynamic> configEntries)
+      : _configEntries = configEntries ?? const {};
+
+  /// Name of this configuration's associated command.
+  final String commandName;
+  final Map<String, dynamic> _configEntries;
+
+  /// The keys of this configuration's entries.
+  Iterable<String> get keys => _configEntries.keys;
+
+  /// Returns the config entry named [name], or `null` if none exists.
+  String getString(String name) => _configEntries[name];
+}

--- a/packages/melos/lib/src/common/workspace_config.dart
+++ b/packages/melos/lib/src/common/workspace_config.dart
@@ -21,6 +21,7 @@ import 'package:path/path.dart';
 import 'package:yaml/yaml.dart';
 
 import 'utils.dart';
+import 'workspace_command_config.dart';
 import 'workspace_scripts.dart';
 
 String get _yamlConfigDefault {
@@ -86,10 +87,16 @@ class MelosWorkspaceConfig {
   MelosWorkspaceScripts get scripts =>
       MelosWorkspaceScripts(_yamlContents['scripts'] as Map ?? {});
 
+  /// Command-specific configurations defined by the workspace.
+  MelosWorkspaceCommandConfigs get commands =>
+      _commands ??= MelosWorkspaceCommandConfigs.fromYaml(
+          _yamlContents['command'] as YamlMap);
+  MelosWorkspaceCommandConfigs _commands;
+
   /// Creates a new configuration from a [directory].
   ///
   /// If no `melos.yaml` is found, but [directory] contains a `packages/`
-  /// sub-directory, a configuration for those packages will be returned.
+  /// sub-directory, a configuration for those packages will be created.
   static Future<MelosWorkspaceConfig> fromDirectory(Directory directory) async {
     if (!isWorkspaceDirectory(directory)) {
       // Allow melos to use a project without a `melos.yaml` file if a `packages`
@@ -112,4 +119,13 @@ class MelosWorkspaceConfig {
 
     return MelosWorkspaceConfig.fromYaml(yamlContents);
   }
+}
+
+/// Thrown when `melos.yaml` configuration is malformed.
+class MelosConfigException implements Exception {
+  MelosConfigException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'melos.yaml: $message';
 }

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -1,0 +1,139 @@
+import 'package:melos/src/common/workspace_command_config.dart';
+import 'package:melos/src/common/workspace_config.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('MelosWorkspaceConfig', () {
+    group('command section', () {
+      test('does not fail when missing from file', () {
+        expect(() {
+          final config = createTestWorkspaceConfig({
+            'name': 'mono-root',
+            'packages': ['packages/*'],
+          });
+          return config.commands;
+        }, returnsNormally);
+      });
+
+      test('produces a commands map when provided', () {
+        final config = createTestWorkspaceConfig({
+          'command': {
+            'version': {},
+          },
+        });
+        expect(config.commands, isA<MelosWorkspaceCommandConfigs>());
+      });
+
+      test('produces a commands map even when missing from file', () {
+        final config = createTestWorkspaceConfig();
+        expect(config.commands, isA<MelosWorkspaceCommandConfigs>());
+      });
+    });
+  });
+
+  group('MelosWorkspaceCommandConfigs', () {
+    test('vends command-specific config objects', () {
+      const expectedMessage = 'Version message';
+      const expectedTagPrefix = 'v';
+      final commandConfig = MelosWorkspaceCommandConfigs({
+        'version': {
+          'message': expectedMessage,
+        },
+        'publish': {
+          'tagPrefix': expectedTagPrefix,
+        },
+      });
+
+      final versionConfig = commandConfig.configForCommandNamed('version');
+      expect(versionConfig, isNotNull);
+      expect(versionConfig.getString('message'), expectedMessage);
+
+      final publishConfig = commandConfig.configForCommandNamed('publish');
+      expect(publishConfig, isNotNull);
+      expect(publishConfig.getString('tagPrefix'), expectedTagPrefix);
+    });
+
+    test(
+        'vends (empty) command configs even when not provided in the '
+        'backing map', () {
+      final commandConfig = MelosWorkspaceCommandConfigs({});
+      final versionConfig = commandConfig.configForCommandNamed('version');
+      expect(versionConfig, isNotNull);
+      expect(versionConfig.keys, isEmpty);
+    });
+
+    test('can be constructed without a backing map', () {
+      final commandConfig = MelosWorkspaceCommandConfigs();
+      final versionConfig = commandConfig.configForCommandNamed('version');
+      expect(versionConfig, isNotNull);
+    });
+
+    group('fromYaml', () {
+      test('can be constructed with a null yaml map', () {
+        expect(
+          () => MelosWorkspaceCommandConfigs.fromYaml(null),
+          returnsNormally,
+        );
+      });
+
+      test('fails if command configs are not maps', () {
+        final commandSection = createYamlMap({
+          'version': ['should', 'be', 'a', 'map'],
+        });
+
+        expect(
+          () => MelosWorkspaceCommandConfigs.fromYaml(commandSection),
+          throwsA(isA<MelosConfigException>()),
+        );
+      });
+
+      test('succeeds with a well-formed config', () {
+        const expectedMessage = 'This is my message';
+        const expectedPrefix = 'v';
+
+        final commandSection = createYamlMap({
+          'version': {
+            'message': expectedMessage,
+          },
+          'publish': {
+            'tagPrefix': expectedPrefix,
+          },
+        });
+        final commandConfig =
+            MelosWorkspaceCommandConfigs.fromYaml(commandSection);
+
+        expect(
+          commandConfig.configForCommandNamed('version').getString('message'),
+          expectedMessage,
+        );
+        expect(
+          commandConfig.configForCommandNamed('publish').getString('tagPrefix'),
+          expectedPrefix,
+        );
+      });
+    });
+  });
+}
+
+/// Default values used by [createTestWorkspaceConfig].
+const configMapDefaults = {
+  'name': 'mono-root',
+  'packages': ['packages/*'],
+};
+
+/// [configMap] is a map representation of `melos.yaml` contents
+MelosWorkspaceConfig createTestWorkspaceConfig([
+  Map<String, dynamic> configMap = const {},
+]) {
+  return MelosWorkspaceConfig.fromYaml(
+      createYamlMap(configMap, defaults: configMapDefaults));
+}
+
+YamlMap createYamlMap(Map<String, dynamic> configMap,
+    {Map<String, dynamic> defaults = const {}}) {
+  return YamlMap.wrap({
+    ...defaults,
+    ...configMap,
+  }, sourceUrl: '/mono-root/melos.yaml');
+}


### PR DESCRIPTION
`melos.yaml` can now contain a `command` section, which is a map of command-specific configuration objects. For example:

```yaml
# melos.yaml
name: my-mono-repo
packages:
- packages/**
command:
  version: # Configuration for version command
    message: Here's a commit message!
  publish: # Configuration for publish command
    tagPrefix: v
```

This makes available configurations for two commands, 'version' and 'publish', which have access to the config maps through the `MelosCommand.commandConfig` property.

`command.version.message` is the first implementation of such a config. The existence of this field in `melos.yaml` configures `melos version` to use its value as a commit message, unless overridden by the `--message` option.

I also wrote a few tests, but had to mess around with the `melos.yaml`'s test script to get things running right. For some reason it was configured to only test the `melos` package, but I couldn't see a good reason for it...so now everything gets tested.

Fixes #76 