### PR TITLE
fix: incorrect intellij project clean glob pattern in windows

### DIFF
--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -229,10 +229,9 @@ class IntellijProject {
   }
 
   Future<void> clean() async {
-    final melosConfigurationsPath = joinAll([pathDotIdea, 'runConfigurations']);
-    if (Directory(melosConfigurationsPath).existsSync()) {
+    if (Directory(joinAll([pathDotIdea, 'runConfigurations'])).existsSync()) {
       final melosConfigurations =
-          createGlob('$melosConfigurationsPath/melos_*.xml')
+          createGlob('$pathDotIdea/runConfigurations/melos_*.xml')
               .listFileSystem(const LocalFileSystem());
       await for (final file in melosConfigurations) {
         await file.delete();


### PR DESCRIPTION
Sorry for the mistake in #96 that creates an incorrect glob pattern in windows.

Glob always uses the `/` as the separator (https://pub.dev/packages/glob#syntax).