### PR TITLE
fix: exec hang, exec trailing options

### DIFF
--- a/packages/melos/lib/src/command/base.dart
+++ b/packages/melos/lib/src/command/base.dart
@@ -13,7 +13,13 @@ abstract class MelosCommand extends Command<void> {
   MelosCommandConfig get commandConfig =>
       currentWorkspace!.config.commands.configForCommandNamed(name);
 
+  /// see [ArgParser.allowTrailingOptions]
+  bool get allowTrailingOptions => true;
+
   /// Overridden to support line wrapping when printing usage.
   @override
-  late final ArgParser argParser = ArgParser(usageLineLength: terminalWidth);
+  late final ArgParser argParser = ArgParser(
+    usageLineLength: terminalWidth,
+    allowTrailingOptions: allowTrailingOptions,
+  );
 }

--- a/packages/melos/lib/src/command/exec.dart
+++ b/packages/melos/lib/src/command/exec.dart
@@ -36,6 +36,9 @@ class ExecCommand extends MelosCommand {
   }
 
   @override
+  bool get allowTrailingOptions => false;
+
+  @override
   final String name = 'exec';
 
   @override

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -215,7 +215,9 @@ Future<int> startProcess(
 
   final execProcess = await Process.start(
     executable,
-    currentPlatform.isWindows ? ['/C', '%MELOS_SCRIPT%'] : [],
+    currentPlatform.isWindows
+        ? ['/C', '%MELOS_SCRIPT%']
+        : ['-c', filteredArgs.join(' ')],
     workingDirectory: workingDirectoryPath,
     environment: {
       ...environment,
@@ -224,13 +226,6 @@ Future<int> startProcess(
     },
     runInShell: true,
   );
-
-  if (!currentPlatform.isWindows) {
-    // Pipe in the arguments to trigger the script to run.
-    execProcess.stdin.writeln(filteredArgs.join(' '));
-    // Exit the process with the same exit code as the previous command.
-    execProcess.stdin.writeln(r'exit $?');
-  }
 
   var stdoutStream = execProcess.stdout;
   var stderrStream = execProcess.stderr;

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -213,15 +213,16 @@ Future<int> startProcess(
     return _arg;
   }).where((element) => element != null);
 
-  final scriptSource = filteredArgs.join(' ');
   final execProcess = await Process.start(
     executable,
-    currentPlatform.isWindows ? ['/C', '%MELOS_SCRIPT%'] : ['-c', scriptSource],
+    currentPlatform.isWindows
+        ? ['/C', '%MELOS_SCRIPT%']
+        : ['-c', r'eval "$MELOS_SCRIPT"'],
     workingDirectory: workingDirectoryPath,
     environment: {
       ...environment,
       envKeyMelosTerminalWidth: terminalWidth.toString(),
-      'MELOS_SCRIPT': scriptSource,
+      'MELOS_SCRIPT': filteredArgs.join(' '),
     },
     runInShell: true,
   );

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -216,9 +216,7 @@ Future<int> startProcess(
   final scriptSource = filteredArgs.join(' ');
   final execProcess = await Process.start(
     executable,
-    currentPlatform.isWindows
-        ? ['/C', '%MELOS_SCRIPT%']
-        : ['-c', scriptSource],
+    currentPlatform.isWindows ? ['/C', '%MELOS_SCRIPT%'] : ['-c', scriptSource],
     workingDirectory: workingDirectoryPath,
     environment: {
       ...environment,

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -213,16 +213,17 @@ Future<int> startProcess(
     return _arg;
   }).where((element) => element != null);
 
+  final scriptSource = filteredArgs.join(' ');
   final execProcess = await Process.start(
     executable,
     currentPlatform.isWindows
         ? ['/C', '%MELOS_SCRIPT%']
-        : ['-c', filteredArgs.join(' ')],
+        : ['-c', scriptSource],
     workingDirectory: workingDirectoryPath,
     environment: {
       ...environment,
       envKeyMelosTerminalWidth: terminalWidth.toString(),
-      'MELOS_SCRIPT': filteredArgs.join(' '),
+      'MELOS_SCRIPT': scriptSource,
     },
     runInShell: true,
   );


### PR DESCRIPTION
closes #15
closes #16
inspired by #16

- pass script source directly to shell using `-c` option
- ignore trailing options in exec command (exec tried to parse all available options including those passed to the child script)
  same approach is used in `pub run` https://github.com/dart-lang/pub/blob/291705ca0b9632cb945dd39493dd5b9db41b897a/lib/src/command/run.dart#L27