### PR TITLE
refactor: Instantiate workspace from configs

### DIFF
--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -74,8 +74,8 @@ mixin _RunMixin on _Melos {
     };
 
     if (script.filter != null) {
-      final workspace = await MelosWorkspace.fromDirectory(
-        Directory(config.path),
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
         filter: script.filter,
         logger: logger,
       );

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -85,8 +85,9 @@ abstract class _Melos {
       );
     }
 
-    return MelosWorkspace.fromDirectory(
-      workingDirectory,
+    final config = await MelosWorkspaceConfig.fromDirectory(workingDirectory);
+    return MelosWorkspace.fromConfig(
+      config,
       filter: filterWithEnv,
       logger: logger,
     );

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -48,15 +48,12 @@ class MelosWorkspace {
     required this.logger,
   });
 
-  /// Build a [MelosWorkspace] from a Directory.
-  /// If the directory is not a valid Melos workspace (e.g. no "melos.yaml" file)
-  /// then null is returned.
-  static Future<MelosWorkspace> fromDirectory(
-    Directory directory, {
+  /// Build a [MelosWorkspace] from a workspace configuration.
+  static Future<MelosWorkspace> fromConfig(
+    MelosWorkspaceConfig workspaceConfig, {
     PackageFilter? filter,
     required Logger logger,
   }) async {
-    final workspaceConfig = await MelosWorkspaceConfig.fromDirectory(directory);
     final allPackages = await PackageMap.resolvePackages(
       workspacePath: workspaceConfig.path,
       packages: workspaceConfig.packages,

--- a/packages/melos/test/package_filter_test.dart
+++ b/packages/melos/test/package_filter_test.dart
@@ -23,8 +23,9 @@ void main() {
         const PubSpec(name: 'b'),
       );
 
-      final workspace = await MelosWorkspace.fromDirectory(
-        workspaceDir,
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
         logger: TestLogger(),
         filter: PackageFilter(
           dirExists: ['test'],
@@ -58,8 +59,9 @@ void main() {
         const PubSpec(name: 'b'),
       );
 
-      final workspace = await MelosWorkspace.fromDirectory(
-        workspaceDir,
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
         logger: TestLogger(),
         filter: PackageFilter(
           fileExists: ['log.txt'],

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:glob/glob.dart';
 import 'package:melos/src/package.dart';
 import 'package:melos/src/workspace.dart';
+import 'package:melos/src/workspace_configs.dart';
 import 'package:nock/nock.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
@@ -29,10 +30,13 @@ void main() {
       nock.cleanAll();
       IOOverrides.global = MockFs();
 
-      workspace = await MelosWorkspace.fromDirectory(
+      final config = await MelosWorkspaceConfig.fromDirectory(
         createMockWorkspaceFs(
           packages: [MockPackageFs(name: 'melos')],
         ),
+      );
+      workspace = await MelosWorkspace.fromConfig(
+        config,
         logger: TestLogger(),
       );
     });

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/package.dart';
 import 'package:melos/src/workspace.dart';
+import 'package:melos/src/workspace_configs.dart';
 import 'package:test/test.dart';
 
 import 'matchers.dart';
@@ -39,8 +40,9 @@ void main() {
         );
 
         final aDir = Directory('${mockWorkspaceRootDir.path}/packages/a');
-        final workspace = await MelosWorkspace.fromDirectory(
-          aDir,
+        final config = await MelosWorkspaceConfig.fromDirectory(aDir);
+        final workspace = await MelosWorkspace.fromConfig(
+          config,
           logger: TestLogger(),
         );
 
@@ -67,8 +69,11 @@ void main() {
           ],
         );
 
-        final workspace = await MelosWorkspace.fromDirectory(
+        final config = await MelosWorkspaceConfig.fromDirectory(
           mockWorkspaceRootDir,
+        );
+        final workspace = await MelosWorkspace.fromConfig(
+          config,
           logger: TestLogger(),
         );
 
@@ -90,8 +95,11 @@ void main() {
                 MockPackageFs(name: 'b'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('b', currentDirectoryPath: workspaceDir.path)
@@ -114,8 +122,11 @@ void main() {
                 MockPackageFs(name: 'b'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('a', currentDirectoryPath: workspaceDir.path),
@@ -145,8 +156,11 @@ void main() {
                 MockPackageFs(name: 'c'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('a', currentDirectoryPath: workspaceDir.path),
@@ -178,8 +192,11 @@ void main() {
                 MockPackageFs(name: 'd'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('a', currentDirectoryPath: workspaceDir.path),
@@ -208,8 +225,11 @@ void main() {
                 MockPackageFs(name: 'b'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('a', currentDirectoryPath: workspaceDir.path),
@@ -232,8 +252,11 @@ void main() {
                 MockPackageFs(name: 'b'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('b', currentDirectoryPath: workspaceDir.path),
@@ -261,8 +284,11 @@ void main() {
                 MockPackageFs(name: 'c'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('c', currentDirectoryPath: workspaceDir.path),
@@ -294,8 +320,11 @@ void main() {
                 MockPackageFs(name: 'd'),
               ],
             );
-            final workspace = await MelosWorkspace.fromDirectory(
+            final config = await MelosWorkspaceConfig.fromDirectory(
               workspaceDir,
+            );
+            final workspace = await MelosWorkspace.fromConfig(
+              config,
               filter: PackageFilter(
                 scope: [
                   createGlob('d', currentDirectoryPath: workspaceDir.path),


### PR DESCRIPTION
This prevents the workspace config from being parsed multiple times under certain scenarios. At the same time, it helps to implement a cleaner solution to match unknown commands with scripts (#163).