### PR TITLE
fix(bootstrap): use original `pubspec.lock` files when running pub get inside mirrored workspace (fixes #68)

### DIFF
--- a/packages/melos/lib/src/command/bootstrap.dart
+++ b/packages/melos/lib/src/command/bootstrap.dart
@@ -174,11 +174,9 @@ class BootstrapCommand extends MelosCommand {
     // .melos_tool directory we need to use unscoped packages here so as to
     // preserve any local 'dependencies' or 'dependency_overrides' that packages
     // in `currentWorkspace.packages` may be referencing by relative paths.
-    await Future.forEach(currentWorkspace.packagesNoScope,
-        (MelosPackage package) async {
+    for (final package in currentWorkspace.packagesNoScope) {
       final pluginTemporaryPath =
           join(currentWorkspace.melosToolPath, package.pathRelativeToWorkspace);
-
       final generatedYamlMap = Map.from(package.yamlContents);
 
       // As melos boostrap builds a 1-1 mirror of the packages tree in the
@@ -243,11 +241,23 @@ class BootstrapCommand extends MelosCommand {
       final generatedPubspecYamlString =
           '$header\n${toYamlString(generatedYamlMap)}';
 
-      await File(utils.pubspecPathForDirectory(Directory(pluginTemporaryPath)))
-          .create(recursive: true);
-      await File(utils.pubspecPathForDirectory(Directory(pluginTemporaryPath)))
-          .writeAsString(generatedPubspecYamlString);
-    });
+      File(utils.pubspecPathForDirectory(Directory(pluginTemporaryPath)))
+          .createSync(recursive: true);
+      File(utils.pubspecPathForDirectory(Directory(pluginTemporaryPath)))
+          .writeAsStringSync(generatedPubspecYamlString);
+
+      // Original pubspec.lock files should also be preserved in our packages
+      // mirror, if we don't then this makes melos bootstrap function the same
+      // as `dart pub upgrade` every time - which we don't want.
+      // See https://github.com/invertase/melos/issues/68
+      final originalPubspecLock = join(package.path, 'pubspec.lock');
+      if (File(originalPubspecLock).existsSync()) {
+        final pubspecLockContents =
+            File(originalPubspecLock).readAsStringSync();
+        final copiedPubspecLock = join(pluginTemporaryPath, 'pubspec.lock');
+        File(copiedPubspecLock).writeAsStringSync(pubspecLockContents);
+      }
+    }
 
     final pool = Pool(utils.isCI ? 1 : 3);
     // As noted in previous `packages` loops/forEach blocks above re using

--- a/packages/melos/lib/src/common/glob.dart
+++ b/packages/melos/lib/src/common/glob.dart
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import 'dart:io';
 
 import 'package:glob/glob.dart';

--- a/packages/melos/lib/src/common/package_graph.dart
+++ b/packages/melos/lib/src/common/package_graph.dart
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import 'package.dart';
 import 'workspace.dart';
 


### PR DESCRIPTION
Original pubspec.lock files should also be preserved in our packages mirror, if we don't then this makes `melos bootstrap` function the same as `dart pub upgrade` every time - which we don't want.

Fixes #68 