### PR TITLE
feat: Match unknown commands with scripts

### DIFF
--- a/packages/melos/lib/src/command/run.dart
+++ b/packages/melos/lib/src/command/run.dart
@@ -36,27 +36,16 @@ class RunCommand extends MelosCommand {
   }
 
   @override
-  final String name = 'run';
+  String get name => 'run';
 
   @override
-  final String description =
+  String get description =>
       'Run a script by name defined in the workspace melos.yaml config file.';
 
   @override
-  final String invocation = 'melos run <name>';
+  String get invocation => 'melos run <name>';
 
-  @override
-  Future<void> run() async {
-    if (currentWorkspace.config.scripts.names.isEmpty) {
-      logger.stderr(
-        AnsiStyles.yellow(
-            "Warning: This workspace has no scripts defined in it's 'melos.yaml' file.\n"),
-      );
-      logger.stdout(usage);
-      exitCode = 1;
-      return;
-    }
-
+  String getScriptName() {
     String scriptName;
 
     if (argResults.rest.isEmpty) {
@@ -83,14 +72,32 @@ class RunCommand extends MelosCommand {
 
         logger.stdout('');
       } else {
-        logger.stderr('You have no scripts defined in your melos.yaml file.\n');
-        logger.stdout(usage);
-        exitCode = 1;
-        return;
+        return null;
       }
     }
 
-    scriptName ??= argResults.rest[0];
+    return scriptName ?? argResults.rest[0];
+  }
+
+  @override
+  Future<void> run() async {
+    if (currentWorkspace.config.scripts.names.isEmpty) {
+      logger.stderr(
+        AnsiStyles.yellow(
+            "Warning: This workspace has no scripts defined in it's 'melos.yaml' file.\n"),
+      );
+      logger.stdout(usage);
+      exitCode = 1;
+      return;
+    }
+
+    final scriptName = getScriptName();
+    if (scriptName == null) {
+      logger.stderr('You have no scripts defined in your melos.yaml file.\n');
+      logger.stdout(usage);
+      exitCode = 1;
+      return;
+    }
 
     if (!currentWorkspace.config.scripts.exists(scriptName)) {
       logger.stderr('Invalid run script name specified.\n');

--- a/packages/melos/lib/src/command/script.dart
+++ b/packages/melos/lib/src/command/script.dart
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'run.dart';
+
+class ScriptCommand extends RunCommand {
+  ScriptCommand(this.name);
+
+  @override
+  final String name;
+
+  @override
+  String get description =>
+      'Run the "$name" script defined in the workspace melos.yaml config file.';
+
+  @override
+  String get invocation => 'melos <script>';
+
+  @override
+  bool get hidden => true;
+
+  @override
+  String getScriptName() => name;
+}


### PR DESCRIPTION
Allow running `melos <script>` as a shortcut for `melos run <script>`, provided that the script name doesn't conflict with built-in commands.

```yaml
name: test_workspace
packages: [packages/**]
scripts:
  test: echo "running test script..."
  clean: echo "running clean script..."
```

In the above workspace, `melos test` is equivalent to `melos run test`:
```
$ melos test
melos run test
   └> echo "running test script..."
       └> RUNNING

running test script...

melos run test
   └> echo "running test script..."
       └> SUCCESS
```

However, `melos clean` is a built-in command:
```
$ melos clean
Cleaning workspace...

Workspace cleaned. You will need to run the bootstrap command again to use this workspace.
```

Close: #163