### PR TITLE
docs: Rewrapped melos README to avoid an unfortunate space

### DIFF
--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -11,8 +11,9 @@ Splitting up large code bases into separate independently versioned packages is 
 However, making changes across many repositories is _messy_ and difficult to track, and testing across repositories gets
 complicated really fast.
 
-To solve these (and many other) problems, some projects will organize their code bases into multi-package repositories (
-sometimes called [monorepos](https://en.wikipedia.org/wiki/Monorepo))
+To solve these (and many other) problems, some projects will organize their code
+bases into multi-package repositories (sometimes called
+[monorepos](https://en.wikipedia.org/wiki/Monorepo))
 
 **Melos is a tool that optimizes the workflow around managing multi-package repositories with git and Pub.**
 


### PR DESCRIPTION
A line break was inserting a space immediately after a paren.