### PR TITLE
fix: The default workspace no-longer searches for projects inside the .dart_tool folder of packages

### DIFF
--- a/packages/melos/lib/src/common/workspace.dart
+++ b/packages/melos/lib/src/common/workspace.dart
@@ -98,10 +98,13 @@ class MelosWorkspace {
   /// Calling this method sets the [allPackages] field upon completion.
   Future<List<MelosPackage>> _loadPackages() async {
     final includeGlobs = config.packages.map(createGlob).toList();
+    final dartToolGlob = createGlob('**/.dart_tool/**');
+
     return allPackages = await Directory(path)
         .list(recursive: true, followLinks: false)
         .where((file) =>
             file.path.endsWith('pubspec.yaml') &&
+            !dartToolGlob.matches(file.path) &&
             includeGlobs.any((glob) => glob.matches(file.path)))
         .asyncMap((entity) {
       // Convert into Package for further filtering

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -23,6 +23,29 @@ import 'mock_workspace_fs.dart';
 
 void main() {
   group('Workspace', () {
+    test(
+        'does not include projects inside packages/whatever/.dart_tool when no melos.yaml is specified',
+        withMockFs(() async {
+      // regression test for https://github.com/invertase/melos/issues/101
+
+      final mockWorkspaceRootDir = createMockWorkspaceFs(
+        workspaceRoot: '/root',
+        packages: [
+          MockPackageFs(name: 'a'),
+          MockPackageFs(name: 'b', path: '/root/packages/a/.dart_tool/b'),
+        ],
+      );
+
+      final workspace =
+          await MelosWorkspace.fromDirectory(mockWorkspaceRootDir);
+      final filteredPackages = await workspace.loadPackagesWithFilters();
+
+      expect(
+        filteredPackages,
+        [packageNamed('a')],
+      );
+    }));
+
     group('package filtering', () {
       group('--include-dependencies', () {
         test('includes the scoped package', withMockFs(() async {


### PR DESCRIPTION
fixes #101 