### PR TITLE
fix: Find templates using a resolved package URI

### DIFF
--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -40,9 +40,9 @@ class IntellijProject {
   final Map<String, String> _cacheTemplates = <String, String>{};
 
   /// Fully qualified path to the intellij templates shipped as part of Melos.
-  String get pathTemplates {
+  Future<String> get pathTemplates async {
     return joinAll([
-      utils.getMelosRoot(),
+      await utils.getMelosRoot(),
       _kTemplatesDirName,
       _kIntellijDirName,
     ]);
@@ -67,8 +67,8 @@ class IntellijProject {
     return joinAll([pathDotIdea, 'modules.xml']);
   }
 
-  String pathTemplatesForDirectory(String directory) {
-    return joinAll([pathTemplates, directory]);
+  Future<String> pathTemplatesForDirectory(String directory) async {
+    return joinAll([await pathTemplates, directory]);
   }
 
   String pathPackageModuleIml(MelosPackage package) {
@@ -114,9 +114,9 @@ class IntellijProject {
     }
     String templatesRootPath;
     if (templateCategory != null) {
-      templatesRootPath = pathTemplatesForDirectory(templateCategory);
+      templatesRootPath = await pathTemplatesForDirectory(templateCategory);
     } else {
-      templatesRootPath = pathTemplates;
+      templatesRootPath = await pathTemplates;
     }
 
     final templateFile =


### PR DESCRIPTION
Melos can be run from fairly arbitrary locations, depending on the PUB_HOSTED_URL environment variable, or if the script is being called directly.

To simplify searching for the templates that correspond to the currently running Melos, we use `Isolate.resolvePackageUri` to resolve Melos' package URI to a file, and base our template file paths on that.

Fixes #82