### PR TITLE
feat: Add filtering flags for including dependencies and dependents

### DIFF
--- a/packages/melos/lib/src/command/run.dart
+++ b/packages/melos/lib/src/command/run.dart
@@ -132,6 +132,10 @@ class RunCommand extends MelosCommand {
             script.selectPackageOptions[filterOptionDependsOn] as List<String>,
         noDependsOn: script.selectPackageOptions[filterOptionNoDependsOn]
             as List<String>,
+        includeDependents:
+            script.selectPackageOptions[filterOptionIncludeDependents],
+        includeDependencies:
+            script.selectPackageOptions[filterOptionIncludeDependencies],
       );
 
       var choices = currentWorkspace.packages

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -52,57 +52,61 @@ class MelosCommandRunner extends CommandRunner {
     argParser.addFlag(
       filterOptionNoPrivate,
       negatable: false,
-      help:
-          'Exclude private packages (`publish_to: none`). They are included by default.',
+      help: 'Exclude private packages (`publish_to: none`). They are included '
+          'by default.',
     );
 
     argParser.addFlag(
       filterOptionPublished,
       defaultsTo: null,
-      help:
-          'Filter packages where the current local package version exists on pub.dev. Or "-no-published" to filter packages that have not had their current version published yet.',
+      help: 'Filter packages where the current local package version exists on '
+          'pub.dev. Or "-no-published" to filter packages that have not had '
+          'their current version published yet.',
     );
 
     argParser.addFlag(
       filterOptionNullsafety,
       defaultsTo: null,
       help:
-          'Filter packages where the current local version uses a "nullsafety" prerelease preid. Or "-no-nullsafety" to filter packages where their current version does not have a "nullsafety" preid.',
+          'Filter packages where the current local version uses a "nullsafety" '
+          'prerelease preid. Or "-no-nullsafety" to filter packages where '
+          'their current version does not have a "nullsafety" preid.',
     );
 
     argParser.addFlag(
       filterOptionFlutter,
       defaultsTo: null,
-      help:
-          'Filter packages where the package depends on the Flutter SDK. Or "-no-flutter" to filter packages that do not depend on the Flutter SDK.',
+      help: 'Filter packages where the package depends on the Flutter SDK. Or '
+          '"-no-flutter" to filter packages that do not depend on the Flutter '
+          'SDK.',
     );
 
     argParser.addMultiOption(
       filterOptionScope,
       valueHelp: 'glob',
-      help:
-          'Include only packages with names matching the given glob. This option can be repeated.',
+      help: 'Include only packages with names matching the given glob. This '
+          'option can be repeated.',
     );
 
     argParser.addMultiOption(
       filterOptionIgnore,
       valueHelp: 'glob',
-      help:
-          'Exclude packages with names matching the given glob. This option can be repeated.',
+      help: 'Exclude packages with names matching the given glob. This option '
+          'can be repeated.',
     );
 
     argParser.addOption(
       filterOptionSince,
       valueHelp: 'ref',
-      help:
-          'Only include packages that have been changed since the specified `ref`, e.g. a commit sha or git tag.',
+      help: 'Only include packages that have been changed since the specified '
+          '`ref`, e.g. a commit sha or git tag.',
     );
 
     argParser.addMultiOption(
       filterOptionDirExists,
       valueHelp: 'dirRelativeToPackageRoot',
-      help:
-          'Include only packages where a specific directory exists inside the package.',
+      help: 'Include only packages where a specific directory exists inside '
+          'the package.',
     );
 
     argParser.addMultiOption(
@@ -112,18 +116,16 @@ class MelosCommandRunner extends CommandRunner {
           'Include only packages where a specific file exists in the package.',
     );
 
-    argParser.addMultiOption(
-      filterOptionDependsOn,
-      valueHelp: 'dependantPackageName',
-      help:
-          'Include only packages that depend on a specific package. This option can be repeated.',
-    );
+    argParser.addMultiOption(filterOptionDependsOn,
+        valueHelp: 'dependentPackageName',
+        help: 'Include only packages that depend on a specific package. This '
+            'option can be repeated, to further filter the list of packages.');
 
     argParser.addMultiOption(
       filterOptionNoDependsOn,
       valueHelp: 'noDependantPackageName',
-      help:
-          "Include only packages that *don't* depend on a specific package. This option can be repeated.",
+      help: "Include only packages that *don't* depend on a specific package. "
+          'This option can be repeated.',
     );
 
     addCommand(ExecCommand());

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -128,6 +128,16 @@ class MelosCommandRunner extends CommandRunner {
           'This option can be repeated.',
     );
 
+    argParser.addFlag(filterOptionIncludeDependents,
+        help: 'Include all transitive dependents for each package that matches '
+            'the other filters. The included packages skip --ignore and '
+            '--since checks.');
+
+    argParser.addFlag(filterOptionIncludeDependencies,
+        help: 'Include all transitive dependencies for each package that '
+            'matches the other filters. The included packages skip --ignore '
+            'and --since checks.');
+
     addCommand(ExecCommand());
     addCommand(BootstrapCommand());
     addCommand(CleanCommand());
@@ -198,6 +208,8 @@ class MelosCommandRunner extends CommandRunner {
         hasFlutter: topLevelResults[filterOptionFlutter] as bool,
         dependsOn: topLevelResults[filterOptionDependsOn] as List<String>,
         noDependsOn: topLevelResults[filterOptionNoDependsOn] as List<String>,
+        includeDependents: topLevelResults[filterOptionIncludeDependents],
+        includeDependencies: topLevelResults[filterOptionIncludeDependencies],
       );
     }
 

--- a/packages/melos/lib/src/common/glob.dart
+++ b/packages/melos/lib/src/common/glob.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
+
+/// Returns a [Glob] configured to work in both production and test
+/// environments.
+///
+/// Workaround for https://github.com/dart-lang/glob/issues/52
+Glob createGlob(
+  String pattern, {
+  p.Context context,
+  bool recursive = false,
+  bool caseSensitive,
+}) {
+  context ??= p.Context(
+    style: p.context.style,
+    // This ensures that IOOverrides are taken into account when determining the
+    // current working directory used by the Glob.
+    //
+    // See https://github.com/dart-lang/glob/issues/52 for more information.
+    current: Directory.current.path,
+  );
+  return Glob(
+    pattern,
+    context: context,
+    recursive: recursive,
+    caseSensitive: caseSensitive,
+  );
+}

--- a/packages/melos/lib/src/common/package.dart
+++ b/packages/melos/lib/src/common/package.dart
@@ -19,11 +19,11 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:ansi_styles/ansi_styles.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' show join, joinAll;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
-import 'package:ansi_styles/ansi_styles.dart';
 
 import 'logger.dart';
 import 'utils.dart';
@@ -124,30 +124,6 @@ class MelosPackage {
     return PackageType.dartPackage;
   }
 
-  /// Dependencies of this package.
-  /// Sourced from pubspec.yaml.
-  Map<String, dynamic> get dependencies {
-    if (yamlContents[_kDependencies] != null) {
-      final deps = <String, dynamic>{};
-      yamlContents[_kDependencies].keys.forEach((key) {
-        deps[key as String] = yamlContents[_kDependencies][key];
-      });
-      return deps;
-    }
-    return {};
-  }
-
-  /// Dependencies of this package that are also packages in the current workspace.
-  List<MelosPackage> get dependenciesInWorkspace {
-    final out = <MelosPackage>[];
-    for (final package in _workspace.packages) {
-      if (dependencies[package.name] != null) {
-        out.add(package);
-      }
-    }
-    return out;
-  }
-
   Future<void> setPubspecVersion(String newVersion) async {
     final pubspec = File(pubspecPathForDirectory(Directory(path)));
     final contents = await pubspec.readAsString();
@@ -195,6 +171,31 @@ class MelosPackage {
     }
 
     return pubspec.writeAsString(updatedContents);
+  }
+
+  /// Dependencies of this package.
+  /// Sourced from pubspec.yaml.
+  Map<String, dynamic> get dependencies {
+    if (yamlContents[_kDependencies] != null) {
+      final deps = <String, dynamic>{};
+      yamlContents[_kDependencies].keys.forEach((key) {
+        deps[key as String] = yamlContents[_kDependencies][key];
+      });
+      return deps;
+    }
+    return {};
+  }
+
+  /// Dependencies of this package that are also packages in the current
+  /// workspace.
+  List<MelosPackage> get dependenciesInWorkspace {
+    final out = <MelosPackage>[];
+    for (final package in _workspace.packages) {
+      if (dependencies[package.name] != null) {
+        out.add(package);
+      }
+    }
+    return out;
   }
 
   /// Dev dependencies of this package that are also packages in the current workspace.

--- a/packages/melos/lib/src/common/package.dart
+++ b/packages/melos/lib/src/common/package.dart
@@ -209,6 +209,28 @@ class MelosPackage {
     return out;
   }
 
+  /// A list of dependendencies and dev dependendencies whose packages exist in
+  /// this workspace.
+  ///
+  /// Not subject to filtering.
+  List<MelosPackage> get allDependenciesInWorkspace {
+    final out = <MelosPackage>[];
+    for (final package in _workspace.allPackages) {
+      if (dependencies.containsKey(package.name) ||
+          devDependencies.containsKey(package.name)) {
+        out.add(package);
+      }
+    }
+    return out;
+  }
+
+  /// Transitive dependencies of this package that are also packages in the
+  /// current workspace.
+  ///
+  /// Not subject to filtering.
+  List<MelosPackage> get transitiveDependenciesInWorkspace =>
+      workspace.packageGraph.transitiveDependenciesForPackage(this).toList();
+
   /// Packages in current workspace that directly depend on this package.
   List<MelosPackage> get dependentsInWorkspace {
     final out = <MelosPackage>[];
@@ -219,6 +241,12 @@ class MelosPackage {
     }
     return out;
   }
+
+  /// Packages in current workspace that transitively depend on this package.
+  ///
+  /// Not subject to filtering.
+  List<MelosPackage> get transitiveDependentsInWorkspace =>
+      workspace.packageGraph.transitiveDependentsForPackage(this).toList();
 
   /// Packages in current workspace that list this package as a dev dependency.
   List<MelosPackage> get devDependentsInWorkspace {

--- a/packages/melos/lib/src/common/package_graph.dart
+++ b/packages/melos/lib/src/common/package_graph.dart
@@ -1,0 +1,60 @@
+import 'package.dart';
+import 'workspace.dart';
+
+/// Determines transitive relations between packages.
+///
+/// The relations computed by this class are cached.
+class PackageGraph {
+  PackageGraph(this._workspace);
+
+  final MelosWorkspace _workspace;
+
+  bool _graphComputed = false;
+  final _transitiveDependenciesByPackage = <MelosPackage, Set<MelosPackage>>{};
+  final _transitiveDependentsByPackage = <MelosPackage, Set<MelosPackage>>{};
+
+  /// Calculates the set of packages that are transitive dependencies of [root].
+  Set<MelosPackage> transitiveDependenciesForPackage(
+    MelosPackage root,
+  ) {
+    if (_transitiveDependenciesByPackage.containsKey(root)) {
+      return _transitiveDependenciesByPackage[root];
+    }
+
+    final visited = _transitiveDependenciesByPackage[root] = <MelosPackage>{};
+    for (final package in root.allDependenciesInWorkspace) {
+      visited
+        ..add(package)
+        ..addAll(transitiveDependenciesForPackage(package));
+    }
+    return visited.toSet();
+  }
+
+  /// Calculates the set of packages that are transitive dependents of [root].
+  Set<MelosPackage> transitiveDependentsForPackage(MelosPackage root) {
+    _computeTransitiveDependents();
+    return _transitiveDependentsByPackage[root];
+  }
+
+  /// Computes transitive dependents for each package in the workspace.
+  void _computeTransitiveDependents() {
+    if (_graphComputed) return;
+
+    // First we need the transitive dependencies
+    _workspace.allPackages.forEach(transitiveDependenciesForPackage);
+
+    // Invert the dependendencies to create the dependents graph
+    for (final package in _workspace.allPackages) {
+      _transitiveDependentsByPackage[package] ??= {};
+
+      for (final dependency in _transitiveDependenciesByPackage[package]) {
+        if (!_transitiveDependentsByPackage.containsKey(dependency)) {
+          _transitiveDependentsByPackage[dependency] = {};
+        }
+        _transitiveDependentsByPackage[dependency].add(package);
+      }
+    }
+
+    _graphComputed = true;
+  }
+}

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -38,6 +38,8 @@ const filterOptionPublished = 'published';
 const filterOptionFlutter = 'flutter';
 const filterOptionDependsOn = 'depends-on';
 const filterOptionNoDependsOn = 'no-depends-on';
+const filterOptionIncludeDependents = 'include-dependents';
+const filterOptionIncludeDependencies = 'include-dependencies';
 
 // MELOS_PACKAGES environment variable is a comma delimited list of
 // package names - used instead of filters if it is present.

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   cli_util: ^0.3.0
   collection: ^1.14.12
   conventional_commit: ^0.3.0+1
+  file: ^6.1.0
   glob: ^2.0.1
   http: ^0.13.1
   meta: ^1.1.8

--- a/packages/melos/test/matchers.dart
+++ b/packages/melos/test/matchers.dart
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:melos/src/common/package.dart';
+import 'package:test/test.dart';
+
+Matcher packageNamed(dynamic matcher) => _PackageNameMatcher(matcher);
+
+class _PackageNameMatcher extends CustomMatcher {
+  _PackageNameMatcher(matcher) : super('package named', 'name', matcher);
+  @override
+  Object featureValueOf(Object actual) => (actual as MelosPackage).name;
+}
+
+const containsDuplicates = _ContainsDuplicatesMatcher();
+
+class _ContainsDuplicatesMatcher extends Matcher {
+  const _ContainsDuplicatesMatcher();
+
+  @override
+  Description describe(Description description) =>
+      description.add('contains duplicates');
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    if (item is Iterable) {
+      final seen = <dynamic>{};
+      for (final element in item) {
+        if (seen.contains(element)) {
+          return true;
+        }
+        seen.add(element);
+      }
+
+      return false;
+    }
+    return false;
+  }
+}

--- a/packages/melos/test/mock_fs.dart
+++ b/packages/melos/test/mock_fs.dart
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file/memory.dart';
+
+/// Overrides the body of a test so that I/O is run against an in-memory
+/// file system, not the host's disk.
+///
+/// The I/O override is applied only to the code running within [testBody].
+FutureOr<R> Function() withMockFs<R>(FutureOr<R> Function() testBody) {
+  return () {
+    return IOOverrides.runWithIOOverrides(testBody, MockFs());
+  };
+}
+
+/// Used to override file I/O with an in-memory file system for testing.
+///
+/// Usage:
+///
+/// ```dart
+/// test('My FS test', withMockFs(() {
+///   File('foo').createSync(); // File created in memory
+/// }));
+/// ```
+///
+/// Alternatively, set [IOOverrides.global] to a [MockFs] instance in your
+/// test's `setUp`, and to `null` in the `tearDown`.
+class MockFs extends IOOverrides {
+  /// Note that we only support [MemoryFileSystem]s, because a local file system
+  /// would create infinite loops IOOverride -> FS -> IOOverride -> FS...
+  final MemoryFileSystem fs = MemoryFileSystem(
+    // Match the platform pathing style
+    style: Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+  );
+
+  @override
+  Directory createDirectory(String path) => fs.directory(path);
+
+  @override
+  File createFile(String path) => fs.file(path);
+
+  @override
+  Link createLink(String path) => fs.link(path);
+
+  @override
+  Stream<FileSystemEvent> fsWatch(String path, int events, bool recursive) =>
+      fs.file(path).watch(events: events, recursive: recursive);
+
+  @override
+  bool fsWatchIsSupported() => fs.isWatchSupported;
+
+  @override
+  Future<FileSystemEntityType> fseGetType(String path, bool followLinks) =>
+      fs.type(path, followLinks: followLinks ?? true);
+
+  @override
+  FileSystemEntityType fseGetTypeSync(String path, bool followLinks) =>
+      fs.typeSync(path, followLinks: followLinks ?? true);
+
+  @override
+  Future<bool> fseIdentical(String path1, String path2) =>
+      fs.identical(path1, path2);
+
+  @override
+  bool fseIdenticalSync(String path1, String path2) =>
+      fs.identicalSync(path1, path2);
+
+  @override
+  Directory getCurrentDirectory() => fs.currentDirectory;
+
+  @override
+  Directory getSystemTempDirectory() => fs.systemTempDirectory;
+
+  @override
+  void setCurrentDirectory(String path) {
+    fs.currentDirectory = path;
+  }
+
+  @override
+  Future<FileStat> stat(String path) => fs.stat(path);
+
+  @override
+  FileStat statSync(String path) => fs.statSync(path);
+}

--- a/packages/melos/test/mock_workspace_fs.dart
+++ b/packages/melos/test/mock_workspace_fs.dart
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart';
+
+import 'mock_fs.dart';
+
+/// Creates a mock workspace at [workspaceRoot], containing a `melos.yaml`
+/// and a set of package folders as described by [packages].
+///
+/// The returned directory represents the workspace root.
+Directory createMockWorkspaceFs({
+  String workspaceName = 'monorepo',
+  String workspaceRoot = '/melos_workspace',
+  Iterable<String> workspacePackagesGlobs = const ['packages/**'],
+  Iterable<MockPackageFs> packages = const [],
+  bool setCwdToWorkspace = true,
+}) {
+  assert(IOOverrides.current is MockFs,
+      'Mock workspaces can only be created inside a mock filesystem');
+
+  // Create a `melos.yaml`
+  _createMelosConfig(workspaceRoot, workspaceName, workspacePackagesGlobs);
+
+  // Sythesize a "package" (enough to satisfy our test requirements) for each
+  // entry in `packages`
+  for (final package in packages) {
+    _createPackage(package, workspaceRoot);
+    if (package.createExamplePackage) {
+      _createPackage(package.examplePackage, workspaceRoot);
+    }
+  }
+
+  if (setCwdToWorkspace) {
+    Directory.current = workspaceRoot;
+  }
+
+  return Directory(workspaceRoot);
+}
+
+void _createMelosConfig(
+  String workspaceRoot,
+  String workspaceName,
+  Iterable<String> workspacePackagesGlobs,
+) {
+  File(join(workspaceRoot, 'melos.yaml'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+name: $workspaceName
+packages:
+${_yamlStringList(workspacePackagesGlobs)}
+''');
+}
+
+void _createPackage(MockPackageFs package, String workspaceRoot) {
+  final pubspec = StringBuffer();
+  pubspec.writeln('name: ${package.name}');
+  if (package.publishToNone) {
+    pubspec.writeln('publish_to: none');
+  }
+  pubspec.writeln('''
+dependencies:
+${_yamlMap(package.dependencyMap, indent: 2)}
+''');
+
+  File(join(workspaceRoot, package.path, 'pubspec.yaml'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync(pubspec.toString());
+}
+
+String _yamlStringList(Iterable<String> elements) {
+  return elements.map((element) => '- $element').join('\n');
+}
+
+String _yamlMap(Map<String, String> map, {int indent}) {
+  final indentString = ' ' * indent;
+  return map.entries.map((e) => '$indentString${e.key}: ${e.value}').join('\n');
+}
+
+/// Used to generate a package's on-disk representation via [createMockWorkspaceFs].
+class MockPackageFs {
+  MockPackageFs({
+    @required this.name,
+    String path,
+    List<String> dependencies,
+    bool publishToNone,
+    bool generateExample,
+  })  : _path = path,
+        publishToNone = publishToNone ?? false,
+        dependencies = dependencies ?? const [],
+        createExamplePackage = generateExample ?? false;
+
+  /// Name of the package (must be a valid Dart package name)
+  final String name;
+
+  /// Workspace-root relative path
+  String get path => _path ?? 'packages/$name';
+  final String _path;
+
+  /// `true` if this package's yaml has a `publish_to: none` setting.
+  final bool publishToNone;
+
+  /// A list of package names this one depends on
+  final List<String> dependencies;
+
+  /// A mapping of dependency names to their versions (always "any")
+  Map<String, String> get dependencyMap {
+    return Map.fromEntries(dependencies.map((name) => MapEntry(name, 'any')));
+  }
+
+  /// `true` if an example package should be generated
+  final bool createExamplePackage;
+
+  /// Returns a file system description for this package's example
+  MockPackageFs get examplePackage {
+    return createExamplePackage
+        ? MockPackageFs(
+            name: '${name}_example',
+            path: join(path, 'example'),
+            dependencies: [name],
+            publishToNone: true,
+          )
+        : null;
+  }
+}

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:melos/src/common/workspace_command_config.dart';
 import 'package:melos/src/common/workspace_config.dart';
 import 'package:test/test.dart';

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:melos/src/common/workspace.dart';
+import 'package:test/test.dart';
+
+import 'matchers.dart';
+import 'mock_fs.dart';
+import 'mock_workspace_fs.dart';
+
+void main() {
+  group('Workspace', () {
+    group('package filtering', () {
+      group('--include-dependencies', () {
+        test('includes the scoped package', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['b'],
+            includeDependencies: true,
+          );
+
+          expect(filteredPackages, [packageNamed('b')]);
+        }));
+
+        test('includes direct dependencies', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['a'],
+            includeDependencies: true,
+          );
+
+          expect(filteredPackages, hasLength(2));
+          expect(
+            filteredPackages,
+            containsAll([packageNamed('a'), packageNamed('b')]),
+          );
+        }));
+
+        test('includes transient dependencies', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b', dependencies: ['c']),
+                MockPackageFs(name: 'c'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['a'],
+            includeDependencies: true,
+          );
+
+          expect(
+            filteredPackages,
+            containsAll([
+              packageNamed('a'),
+              packageNamed('b'),
+              packageNamed('c'), // This dep is transitive
+            ]),
+          );
+        }));
+
+        test('does not include duplicates', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b', 'c']),
+                MockPackageFs(name: 'b', dependencies: ['d']),
+                MockPackageFs(name: 'c', dependencies: ['d']),
+                MockPackageFs(name: 'd'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['a'],
+            includeDependencies: true,
+          );
+
+          expect(filteredPackages, hasLength(4));
+          expect(filteredPackages, isNot(containsDuplicates));
+        }));
+      });
+
+      group('--include-dependents', () {
+        test('includes the scoped package', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['a'],
+            includeDependents: true,
+          );
+
+          expect(filteredPackages, [packageNamed('a')]);
+        }));
+
+        test('includes direct dependents', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['b'],
+            includeDependents: true,
+          );
+
+          expect(filteredPackages, hasLength(2));
+          expect(
+            filteredPackages,
+            containsAll([packageNamed('a'), packageNamed('b')]),
+          );
+        }));
+
+        test('includes transient dependents', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b']),
+                MockPackageFs(name: 'b', dependencies: ['c']),
+                MockPackageFs(name: 'c'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['c'],
+            includeDependents: true,
+          );
+
+          expect(
+            filteredPackages,
+            containsAll([
+              packageNamed('a'),
+              packageNamed('b'),
+              packageNamed('c'), // This dep is transitive
+            ]),
+          );
+        }));
+
+        test('does not include duplicates', withMockFs(() async {
+          final workspace = await MelosWorkspace.fromDirectory(
+            createMockWorkspaceFs(
+              packages: [
+                MockPackageFs(name: 'a', dependencies: ['b', 'c']),
+                MockPackageFs(name: 'b', dependencies: ['d']),
+                MockPackageFs(name: 'c', dependencies: ['d']),
+                MockPackageFs(name: 'd'),
+              ],
+            ),
+          );
+          final filteredPackages = await workspace.loadPackagesWithFilters(
+            scope: ['d'],
+            includeDependents: true,
+          );
+
+          expect(filteredPackages, hasLength(4));
+          expect(filteredPackages, isNot(containsDuplicates));
+        }));
+      });
+    });
+  });
+}


### PR DESCRIPTION
### Whoa now. Big PR.
Quite a few additions here. I'm happy to split up into a few PRs. Alternatively, the commits are well organized and tightly focused, if you wanted to go one-by-one.

### Filters
Adds two additional top-level filtering flags that expand the set of matched packages.

`--include-dependencies` takes the filtered list of packages, and expands them to include those packages' transitive dependencies (ignoring filters)

`--include-dependents` takes the filtered list of packages, and expands them to include those packages' transitive dependents (ignoring filters)

Example:

```sh
melos list --scope=some_package --with-dependencies # some_package, dep1, dep2, ...
```

### ✨ Testing
In order to test the flags, the PR introduces the facility to mock a filesystem, and helpers for constructing a workspace's filesystem.

### Cleanup
Rearranged some methods, added comments, wrapped at 80.