### PR TITLE
refactor: Move to a stubbable Platform abstraction

### DIFF
--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -28,6 +28,7 @@ import '../command_runner.dart';
 import '../common/intellij_project.dart';
 import '../common/logger.dart';
 import '../common/package.dart';
+import '../common/platform.dart';
 import '../common/utils.dart' as utils;
 import '../common/workspace.dart';
 import 'base.dart';
@@ -52,11 +53,11 @@ class BootstrapCommand extends MelosCommand {
     final execArgs = currentWorkspace.isFlutterWorkspace
         ? ['flutter', ...pubGetArgs]
         : [if (utils.isPubSubcommand()) 'dart', ...pubGetArgs];
-    final executable = Platform.isWindows ? 'cmd' : '/bin/sh';
+    final executable = currentPlatform.isWindows ? 'cmd' : '/bin/sh';
     final pluginTemporaryPath =
         join(currentWorkspace.melosToolPath, package.pathRelativeToWorkspace);
     final execProcess = await Process.start(
-        executable, Platform.isWindows ? ['/C', '%MELOS_SCRIPT%'] : [],
+        executable, currentPlatform.isWindows ? ['/C', '%MELOS_SCRIPT%'] : [],
         workingDirectory: pluginTemporaryPath,
         includeParentEnvironment: true,
         environment: {
@@ -66,7 +67,7 @@ class BootstrapCommand extends MelosCommand {
         runInShell: true);
     _runningProcesses.add(execProcess);
 
-    if (!Platform.isWindows) {
+    if (!currentPlatform.isWindows) {
       // Pipe in the arguments to trigger the script to run.
       execProcess.stdin.writeln(execArgs.join(' '));
       // Exit the process with the same exit code as the previous command.

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -30,6 +30,7 @@ import 'command/publish.dart';
 import 'command/run.dart';
 import 'command/version.dart';
 import 'common/logger.dart';
+import 'common/platform.dart';
 import 'common/utils.dart';
 import 'common/workspace.dart';
 
@@ -187,12 +188,12 @@ class MelosCommandRunner extends CommandRunner {
       return;
     }
 
-    if (Platform.environment.containsKey(envKeyMelosPackages)) {
+    if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
       // MELOS_PACKAGES environment variable is a comma delimited list of
       // package names - used instead of filters if it is present.
       // This can be user defined or can come from package selection in `melos run`.
       await currentWorkspace.loadPackagesWithNames(
-        Platform.environment[envKeyMelosPackages].split(','),
+        currentPlatform.environment[envKeyMelosPackages].split(','),
       );
     } else {
       await currentWorkspace.loadPackagesWithFilters(

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -23,6 +23,7 @@ import 'package:path/path.dart' show joinAll;
 import '../common/package.dart';
 import '../common/utils.dart' as utils;
 import '../common/workspace.dart';
+import 'platform.dart';
 
 const String _kTemplatesDirName = 'templates';
 const String _kIntellijDirName = 'intellij';
@@ -187,8 +188,8 @@ class IntellijProject {
   }
 
   String getMelosBinForIde() {
-    if (Platform.isWindows) {
-      if (Platform.script.path.contains('Roaming')) {
+    if (currentPlatform.isWindows) {
+      if (currentPlatform.script.path.contains('Roaming')) {
         return r'$USER_HOME$/AppData/Roaming/Pub/Cache/bin/melos.bat';
       }
       return r'$USER_HOME$/AppData/Local/Pub/Cache/bin/melos.bat';

--- a/packages/melos/lib/src/common/package.dart
+++ b/packages/melos/lib/src/common/package.dart
@@ -67,6 +67,14 @@ List<String> _generatedPubFilePaths = [
   '.dart_tool${Platform.pathSeparator}version',
 ];
 
+/// The URL where we can find a package server.
+///
+/// The default is `pub.dev`, but it can be overridden using the
+/// `PUB_HOSTED_URL` environment variable.
+/// https://dart.dev/tools/pub/environment-variables
+Uri get pubUrl =>
+    Uri.parse(Platform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dev');
+
 /// Enum representing what type of package this is.
 enum PackageType {
   dartPackage,
@@ -381,8 +389,8 @@ class MelosPackage {
       return _registryVersions;
     }
 
-    final url = 'https://pub.dev/packages/$name.json';
-    final response = await http.get(Uri.parse(url));
+    final url = pubUrl.replace(path: '/packages/$name.json');
+    final response = await http.get(url);
     if (response.statusCode == 404) {
       return [];
     } else if (response.statusCode != 200) {

--- a/packages/melos/lib/src/common/package.dart
+++ b/packages/melos/lib/src/common/package.dart
@@ -26,6 +26,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import 'logger.dart';
+import 'platform.dart';
 import 'utils.dart';
 import 'workspace.dart';
 
@@ -62,9 +63,9 @@ List<String> _generatedPubFilePaths = [
   '.packages',
   '.flutter-plugins',
   '.flutter-plugins-dependencies',
-  '.dart_tool${Platform.pathSeparator}package_config.json',
-  '.dart_tool${Platform.pathSeparator}package_config_subset',
-  '.dart_tool${Platform.pathSeparator}version',
+  '.dart_tool${currentPlatform.pathSeparator}package_config.json',
+  '.dart_tool${currentPlatform.pathSeparator}package_config_subset',
+  '.dart_tool${currentPlatform.pathSeparator}version',
 ];
 
 /// The URL where we can find a package server.
@@ -72,8 +73,8 @@ List<String> _generatedPubFilePaths = [
 /// The default is `pub.dev`, but it can be overridden using the
 /// `PUB_HOSTED_URL` environment variable.
 /// https://dart.dev/tools/pub/environment-variables
-Uri get pubUrl =>
-    Uri.parse(Platform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dev');
+Uri get pubUrl => Uri.parse(
+    currentPlatform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dev');
 
 /// Enum representing what type of package this is.
 enum PackageType {
@@ -345,7 +346,7 @@ class MelosPackage {
       final exampleParentPackagePath = Directory(path).parent.path;
       final exampleParentPackage = await fromPubspecPathAndWorkspace(
           File(
-              '$exampleParentPackagePath${Platform.pathSeparator}pubspec.yaml'),
+              '$exampleParentPackagePath${currentPlatform.pathSeparator}pubspec.yaml'),
           _workspace);
       if (exampleParentPackage != null) {
         environment['MELOS_PARENT_PACKAGE_NAME'] = exampleParentPackage.name;
@@ -374,7 +375,7 @@ class MelosPackage {
       var temporaryFileContents = await fileToCopy.readAsString();
       temporaryFileContents = temporaryFileContents.replaceAll(
           RegExp(
-              '\\.melos_tool${Platform.isWindows ? r'\' : ''}${Platform.pathSeparator}'),
+              '\\.melos_tool${currentPlatform.isWindows ? r'\' : ''}${currentPlatform.pathSeparator}'),
           '');
       final fileToCreate = File(join(path, tempFilePath));
       await fileToCreate.create(recursive: true);
@@ -561,7 +562,8 @@ class MelosPackage {
         platform == kMacos ||
         platform == kWindows ||
         platform == kLinux);
-    return Directory('$path${Platform.pathSeparator}$platform').existsSync();
+    return Directory('$path${currentPlatform.pathSeparator}$platform')
+        .existsSync();
   }
 
   bool _flutterPluginSupportsPlatform(String platform) {

--- a/packages/melos/lib/src/common/platform.dart
+++ b/packages/melos/lib/src/common/platform.dart
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
+@visibleForTesting
+const currentPlatformZoneKey = #currentPlatform;
+
+/// The system's platform. Should be used in place of `dart:io`'s [Platform].
+///
+/// Can be stubbed during tests by setting a the [currentPlatformZoneKey] zone value
+/// a [Platform] instance.
+Platform get currentPlatform =>
+    Zone.current[currentPlatformZoneKey] ?? const LocalPlatform();

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -92,26 +92,10 @@ bool get isCI {
       keys.contains('RUN_ID');
 }
 
-String getMelosRoot() {
-  if (currentPlatform.script.path.contains('global_packages')) {
-    return joinAll([
-      File.fromUri(currentPlatform.script).parent.parent.parent.parent.path,
-      'hosted',
-      'pub.dartlang.org',
-      'melos-$melosVersion'
-    ]);
-  }
-
-  // This allows us to use melos on itself during development.
-  if (currentPlatform.script.path.contains('melos_dev.dart')) {
-    return joinAll([
-      File.fromUri(currentPlatform.script).parent.parent.path,
-      'packages',
-      'melos'
-    ]);
-  }
-
-  return File.fromUri(currentPlatform.script).parent.parent.path;
+Future<String> getMelosRoot() async {
+  final melosPackageFileUri = await Isolate.resolvePackageUri(melosPackageUri);
+  // Get from lib/melos.dart to the package root
+  return File(melosPackageFileUri.toFilePath()).parent.parent.path;
 }
 
 Map loadYamlFileSync(String path) {

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -26,7 +26,6 @@ import 'package:prompts/prompts.dart' as prompts;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
-import '../../version.g.dart';
 import 'platform.dart';
 
 const filterOptionScope = 'scope';

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   meta: ^1.1.8
   mustache_template: ^2.0.0
   path: ^1.7.0
+  platform: ^3.0.0
   pool: ^1.4.0
   prompts: ^1.3.1
   pub_semver: ^2.0.0

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   yaml: ^3.1.0
   yamlicious: ^0.1.0
 dev_dependencies:
+  nock: ^1.2.0
   test: any
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/packages/melos/test/mock_env.dart
+++ b/packages/melos/test/mock_env.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:melos/src/common/platform.dart';
+import 'package:meta/meta.dart';
+import 'package:platform/platform.dart';
+
+/// Overrides the current platform in [testBody] with [platform] for the
+/// duration of [testBody].
+FutureOr<R> Function() withMockPlatform<R>(
+  FutureOr<R> Function() testBody, {
+  @required Platform platform,
+}) {
+  return () async {
+    return runZoned(
+      testBody,
+      zoneValues: {
+        currentPlatformZoneKey: platform,
+      },
+    );
+  };
+}

--- a/packages/melos/test/mock_fs.dart
+++ b/packages/melos/test/mock_fs.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:file/memory.dart';
+import 'package:melos/src/common/platform.dart';
 
 /// Overrides the body of a test so that I/O is run against an in-memory
 /// file system, not the host's disk.
@@ -48,7 +49,9 @@ class MockFs extends IOOverrides {
   /// would create infinite loops IOOverride -> FS -> IOOverride -> FS...
   final MemoryFileSystem fs = MemoryFileSystem(
     // Match the platform pathing style
-    style: Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+    style: currentPlatform.isWindows
+        ? FileSystemStyle.windows
+        : FileSystemStyle.posix,
   );
 
   @override

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:melos/src/common/workspace.dart';
+import 'package:nock/nock.dart';
+import 'package:platform/platform.dart';
+import 'package:test/test.dart';
+
+import 'mock_env.dart';
+import 'mock_fs.dart';
+import 'mock_workspace_fs.dart';
+
+const pubPackageJson = '''
+  {
+    "versions": [
+      "1.0.0"
+    ]
+  }
+''';
+
+void main() {
+  group('MelosPackage', () {
+    setUpAll(nock.init);
+
+    MelosWorkspace workspace;
+    setUp(() async {
+      nock.cleanAll();
+      IOOverrides.global = MockFs();
+
+      workspace = await MelosWorkspace.fromDirectory(
+        createMockWorkspaceFs(
+          packages: [MockPackageFs(name: 'melos')],
+        ),
+      );
+      await workspace.loadPackagesWithFilters();
+    });
+
+    tearDown(() {
+      IOOverrides.global = null;
+    });
+
+    test('requests published packages from pub.dev by default', () async {
+      final interceptor = nock('https://pub.dev').get('/packages/melos.json')
+        ..reply(200, pubPackageJson);
+
+      final package = workspace.packages.first;
+      await package.getPublishedVersions();
+
+      expect(interceptor.isDone, isTrue);
+    });
+
+    test(
+      'requests published packages from PUB_HOSTED_URL if present',
+      withMockPlatform(
+        () async {
+          final interceptor = nock('http://localhost:8080')
+              .get('/packages/melos.json')
+                ..reply(200, pubPackageJson);
+
+          final package = workspace.packages.first;
+          await package.getPublishedVersions();
+
+          expect(interceptor.isDone, isTrue);
+        },
+        platform: FakePlatform.fromPlatform(const LocalPlatform())
+          ..environment['PUB_HOSTED_URL'] = 'http://localhost:8080',
+      ),
+    );
+  });
+}


### PR DESCRIPTION
This introduces the use of the `platform` package so that we can stub out the `Platform` for tests.

`currentPlatform` should be used in place of direct `Platform` access. It can be overridden through a Zone value, which is useful in testing scenarios (see included test for an example).

**Side note**: This is where Dart's lack of custom lints can be felt. In an ideal system, I'd want to set up a rule where direct use of `Platform` warned the user.