### PR TITLE
refactor: Pass workspace config from the top

### DIFF
--- a/packages/melos/bin/melos.dart
+++ b/packages/melos/bin/melos.dart
@@ -2,10 +2,12 @@ import 'dart:io';
 
 import 'package:melos/src/command_runner.dart';
 import 'package:melos/src/common/exception.dart';
+import 'package:melos/src/workspace_configs.dart';
 
-void main(List<String> arguments) {
+Future<void> main(List<String> arguments) async {
   try {
-    MelosCommandRunner().run(arguments);
+    final config = await MelosWorkspaceConfig.fromDirectory(Directory.current);
+    await MelosCommandRunner(config).run(arguments);
   } on MelosException catch (err) {
     stderr.writeln(err.toString());
     exitCode = 1;

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -26,6 +26,7 @@ import 'command_runner/publish.dart';
 import 'command_runner/run.dart';
 import 'command_runner/version.dart';
 import 'common/utils.dart';
+import 'workspace_configs.dart';
 
 /// A class that can run Melos commands.
 ///
@@ -37,7 +38,7 @@ import 'common/utils.dart';
 /// await melos.run(['boostrap']);
 /// ```
 class MelosCommandRunner extends CommandRunner<void> {
-  MelosCommandRunner()
+  MelosCommandRunner(MelosWorkspaceConfig config)
       : super(
           'melos',
           'A CLI tool for managing Dart & Flutter projects with multiple packages.',
@@ -55,13 +56,13 @@ class MelosCommandRunner extends CommandRunner<void> {
       help: 'Print the current Melos version.',
     );
 
-    addCommand(ExecCommand());
-    addCommand(BootstrapCommand());
-    addCommand(CleanCommand());
-    addCommand(RunCommand());
-    addCommand(ListCommand());
-    addCommand(PublishCommand());
-    addCommand(VersionCommand());
+    addCommand(ExecCommand(config));
+    addCommand(BootstrapCommand(config));
+    addCommand(CleanCommand(config));
+    addCommand(RunCommand(config));
+    addCommand(ListCommand(config));
+    addCommand(PublishCommand(config));
+    addCommand(VersionCommand(config));
   }
 
   @override

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
@@ -7,8 +5,13 @@ import 'package:cli_util/cli_logging.dart';
 import '../common/glob.dart';
 import '../common/utils.dart';
 import '../package.dart';
+import '../workspace_configs.dart';
 
 abstract class MelosCommand extends Command<void> {
+  MelosCommand(this.config);
+
+  final MelosWorkspaceConfig config;
+
   Logger get logger =>
       globalResults!['verbose'] as bool ? Logger.verbose() : Logger.standard();
 
@@ -123,7 +126,7 @@ abstract class MelosCommand extends Command<void> {
   }
 
   PackageFilter parsePackageFilter(
-    Directory workspaceDirectory, {
+    String workingDirPath, {
     bool sinceEnabled = true,
   }) {
     assert(
@@ -131,8 +134,6 @@ abstract class MelosCommand extends Command<void> {
           argResults?.command?.name != 'run',
       'unimplemented',
     );
-
-    final workingDirPath = workspaceDirectory.path;
 
     final since =
         sinceEnabled ? argResults![filterOptionSince] as String? : null;

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -16,14 +16,14 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 
 import 'base.dart';
 
 class BootstrapCommand extends MelosCommand {
-  BootstrapCommand() {
+  BootstrapCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
   }
 
@@ -40,10 +40,10 @@ class BootstrapCommand extends MelosCommand {
 
   @override
   FutureOr<void>? run() {
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
     return melos.bootstrap(
-      filter: parsePackageFilter(Directory.current),
+      filter: parsePackageFilter(config.path),
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/clean.dart
+++ b/packages/melos/lib/src/command_runner/clean.dart
@@ -15,14 +15,13 @@
  *
  */
 
-import 'dart:io';
-
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 
 import 'base.dart';
 
 class CleanCommand extends MelosCommand {
-  CleanCommand() {
+  CleanCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
   }
 
@@ -36,10 +35,10 @@ class CleanCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
     await melos.clean(
-      filter: parsePackageFilter(Directory.current),
+      filter: parsePackageFilter(config.path),
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -18,10 +18,11 @@
 import 'dart:io';
 
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 import 'base.dart';
 
 class ExecCommand extends MelosCommand {
-  ExecCommand() {
+  ExecCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
     argParser.addOption('concurrency', defaultsTo: '5', abbr: 'c');
     argParser.addFlag(
@@ -52,9 +53,9 @@ class ExecCommand extends MelosCommand {
       exit(1);
     }
 
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
-    final packageFilter = parsePackageFilter(Directory.current);
+    final packageFilter = parsePackageFilter(config.path);
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final failFast = argResults!['fail-fast'] as bool;
 

--- a/packages/melos/lib/src/command_runner/list.dart
+++ b/packages/melos/lib/src/command_runner/list.dart
@@ -15,13 +15,12 @@
  *
  */
 
-import 'dart:io';
-
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 import 'base.dart';
 
 class ListCommand extends MelosCommand {
-  ListCommand() {
+  ListCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
     argParser.addFlag(
       'long',
@@ -80,7 +79,7 @@ class ListCommand extends MelosCommand {
     final graph = argResults!['graph'] as bool;
     final gviz = argResults!['gviz'] as bool;
 
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
     var kind = ListOutputKind.column;
 
@@ -92,7 +91,7 @@ class ListCommand extends MelosCommand {
     return melos.list(
       showPrivatePackages: all,
       long: long,
-      filter: parsePackageFilter(Directory.current),
+      filter: parsePackageFilter(config.path),
       kind: kind,
     );
   }

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -15,13 +15,12 @@
  *
  */
 
-import 'dart:io';
-
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 import 'base.dart';
 
 class PublishCommand extends MelosCommand {
-  PublishCommand() {
+  PublishCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
     argParser.addFlag(
       'dry-run',
@@ -58,8 +57,8 @@ class PublishCommand extends MelosCommand {
     final gitTagVersion = argResults!['git-tag-version'] as bool;
     final yes = argResults!['yes'] as bool || false;
 
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
-    final filter = parsePackageFilter(Directory.current);
+    final melos = Melos(logger: logger, config: config);
+    final filter = parsePackageFilter(config.path);
 
     return melos.publish(
       filter: filter,

--- a/packages/melos/lib/src/command_runner/run.dart
+++ b/packages/melos/lib/src/command_runner/run.dart
@@ -15,15 +15,14 @@
  *
  */
 
-import 'dart:io';
-
 import 'package:ansi_styles/ansi_styles.dart';
 
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 import 'base.dart';
 
 class RunCommand extends MelosCommand {
-  RunCommand() {
+  RunCommand(MelosWorkspaceConfig config) : super(config) {
     argParser.addFlag(
       'no-select',
       negatable: false,
@@ -44,7 +43,7 @@ class RunCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
     final noSelect = argResults!['no-select'] as bool;
     final scriptName = argResults!.rest.isEmpty ? null : argResults!.rest.first;

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -21,6 +21,7 @@ import 'package:ansi_styles/ansi_styles.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../commands/runner.dart';
+import '../workspace_configs.dart';
 import 'base.dart';
 
 /// Template variable that is replaced with versioned package info in commit
@@ -32,7 +33,7 @@ const defaultCommitMessage =
     'chore(release): publish packages\n\n{$packageVersionsTemplateVar}';
 
 class VersionCommand extends MelosCommand {
-  VersionCommand() {
+  VersionCommand(MelosWorkspaceConfig config) : super(config) {
     setupPackageFilterParser();
     argParser.addFlag(
       'prerelease',
@@ -133,7 +134,7 @@ class VersionCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final melos = Melos(logger: logger, workingDirectory: Directory.current);
+    final melos = Melos(logger: logger, config: config);
 
     final force = argResults!['yes'] as bool;
     final updateDependentsConstraints =
@@ -206,7 +207,7 @@ class VersionCommand extends MelosCommand {
       }
 
       await melos.autoVersion(
-        filter: parsePackageFilter(Directory.current),
+        filter: parsePackageFilter(config.path),
         force: force,
         gitTag: tag,
         updateChangelog: changelog,

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -5,25 +5,20 @@ mixin _RunMixin on _Melos {
   Future<void> run({
     String? scriptName,
     bool noSelect = false,
-    // Optional configs to avoid re-parsing the configs
-    MelosWorkspaceConfig? configs,
   }) async {
-    // We don't create a workspace yet, as we don't need to load the packages.
-    configs ??= await MelosWorkspaceConfig.fromDirectory(workingDirectory);
+    if (config.scripts.keys.isEmpty) throw NoScriptException._();
 
-    if (configs.scripts.keys.isEmpty) throw NoScriptException._();
-
-    scriptName ??= await _pickScript(configs);
-    final script = configs.scripts[scriptName];
+    scriptName ??= await _pickScript(config);
+    final script = config.scripts[scriptName];
 
     if (script == null) {
       throw ScriptNotFoundException._(
         scriptName!,
-        configs.scripts.keys.toList(),
+        config.scripts.keys.toList(),
       );
     }
 
-    final exitCode = await _runScript(script, configs, noSelect: noSelect);
+    final exitCode = await _runScript(script, config, noSelect: noSelect);
 
     logger.stdout('');
     logger.stdout(AnsiStyles.yellow.bold('melos run ${script.name}'));

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -54,19 +54,19 @@ class Melos extends _Melos
         _VersionMixin,
         _PublishMixin {
   Melos({
-    required this.workingDirectory,
+    required this.config,
     Logger? logger,
   }) : logger = logger ?? Logger.standard();
 
   @override
   final Logger logger;
   @override
-  final Directory workingDirectory;
+  final MelosWorkspaceConfig config;
 }
 
 abstract class _Melos {
   Logger get logger;
-  Directory get workingDirectory;
+  MelosWorkspaceConfig get config;
 
   Future<MelosWorkspace> createWorkspace({PackageFilter? filter}) async {
     var filterWithEnv = filter;
@@ -79,13 +79,12 @@ abstract class _Melos {
         scope: currentPlatform.environment[envKeyMelosPackages]!
             .split(',')
             .map(
-              (e) => createGlob(e, currentDirectoryPath: workingDirectory.path),
+              (e) => createGlob(e, currentDirectoryPath: config.path),
             )
             .toList(),
       );
     }
 
-    final config = await MelosWorkspaceConfig.fromDirectory(workingDirectory);
     return MelosWorkspace.fromConfig(
       config,
       filter: filterWithEnv,
@@ -111,7 +110,7 @@ abstract class _Melos {
     if (workspace.config.scripts.containsKey(scriptName)) {
       logger.stdout('Running $scriptName script...\n');
 
-      await run(scriptName: scriptName, configs: workspace.config);
+      await run(scriptName: scriptName);
     }
 
     try {
@@ -121,7 +120,7 @@ abstract class _Melos {
       if (workspace.config.scripts.containsKey(postScript)) {
         logger.stdout('Running $postScript script...\n');
 
-        await run(scriptName: postScript, configs: workspace.config);
+        await run(scriptName: postScript);
       }
     }
   }
@@ -129,6 +128,5 @@ abstract class _Melos {
   Future<void> run({
     String? scriptName,
     bool noSelect = false,
-    MelosWorkspaceConfig? configs,
   });
 }

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -49,7 +49,7 @@ mixin _VersionMixin on _RunMixin {
 
     if (workspace.config.scripts.containsKey('preversion')) {
       logger.stdout('Running "preversion" lifecycle script...\n');
-      await run(scriptName: 'preversion', configs: workspace.config);
+      await run(scriptName: 'preversion');
     }
 
     final packageCommits = await _getPackageCommits(
@@ -186,7 +186,7 @@ Hint: try running "melos version --all" to include private packages.
     // TODO allow support for individual package lifecycle version scripts
     if (workspace.config.scripts.containsKey('version')) {
       logger.stdout('Running "version" lifecycle script...\n');
-      await run(scriptName: 'version', configs: workspace.config);
+      await run(scriptName: 'version');
     }
 
     if (gitTag) {
@@ -206,7 +206,7 @@ Hint: try running "melos version --all" to include private packages.
     // TODO allow support for individual package lifecycle postversion scripts
     if (workspace.config.scripts.containsKey('postversion')) {
       logger.stdout('Running "postversion" lifecycle script...\n');
-      await run(scriptName: 'postversion', configs: workspace.config);
+      await run(scriptName: 'postversion');
     }
 
     // TODO automatic push support
@@ -285,7 +285,7 @@ Hint: try running "melos version --all" to include private packages.
     // TODO allow support for individual package lifecycle version scripts
     if (workspace.config.scripts.containsKey('preversion')) {
       logger.stdout('Running "preversion" lifecycle script...\n');
-      await run(scriptName: 'preversion', configs: workspace.config);
+      await run(scriptName: 'preversion');
     }
 
     // Update package pubspec version.
@@ -325,7 +325,7 @@ Hint: try running "melos version --all" to include private packages.
     // TODO allow support for individual package lifecycle version scripts
     if (workspace.config.scripts.containsKey('version')) {
       logger.stdout('Running "version" lifecycle script...\n');
-      await run(scriptName: 'version', configs: workspace.config);
+      await run(scriptName: 'version');
     }
 
     logger.stdout(

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -35,9 +35,10 @@ void main() {
       );
 
       final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
       final melos = Melos(
         logger: logger,
-        workingDirectory: workspaceDir,
+        config: config,
       );
 
       await melos.bootstrap();
@@ -95,9 +96,10 @@ Generating IntelliJ IDE files...
       );
 
       final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
       final melos = Melos(
         logger: logger,
-        workingDirectory: workspaceDir,
+        config: config,
       );
 
       await expectLater(

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -33,9 +33,10 @@ void main() {
       );
 
       final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
       final melos = Melos(
         logger: logger,
-        workingDirectory: workspaceDir,
+        config: config,
       );
 
       await melos.exec(

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -1,6 +1,7 @@
 import 'package:melos/src/commands/runner.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/package.dart';
+import 'package:melos/src/workspace_configs.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/scaffolding.dart';
 import 'package:test/test.dart';
@@ -27,7 +28,8 @@ void main() {
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list();
 
@@ -60,7 +62,8 @@ b
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list();
 
@@ -92,7 +95,8 @@ a
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list(showPrivatePackages: true);
 
@@ -120,7 +124,8 @@ c
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list(
             showPrivatePackages: true,
@@ -154,7 +159,8 @@ c
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list(
             showPrivatePackages: true,
@@ -185,7 +191,8 @@ long_name 0.0.0 packages/long_name PRIVATE
             ],
           );
 
-          final melos = Melos(logger: logger, workingDirectory: workspaceDir);
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
 
           await melos.list(long: true);
 

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -47,9 +47,10 @@ void main() {
       );
 
       final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
       final melos = Melos(
         logger: logger,
-        workingDirectory: workspaceDir,
+        config: config,
       );
 
       await melos.run(scriptName: 'test_script', noSelect: true);


### PR DESCRIPTION
To be able to match unknown commands with scripts (#163), the list of scripts must be known before parsing command-line arguments.

Thus, instead of reading the workspace config in individual commands, read the config early on startup and pass it down to the command runner and commands so that:

  a) commands don't need to read the config again, and
  b) it will be straightforward to introduce a new command that matches unknown commands with scripts.