### PR TITLE
fix: Fix --published/--no-published filters

### DIFF
--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -201,8 +201,9 @@ class MelosWorkspace {
       final pool = Pool(10);
       final packagesFilteredWithPublishStatus = <MelosPackage>[];
       await pool.forEach<MelosPackage, void>(packages, (package) {
+        final packageVersion = package.version.toString();
         return package.getPublishedVersions().then((versions) {
-          final isOnPubRegistry = versions.contains(package.version);
+          final isOnPubRegistry = versions.contains(packageVersion);
           if (published == isOnPubRegistry) {
             packagesFilteredWithPublishStatus.add(package);
           }


### PR DESCRIPTION
This check was failing because MelosPackage.version is a `Version` instance, and the value returned from MelosPackage.getPublishedVersions() is a `List<String>`.

I'd considered adding a test here, but it's slightly more involved because we'd need to be mocking pub responses. Doable (maybe using something like [`nock`](https://github.com/nock/nock)?) but felt like it needed its own PR.