### PR TITLE
fix: commit scope should support asterisk characters

### DIFF
--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -16,7 +16,7 @@
  */
 
 final _conventionalCommitRegex = RegExp(
-    r'^(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s]+\)?((?=:\s)|(?=!:\s)))?(?<breaking>!)?(?<description>:\s.*)?|^(?<merge>Merge \w+)');
+    r'^(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s)|(?=!:\s)))?(?<breaking>!)?(?<description>:\s.*)?|^(?<merge>Merge \w+)');
 
 final _breakingChangeRegex =
     RegExp(r'^BREAKING(\sCHANGE)?:\s(?<description>.*$)', multiLine: true);

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -49,6 +49,12 @@ Co-authored-by: @Salakar
 Refs #123 #1234
 ''';
 
+const commitMessageStarScope = '''
+feat(*): a new something (#1234)
+
+This also fixes an issue something else.
+''';
+
 void main() {
   group('$ConventionalCommit', () {
     test('invalid commit messages', () {
@@ -58,6 +64,17 @@ void main() {
       expect(ConventionalCommit.tryParse(' (): new feature'), isNull);
       expect(ConventionalCommit.tryParse('feat()'), isNull);
       expect(ConventionalCommit.tryParse('custom: new feature'), isNull);
+    });
+
+    test('correctly handles messages with a `*` scope', () {
+      final commit = ConventionalCommit.tryParse(commitMessageStarScope);
+      expect(commit, isNotNull);
+      expect(commit!.description, equals('a new something (#1234)'));
+      expect(commit.body, equals('This also fixes an issue something else.'));
+      expect(commit.type, equals('feat'));
+      expect(commit.scopes, equals(['*']));
+      expect(commit.isVersionableCommit, isTrue);
+      expect(commit.semverReleaseType, SemverReleaseType.minor);
     });
 
     test('header', () {


### PR DESCRIPTION
Fixes a bug as discovered on the following commit from FlutterFire;

```
feat(*): Upgrade Firebase Android BoM version to 28.1.0 (#6338)

This fixes an issue with Cloud Firestore when retrieving data after the app has resumed from the background.
```