### PR TITLE
docs: Fix wikipedia redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Splitting up large code bases into separate independently versioned packages is extremely useful for code sharing. However, making changes across many repositories is messy and difficult to track, and testing across repositories gets complicated really fast.
 
-To solve these (and many other) problems, some projects will organize their code bases into multi-package repositories (sometimes called [monorepos](https://en.wikipedia.org/wiki/Monorepohttps://en.wikipedia.org/wiki/Monorepo)).
+To solve these (and many other) problems, some projects will organize their code bases into multi-package repositories (sometimes called [monorepos](https://en.wikipedia.org/wiki/Monorepo)).
 
 **Melos is a tool that optimizes the workflow around managing multi-package repositories with git and Pub.**
 


### PR DESCRIPTION
The Wikipedia URL was pasted twice. Therefore, it would redirect to the incorrect URL and people could not learn more about Monorepo easily. This URL hopefully fixes that! 