### PR TITLE
feat!: migrate conventional_commit to null-safety

### DIFF
--- a/packages/conventional_commit/example/conventional_commit.dart
+++ b/packages/conventional_commit/example/conventional_commit.dart
@@ -15,7 +15,7 @@ Refs #123 #456
 ''';
 
 void main() {
-  final parsedCommit = ConventionalCommit.parse(commitMessageExample);
+  final parsedCommit = ConventionalCommit.tryParse(commitMessageExample)!;
 
   print(parsedCommit.description);
   // : An exciting new feature.

--- a/packages/conventional_commit/pubspec.yaml
+++ b/packages/conventional_commit/pubspec.yaml
@@ -1,8 +1,11 @@
-name: "conventional_commit"
-description: "Parse a git commit message using the Conventional Commits specification."
-version: "0.3.0+1"
-homepage: "https://github.com/invertase/melos/tree/master/packages/conventional_commit"
-dev_dependencies:
-  test: any
+name: conventional_commit
+description: Parse a git commit message using the Conventional Commits specification.
+version: 0.3.0+1
+homepage: https://github.com/invertase/melos/tree/master/packages/conventional_commit
+
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+
+dev_dependencies:
+  collection: ^1.15.0
+  test: ^1.17.5

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -17,6 +17,7 @@
 
 import 'package:conventional_commit/conventional_commit.dart';
 import 'package:test/test.dart';
+import 'package:collection/collection.dart';
 
 const bodyExample = '''
 A body describing this commit in more detail.
@@ -51,113 +52,178 @@ Refs #123 #1234
 void main() {
   group('$ConventionalCommit', () {
     test('invalid commit messages', () {
-      expect(ConventionalCommit.parse('new feature!!!'), isNull);
-      expect(() {
-        ConventionalCommit.parse(null);
-      }, throwsA(isA<AssertionError>()));
-      expect(ConventionalCommit.parse(''), isNull);
-      expect(ConventionalCommit.parse(': new feature'), isNull);
-      expect(ConventionalCommit.parse(' (): new feature'), isNull);
-      expect(ConventionalCommit.parse('feat()'), isNull);
-      expect(ConventionalCommit.parse('custom: new feature'), isNull);
+      expect(ConventionalCommit.tryParse('new feature!!!'), isNull);
+      expect(ConventionalCommit.tryParse(''), isNull);
+      expect(ConventionalCommit.tryParse(': new feature'), isNull);
+      expect(ConventionalCommit.tryParse(' (): new feature'), isNull);
+      expect(ConventionalCommit.tryParse('feat()'), isNull);
+      expect(ConventionalCommit.tryParse('custom: new feature'), isNull);
     });
 
     test('header', () {
-      expect(ConventionalCommit.parse('docs: foo bar').header,
-          equals('docs: foo bar'));
-      expect(ConventionalCommit.parse('docs!: foo bar').header,
-          equals('docs!: foo bar'));
-      expect(ConventionalCommit.parse('docs(scope): foo bar').header,
-          equals('docs(scope): foo bar'));
-      expect(ConventionalCommit.parse('docs(scope,dope): foo bar').header,
-          equals('docs(scope,dope): foo bar'));
-      expect(ConventionalCommit.parse('docs(scope,dope)!: foo bar').header,
-          equals('docs(scope,dope)!: foo bar'));
+      expect(
+        ConventionalCommit.tryParse('docs: foo bar')!.header,
+        equals('docs: foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs!: foo bar')!.header,
+        equals('docs!: foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope): foo bar')!.header,
+        equals('docs(scope): foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope): foo bar')!.header,
+        equals('docs(scope,dope): foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope)!: foo bar')!.header,
+        equals('docs(scope,dope)!: foo bar'),
+      );
     });
 
     test('scopes', () {
-      expect(ConventionalCommit.parse('docs: foo bar').scopes, equals([]));
-      expect(ConventionalCommit.parse('docs!: foo bar').scopes, equals([]));
-      expect(ConventionalCommit.parse('docs(scope): foo bar').scopes,
-          equals(['scope']));
-      expect(ConventionalCommit.parse('docs(scope,dope): foo bar').scopes,
-          equals(['scope', 'dope']));
-      expect(ConventionalCommit.parse('docs(scope,dope)!: foo bar').scopes,
-          equals(['scope', 'dope']));
+      expect(
+        ConventionalCommit.tryParse('docs: foo bar')!.scopes,
+        equals([]),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs!: foo bar')!.scopes,
+        equals([]),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope): foo bar')!.scopes,
+        equals(['scope']),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope): foo bar')!.scopes,
+        equals(['scope', 'dope']),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope)!: foo bar')!.scopes,
+        equals(['scope', 'dope']),
+      );
       // Should support spaces in comma delimited scope list.
-      expect(ConventionalCommit.parse('docs(scope, dope)!: foo bar').scopes,
-          equals(['scope', 'dope']));
+      expect(
+        ConventionalCommit.tryParse('docs(scope, dope)!: foo bar')!.scopes,
+        equals(['scope', 'dope']),
+      );
     });
 
     test('type', () {
-      expect(ConventionalCommit.parse('build: foo bar').type, equals('build'));
-      expect(ConventionalCommit.parse('chore: foo bar').type, equals('chore'));
-      expect(ConventionalCommit.parse('ci: foo bar').type, equals('ci'));
-      expect(ConventionalCommit.parse('docs: foo bar').type, equals('docs'));
-      expect(ConventionalCommit.parse('feat!: foo bar').type, equals('feat'));
-      expect(ConventionalCommit.parse('bug!: foo bar').type, equals('bug'));
-      expect(ConventionalCommit.parse('perf(scope): foo bar').type,
-          equals('perf'));
-      expect(ConventionalCommit.parse('refactor(scope): foo bar').type,
-          equals('refactor'));
-      expect(ConventionalCommit.parse('revert(scope,dope): foo bar').type,
-          equals('revert'));
-      expect(ConventionalCommit.parse('style(scope,dope): foo bar').type,
-          equals('style'));
-      expect(ConventionalCommit.parse('test(scope)!: foo bar').type,
-          equals('test'));
+      expect(
+        ConventionalCommit.tryParse('build: foo bar')!.type,
+        equals('build'),
+      );
+      expect(
+        ConventionalCommit.tryParse('chore: foo bar')!.type,
+        equals('chore'),
+      );
+      expect(
+        ConventionalCommit.tryParse('ci: foo bar')!.type,
+        equals('ci'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs: foo bar')!.type,
+        equals('docs'),
+      );
+      expect(
+        ConventionalCommit.tryParse('feat!: foo bar')!.type,
+        equals('feat'),
+      );
+      expect(
+        ConventionalCommit.tryParse('bug!: foo bar')!.type,
+        equals('bug'),
+      );
+      expect(
+        ConventionalCommit.tryParse('perf(scope): foo bar')!.type,
+        equals('perf'),
+      );
+      expect(
+        ConventionalCommit.tryParse('refactor(scope): foo bar')!.type,
+        equals('refactor'),
+      );
+      expect(
+        ConventionalCommit.tryParse('revert(scope,dope): foo bar')!.type,
+        equals('revert'),
+      );
+      expect(
+        ConventionalCommit.tryParse('style(scope,dope): foo bar')!.type,
+        equals('style'),
+      );
+      expect(
+        ConventionalCommit.tryParse('test(scope)!: foo bar')!.type,
+        equals('test'),
+      );
     });
 
     test('isBreakingChange', () {
       expect(
-          ConventionalCommit.parse('docs: foo bar').isBreakingChange, isFalse);
+        ConventionalCommit.tryParse('docs: foo bar')!.isBreakingChange,
+        isFalse,
+      );
       expect(
-          ConventionalCommit.parse('docs!: foo bar').isBreakingChange, isTrue);
-      expect(ConventionalCommit.parse('docs(scope): foo bar').isBreakingChange,
-          isFalse);
+        ConventionalCommit.tryParse('docs!: foo bar')!.isBreakingChange,
+        isTrue,
+      );
       expect(
-          ConventionalCommit.parse('docs(scope,dope): foo bar')
-              .isBreakingChange,
-          isFalse);
+        ConventionalCommit.tryParse('docs(scope): foo bar')!.isBreakingChange,
+        isFalse,
+      );
       expect(
-          ConventionalCommit.parse('docs(scope,dope)!: foo bar')
-              .isBreakingChange,
-          isTrue);
+        ConventionalCommit.tryParse('docs(scope,dope): foo bar')!
+            .isBreakingChange,
+        isFalse,
+      );
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING: I broke something.')
-              .isBreakingChange,
-          isTrue);
+        ConventionalCommit.tryParse('docs(scope,dope)!: foo bar')!
+            .isBreakingChange,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse(
+          'docs(scope): foo bar \n\nBREAKING: I broke something.',
+        )!
+            .isBreakingChange,
+        isTrue,
+      );
       // Confirm exact matching of `BREAKING: ` (with space after colon).
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING:I broke something.')
-              .isBreakingChange,
-          isFalse);
+        ConventionalCommit.tryParse(
+                'docs(scope): foo bar \n\nBREAKING:I broke something.')!
+            .isBreakingChange,
+        isFalse,
+      );
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING CHANGE: I broke something.')
-              .isBreakingChange,
-          isTrue);
+        ConventionalCommit.tryParse(
+          'docs(scope): foo bar \n\nBREAKING CHANGE: I broke something.',
+        )!
+            .isBreakingChange,
+        isTrue,
+      );
       // Confirm exact matching of `BREAKING CHANGE: ` (with space after colon).
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING CHANGE:I broke something.')
-              .isBreakingChange,
-          isFalse);
+        ConventionalCommit.tryParse(
+          'docs(scope): foo bar \n\nBREAKING CHANGE:I broke something.',
+        )!
+            .isBreakingChange,
+        isFalse,
+      );
     });
 
     test('breakingChangeDescription', () {
       // Should be null if isBreakingChange is false.
       expect(
-          ConventionalCommit.parse('docs: foo bar').breakingChangeDescription,
-          isNull);
-      expect(
-          ConventionalCommit.parse('docs(scope): foo bar')
+          ConventionalCommit.tryParse('docs: foo bar')!
               .breakingChangeDescription,
           isNull);
       expect(
-          ConventionalCommit.parse('docs(scope,dope): foo bar')
+          ConventionalCommit.tryParse('docs(scope): foo bar')!
+              .breakingChangeDescription,
+          isNull);
+      expect(
+          ConventionalCommit.tryParse('docs(scope,dope): foo bar')!
               .breakingChangeDescription,
           isNull);
 
@@ -165,140 +231,188 @@ void main() {
       // description is not used.
       //  - without scopes
       expect(
-          ConventionalCommit.parse('docs!: foo bar').breakingChangeDescription,
-          equals('foo bar'));
+        ConventionalCommit.tryParse('docs!: foo bar')!
+            .breakingChangeDescription,
+        equals('foo bar'),
+      );
       // - with scopes
       expect(
-          ConventionalCommit.parse('docs(scope,dope)!: foo bar')
-              .breakingChangeDescription,
-          equals('foo bar'));
+        ConventionalCommit.tryParse('docs(scope,dope)!: foo bar')!
+            .breakingChangeDescription,
+        equals('foo bar'),
+      );
 
       // Should be equal to the BREAKING footer message if specified.
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING: I broke something.')
-              .breakingChangeDescription,
-          equals('I broke something.'));
+        ConventionalCommit.tryParse(
+                'docs(scope): foo bar \n\nBREAKING: I broke something.')!
+            .breakingChangeDescription,
+        equals('I broke something.'),
+      );
 
       // Should be equal to the BREAKING CHANGE footer message if specified.
       expect(
-          ConventionalCommit.parse(
-                  'docs(scope): foo bar \n\nBREAKING CHANGE: I broke something again.')
-              .breakingChangeDescription,
-          equals('I broke something again.'));
+        ConventionalCommit.tryParse(
+          'docs(scope): foo bar \n\nBREAKING CHANGE: I broke something again.',
+        )!
+            .breakingChangeDescription,
+        equals('I broke something again.'),
+      );
     });
 
     test('isMergeCommit', () {
-      expect(ConventionalCommit.parse('docs: Merge foo bar').isMergeCommit,
-          isFalse);
       expect(
-          ConventionalCommit.parse("Merge branch 'master' of invertase/melos")
-              .isMergeCommit,
-          isTrue);
-      expect(ConventionalCommit.parse('docs!: foo bar').isMergeCommit, isFalse);
+        ConventionalCommit.tryParse('docs: Merge foo bar')!.isMergeCommit,
+        isFalse,
+      );
       expect(
-          ConventionalCommit.parse('docs(scope): Merge foo bar').isMergeCommit,
-          isFalse);
+        ConventionalCommit.tryParse("Merge branch 'master' of invertase/melos")!
+            .isMergeCommit,
+        isTrue,
+      );
       expect(
-          ConventionalCommit.parse('docs(scope,dope)!: Merge foo bar')
-              .isMergeCommit,
-          isFalse);
+        ConventionalCommit.tryParse('docs!: foo bar')!.isMergeCommit,
+        isFalse,
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope): Merge foo bar')!
+            .isMergeCommit,
+        isFalse,
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope)!: Merge foo bar')!
+            .isMergeCommit,
+        isFalse,
+      );
     });
 
     test('description', () {
-      expect(ConventionalCommit.parse('docs: foo bar').description,
-          equals('foo bar'));
-      expect(ConventionalCommit.parse('docs!: foo bar').description,
-          equals('foo bar'));
-      expect(ConventionalCommit.parse('docs(scope): foo bar').description,
-          equals('foo bar'));
-      expect(ConventionalCommit.parse('docs(scope,dope)!: foo bar').description,
-          equals('foo bar'));
+      expect(
+        ConventionalCommit.tryParse('docs: foo bar')!.description,
+        equals('foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs!: foo bar')!.description,
+        equals('foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope): foo bar')!.description,
+        equals('foo bar'),
+      );
+      expect(
+        ConventionalCommit.tryParse('docs(scope,dope)!: foo bar')!.description,
+        equals('foo bar'),
+      );
     });
 
     test('isVersionableCommit', () {
-      expect(ConventionalCommit.parse('chore!: foo bar').isVersionableCommit,
-          isTrue);
-      expect(ConventionalCommit.parse('docs: foo bar').isVersionableCommit,
-          isTrue);
       expect(
-          ConventionalCommit.parse('refactor(scope): foo bar')
-              .isVersionableCommit,
-          isTrue);
+        ConventionalCommit.tryParse('chore!: foo bar')!.isVersionableCommit,
+        isTrue,
+      );
       expect(
-          ConventionalCommit.parse('revert(scope,dope)!: foo bar')
-              .isVersionableCommit,
-          isTrue);
+        ConventionalCommit.tryParse('docs: foo bar')!.isVersionableCommit,
+        isTrue,
+      );
       expect(
-          ConventionalCommit.parse('ci(scope,dope): foo bar')
-              .isVersionableCommit,
-          isFalse);
+        ConventionalCommit.tryParse('refactor(scope): foo bar')!
+            .isVersionableCommit,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse('revert(scope,dope)!: foo bar')!
+            .isVersionableCommit,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse('ci(scope,dope): foo bar')!
+            .isVersionableCommit,
+        isFalse,
+      );
     });
 
     test('semverReleaseType', () {
-      expect(ConventionalCommit.parse('chore!: foo bar').semverReleaseType,
-          equals(SemverReleaseType.major));
-      expect(ConventionalCommit.parse('docs: foo bar').semverReleaseType,
-          equals(SemverReleaseType.patch));
       expect(
-          ConventionalCommit.parse('refactor(scope): foo bar')
-              .semverReleaseType,
-          equals(SemverReleaseType.patch));
+        ConventionalCommit.tryParse('chore!: foo bar')!.semverReleaseType,
+        equals(SemverReleaseType.major),
+      );
       expect(
-          ConventionalCommit.parse('feat(scope,dope): foo bar')
-              .semverReleaseType,
-          equals(SemverReleaseType.minor));
+        ConventionalCommit.tryParse('docs: foo bar')!.semverReleaseType,
+        equals(SemverReleaseType.patch),
+      );
+      expect(
+        ConventionalCommit.tryParse('refactor(scope): foo bar')!
+            .semverReleaseType,
+        equals(SemverReleaseType.patch),
+      );
+      expect(
+        ConventionalCommit.tryParse('feat(scope,dope): foo bar')!
+            .semverReleaseType,
+        equals(SemverReleaseType.minor),
+      );
     });
 
     test('body', () {
       // With a multi-line/paragraph body.
-      expect(ConventionalCommit.parse(commitMessageWithBodyExample).body,
-          equals(bodyExample.trim()));
+      expect(
+        ConventionalCommit.tryParse(commitMessageWithBodyExample)!.body,
+        equals(bodyExample.trim()),
+      );
 
       // Without a body it should be null.
-      expect(ConventionalCommit.parse(commitMessageWithoutBodyExample).body,
-          isNull);
+      expect(
+        ConventionalCommit.tryParse(commitMessageWithoutBodyExample)!.body,
+        isNull,
+      );
     });
 
     test('footers', () {
       // With a multi-line/paragraph body.
       final commitWithBodyParsed =
-          ConventionalCommit.parse(commitMessageWithBodyExample);
+          ConventionalCommit.tryParse(commitMessageWithBodyExample)!;
       // Body should not leak into footers.
-      expect(commitWithBodyParsed.footers.length, equals(3));
+      expect(
+        commitWithBodyParsed.footers.length,
+        equals(3),
+      );
       // Footers should exclude the breaking change footer.
       expect(
-          commitWithBodyParsed.footers.firstWhere(
-            (element) => element.contains('BREAKING'),
-            orElse: () => null,
-          ),
-          isNull);
+        commitWithBodyParsed.footers.firstWhereOrNull(
+          (element) => element.contains('BREAKING'),
+        ),
+        isNull,
+      );
       expect(
-          commitWithBodyParsed.footers,
-          equals([
-            'Reviewed-by: @fooBarUser',
-            'Co-authored-by: @Salakar',
-            'Refs #123 #1234',
-          ]));
+        commitWithBodyParsed.footers,
+        equals([
+          'Reviewed-by: @fooBarUser',
+          'Co-authored-by: @Salakar',
+          'Refs #123 #1234',
+        ]),
+      );
 
       // Footers should still parse without a body.
       final commitWithoutBodyParsed =
-          ConventionalCommit.parse(commitMessageWithoutBodyExample);
+          ConventionalCommit.tryParse(commitMessageWithoutBodyExample)!;
       // Header should not leak into footers.
       expect(
-          commitWithoutBodyParsed.footers.firstWhere(
-            (element) => element.contains('refactor: did something'),
-            orElse: () => null,
-          ),
-          isNull);
-      expect(commitWithoutBodyParsed.footers.length, equals(3));
+        commitWithoutBodyParsed.footers.firstWhereOrNull(
+          (element) => element.contains('refactor: did something'),
+        ),
+        isNull,
+      );
       expect(
-          commitWithoutBodyParsed.footers,
-          equals([
-            'Reviewed-by: @fooBarUser',
-            'Co-authored-by: @Salakar',
-            'Refs #123 #1234',
-          ]));
+        commitWithoutBodyParsed.footers.length,
+        equals(3),
+      );
+      expect(
+        commitWithoutBodyParsed.footers,
+        equals([
+          'Reviewed-by: @fooBarUser',
+          'Co-authored-by: @Salakar',
+          'Refs #123 #1234',
+        ]),
+      );
     });
   });
 }

--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -338,7 +338,7 @@ class VersionCommand extends MelosCommand {
         since: globalResults['since'] as String,
       ).then((commits) {
         packageCommits[package.name] = commits
-            .map((commit) => ConventionalCommit.parse(commit.message))
+            .map((commit) => ConventionalCommit.tryParse(commit.message))
             .where((element) => element != null)
             .toList();
       });


### PR DESCRIPTION
This also renamed `ConventionalCommit.parse` into `ConventionalCommit.tryParse` to match other Dart classes that return "null" when the parsing fails:

```
int? value = int.tryParse('')
```