### PR TITLE
docs: Add ema987/paddinger as project using melos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ The following projects are using Melos:
 - [aws-amplify/amplify-flutter](https://github.com/aws-amplify/amplify-flutter)
 - [fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)
 - [GetStream/stream-chat-flutter](https://github.com/GetStream/stream-chat-flutter)
+- [ema987/paddinger](https://github.com/ema987/paddinger)
 
 > [Submit a PR](https://github.com/invertase/melos/edit/master/docs/index.md) to add your project to the list.
 


### PR DESCRIPTION
I hope you are glad having [paddinger](https://github.com/ema987/paddinger) in the list of projects using Melos!