### PR TITLE
feat: make intellij project clean only delete melos run configurations

### DIFF
--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -229,11 +229,14 @@ class IntellijProject {
   }
 
   Future<void> clean() async {
-    final melosConfigurations =
-        createGlob('$pathDotIdea/runConfigurations/melos_*.xml')
-            .listFileSystem(const LocalFileSystem());
-    await for (final file in melosConfigurations) {
-      await file.delete();
+    final melosConfigurationsPath = joinAll([pathDotIdea, 'runConfigurations']);
+    if (Directory(melosConfigurationsPath).existsSync()) {
+      final melosConfigurations =
+          createGlob('$melosConfigurationsPath/melos_*.xml')
+              .listFileSystem(const LocalFileSystem());
+      await for (final file in melosConfigurations) {
+        await file.delete();
+      }
     }
   }
 

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -17,12 +17,14 @@
 
 import 'dart:io';
 
+import 'package:file/local.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' show joinAll;
 
 import '../common/package.dart';
 import '../common/utils.dart' as utils;
 import '../common/workspace.dart';
+import 'glob.dart';
 import 'platform.dart';
 
 const String _kTemplatesDirName = 'templates';
@@ -227,11 +229,11 @@ class IntellijProject {
   }
 
   Future<void> clean() async {
-    final runConfigurationsDirectory =
-        Directory(joinAll([pathDotIdea, 'runConfigurations']));
-    if (runConfigurationsDirectory.existsSync()) {
-      await Directory(joinAll([pathDotIdea, 'runConfigurations']))
-          .delete(recursive: true);
+    final melosConfigurations =
+        createGlob('$pathDotIdea/runConfigurations/melos_*.xml')
+            .listFileSystem(const LocalFileSystem());
+    await for (final file in melosConfigurations) {
+      await file.delete();
     }
   }
 


### PR DESCRIPTION
Make `melos bootstrap` and `melos clean` only delete `.idea/runConfigurations/melos_.xml` files.

Some projects may add custom run configurations and commit them to git.
I think it's better to only clean files created by melos.