### PR TITLE
fix: enable Dart SDK for root IntelliJ project

### DIFF
--- a/packages/melos/templates/intellij/modules/workspace_root_module.iml.tmpl
+++ b/packages/melos/templates/intellij/modules/workspace_root_module.iml.tmpl
@@ -6,5 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>


### PR DESCRIPTION
When you run `melos bootstrap` command it doesn't enable Dart SDK for the root module. This fixes the issue.

Fixes #124 