### PR TITLE
docs: Add documentation for environment variables

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -21,7 +21,7 @@
     [
       "Environment Variables",
       "/environment-variables"
-    ]
+    ],
     [
       "melos.yaml",
       "/melos-yaml"

--- a/docs.json
+++ b/docs.json
@@ -6,10 +6,29 @@
   "theme": "#FFA03F",
   "googleAnalytics": "G-Q7ME6WLFEJ",
   "sidebar": [
-    ["Overview", "/"],
-    ["Getting Started", "/getting-started"],
-    ["Commands", "/commands"],
-    ["melos.yaml", "/melos-yaml"],
-    ["Automated Releases", "/automated-releases"]
+    [
+      "Overview",
+      "/"
+    ],
+    [
+      "Getting Started",
+      "/getting-started"
+    ],
+    [
+      "Commands",
+      "/commands"
+    ],
+    [
+      "Environment Variables",
+      "/environment-variables"
+    ]
+    [
+      "melos.yaml",
+      "/melos-yaml"
+    ],
+    [
+      "Automated Releases",
+      "/automated-releases"
+    ]
   ]
 }

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -1,0 +1,50 @@
+---
+title: Environment Variables
+description: Learn more about all the environment variables Melos supports and also pre-populates.
+---
+
+# Environment Variables
+
+These variables are available as environment variables in scripts run by `melos exec`. They can also automatically replaced/injected on `melos exec` commands e.g. `melos exec --file-exists="./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart" --scope="*example*" -- echo hello`
+
+## Defined by Melos
+
+### `MELOS_ROOT_PATH`
+
+The path to the mono-repo root
+
+### `MELOS_PACKAGE_NAME`
+
+The name of the package that's currently executing a script (when using `melos exec`)
+
+### `MELOS_PACKAGE_VERSION`
+
+The version of the package that's currently executing a script (when using `melos exec`)
+
+### `MELOS_PACKAGE_PATH`
+
+The path of the package that's currently executing a script (when using `melos exec`).
+
+### `MELOS_PARENT_PACKAGE_NAME`
+
+The name of the parent package of the current package that's currently executing a script (when using `melos exec`).
+
+### `MELOS_PARENT_PACKAGE_VERSION`
+
+The version of the parent package of the current package that's currently executing a script (when using `melos exec`).
+
+### `MELOS_PARENT_PACKAGE_PATH`
+
+The path of the parent package of the current package that's currently executing a script (when using `melos exec`).
+
+#### What is a 'parent package'
+
+If a package exists in a directory that is also a child of another package, then its parent is the 'parent package'. For example; the package `firebase_auth` has an `example` directory that is also a package, when running a `melos exec` script in the `example` package then the parent package would be `firebase_auth`.
+
+Note, this 'parent package' functionality only currently works when the 'child package' name ends with `example`
+
+## User Defined
+
+### `MELOS_PACKAGES`
+
+Define a comma delimited list of package names that Melos should focus on. This bypasses all filtering flags if defined.

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -9,6 +9,24 @@ These variables are available as environment variables in scripts run by `melos 
 
 ## Defined by Melos
 
+All examples will follow this directory structure
+```
+monorepo
+│   README.md
+│   melos.yaml
+│
+└───package_1
+│   │   pubspec.yaml
+|   |   ...
+│   │
+│   └───package_1_example
+│       │   pubspec.yaml
+│       │   ...
+│   
+└───package_2
+    │   pubspec.yaml
+```
+
 ### `MELOS_ROOT_PATH`
 
 The path to the mono-repo root

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -9,24 +9,6 @@ These variables are available as environment variables in scripts run by `melos 
 
 ## Defined by Melos
 
-All examples will follow this directory structure
-```
-monorepo
-│   README.md
-│   melos.yaml
-│
-└───package_1
-│   │   pubspec.yaml
-|   |   ...
-│   │
-│   └───package_1_example
-│       │   pubspec.yaml
-│       │   ...
-│   
-└───package_2
-    │   pubspec.yaml
-```
-
 ### `MELOS_ROOT_PATH`
 
 The path to the mono-repo root


### PR DESCRIPTION
In getting started with `melos` at my organization, I had trouble finding the information on these, so thought getting them into the docs would be nice. Transcribes https://github.com/invertase/melos/issues/3 into the documentation format. Realize there is some WIP [here](https://github.com/invertase/melos/pull/126), however would love to have something in the documentation at least until the next iteration of the documentation is published.