### PR TITLE
docs: Fixed command in published

### DIFF
--- a/docs/commands.mdx
+++ b/docs/commands.mdx
@@ -248,7 +248,7 @@ melos bootstrap --no-private
 Filter packages where the current local package version exists on pub.dev.
 
 ```bash
-melos bootstrap --no-private
+melos bootstrap --published
 ```
 
 Use `--no-published` to filter packages that have not had their current version published yet.


### PR DESCRIPTION
Thanks for the great package.
I was reading the documentation and found what I thought was a minor typographical error, so I fixed it.
