### PR TITLE
fix: issue where dependent packages were not versioned

### DIFF
--- a/packages/melos/lib/src/command/version.dart
+++ b/packages/melos/lib/src/command/version.dart
@@ -384,7 +384,7 @@ class VersionCommand extends MelosCommand {
         (packageToVersion) => packageToVersion.package.name == package.name,
       );
 
-      if (!packagesToVersion.contains(package) && packageHasPendingUpdate) {
+      if (!packagesToVersion.contains(package) && !packageHasPendingUpdate) {
         pendingPackageUpdates.add(MelosPendingPackageUpdate(
           package,
           [],


### PR DESCRIPTION
Issue due to an if statement being inverted incorrectly in a previous refactor.