### PR TITLE
build: Upgrade package dependencies

### DIFF
--- a/packages/melos/lib/src/common/package.dart
+++ b/packages/melos/lib/src/common/package.dart
@@ -353,7 +353,7 @@ class MelosPackage {
     }
 
     final url = 'https://pub.dev/packages/$name.json';
-    final response = await http.get(url);
+    final response = await http.get(Uri.parse(url));
     if (response.statusCode == 404) {
       return [];
     } else if (response.statusCode != 200) {

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -6,20 +6,20 @@ executables:
   melos:
 dependencies:
   ansi_styles: ^0.2.0
-  args: ^1.6.0
-  cli_util: ^0.2.0
+  args: ^2.0.0
+  cli_util: ^0.3.0
   collection: ^1.14.12
   conventional_commit: ^0.3.0+1
-  glob: ^1.2.0
-  http: ^0.12.2
+  glob: ^2.0.1
+  http: ^0.13.1
   meta: ^1.1.8
   mustache_template: ^2.0.0
   path: ^1.7.0
   pool: ^1.4.0
   prompts: ^1.3.1
-  pub_semver: ^1.4.4
+  pub_semver: ^2.0.0
   string_scanner: ^1.0.5
-  yaml: ^2.2.1
+  yaml: ^3.1.0
   yamlicious: ^0.1.0
 dev_dependencies:
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dev_dependencies:
   melos:
     path: ./packages/melos
   path: ^1.7.0
-  yaml: ^2.2.1
+  yaml: ^3.1.0
 
 # These allows us to use melos on itself during development.
 # If you make a new local package in this repo that the melos package


### PR DESCRIPTION
All packages had `pub upgrade --major-version` run in their root directories.

The only upgrade that required code changes was in the `melos` package, because `http` moved to requiring `Uri`s instead of `String` URLs.