### PR TITLE
feat: Match unknown commands with scripts

### DIFF
--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -24,6 +24,7 @@ import 'command_runner/exec.dart';
 import 'command_runner/list.dart';
 import 'command_runner/publish.dart';
 import 'command_runner/run.dart';
+import 'command_runner/script.dart';
 import 'command_runner/version.dart';
 import 'common/utils.dart';
 import 'workspace_configs.dart';
@@ -63,6 +64,12 @@ class MelosCommandRunner extends CommandRunner<void> {
     addCommand(ListCommand(config));
     addCommand(PublishCommand(config));
     addCommand(VersionCommand(config));
+
+    // Keep this last to exclude all built-in commands listed above
+    final script = ScriptCommand.fromConfig(config, exclude: commands.keys);
+    if (script != null) {
+      addCommand(script);
+    }
   }
 
   @override

--- a/packages/melos/lib/src/command_runner/script.dart
+++ b/packages/melos/lib/src/command_runner/script.dart
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'package:ansi_styles/ansi_styles.dart';
+
+import '../commands/runner.dart';
+import '../workspace_configs.dart';
+import 'base.dart';
+
+class ScriptCommand extends MelosCommand {
+  ScriptCommand._(
+    MelosWorkspaceConfig config, {
+    required this.scripts,
+  })  : assert(scripts.isNotEmpty),
+        super(config) {
+    argParser.addFlag(
+      'no-select',
+      negatable: false,
+      help:
+          'Skips the prompt to select a package (if defined in the script configuration). Filters defined in the scripts "select-package" options will however still be applied.',
+    );
+  }
+
+  static ScriptCommand? fromConfig(
+    MelosWorkspaceConfig config, {
+    Iterable<String> exclude = const <String>[],
+  }) {
+    final scripts = config.scripts.keys.toSet();
+    scripts.removeAll(exclude);
+    if (scripts.isEmpty) {
+      return null;
+    }
+    return ScriptCommand._(config, scripts: scripts);
+  }
+
+  final Set<String> scripts;
+
+  @override
+  String get name => scripts.first;
+
+  @override
+  List<String> get aliases => scripts.skip(1).toList();
+
+  @override
+  String get description =>
+      'Run scripts by name defined in the workspace melos.yaml config file.';
+
+  @override
+  final String invocation = 'melos <script>';
+
+  @override
+  bool get hidden => true;
+
+  @override
+  Future<void> run() async {
+    final melos = Melos(logger: logger, config: config);
+
+    final scriptName = argResults!.name;
+    final noSelect = argResults!['no-select'] as bool;
+
+    try {
+      return await melos.run(
+        scriptName: scriptName,
+        noSelect: noSelect,
+      );
+    } on NoPackageFoundScriptException catch (err) {
+      logger.stderr(AnsiStyles.yellow(err.toString()));
+      logger.stdout(usage);
+    }
+  }
+}

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -1,0 +1,62 @@
+import 'package:melos/melos.dart';
+import 'package:melos/src/command_runner.dart';
+import 'package:melos/src/common/glob.dart';
+import 'package:melos/src/scripts.dart';
+import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+void main() {
+  group('CommandRunner', () {
+    test('adds hidden script commands', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: Scripts({
+            'test_script1': Script(name: 'test_script1', run: ''),
+            'test_script2': Script(name: 'test_script2', run: ''),
+          }),
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final runner = MelosCommandRunner(config);
+
+      expect(
+        runner.commands.keys,
+        containsAll(<String>['test_script1', 'test_script2']),
+      );
+
+      final command = runner.commands['test_script1'];
+      expect(command, isNotNull);
+      expect(command!.hidden, isTrue);
+    });
+
+    test('excludes conflicting script commands', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: Scripts({
+            'run': Script(name: 'run', run: ''),
+          }),
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final runner = MelosCommandRunner(config);
+
+      final command = runner.commands['run'];
+      expect(command, isNotNull);
+      expect(command!.hidden, isFalse);
+    });
+  });
+}

--- a/packages/melos/test/commands/script_test.dart
+++ b/packages/melos/test/commands/script_test.dart
@@ -1,0 +1,78 @@
+import 'package:melos/src/command_runner/script.dart';
+import 'package:melos/src/common/glob.dart';
+import 'package:melos/src/scripts.dart';
+import 'package:melos/src/workspace_configs.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  group('Script', () {
+    test('fromConfig creates aliases for all scripts', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: Scripts({
+            'test_script1': Script(name: 'test_script1', run: ''),
+            'test_script2': Script(name: 'test_script2', run: ''),
+            'test_script3': Script(name: 'test_script3', run: ''),
+          }),
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final command = ScriptCommand.fromConfig(config);
+      expect(command, isNotNull);
+      expect(
+        [command!.name, ...command.aliases],
+        containsAll(<String>['test_script1', 'test_script2', 'test_script3']),
+      );
+    });
+
+    test('fromConfig excludes given commands', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: Scripts({
+            'run': Script(name: 'run', run: ''),
+            'test_script1': Script(name: 'test_script1', run: ''),
+            'test_script2': Script(name: 'test_script2', run: ''),
+            'test_script3': Script(name: 'test_script3', run: ''),
+          }),
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final command = ScriptCommand.fromConfig(config, exclude: ['run']);
+      expect(command, isNotNull);
+      expect([command!.name, ...command.aliases], isNot(contains('run')));
+    });
+
+    test('fromConfig does not create an empty command', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: Scripts({
+            'clean': Script(name: 'clean', run: ''),
+          }),
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final command = ScriptCommand.fromConfig(config, exclude: ['clean']);
+      expect(command, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Allow running `melos <script>` as a shortcut for `melos run <script>`, provided that the script name doesn't conflict with built-in commands.

```yaml
name: test_workspace
packages: [packages/**]
scripts:
  test: echo "running test script..."
  clean: echo "running clean script..."
```

In the above workspace, `melos test` is equivalent to `melos run test`:
```
$ melos test
melos run test
   └> echo "running test script..."
       └> RUNNING

running test script...

melos run test
   └> echo "running test script..."
       └> SUCCESS
```

However, `melos clean` is a built-in command:
```
$ melos clean
Cleaning workspace...

Workspace cleaned. You will need to run the bootstrap command again to use this workspace.
```

Close: #163