### PR TITLE
fix: melos.yaml ignores should apply also to `run` commands `MELOS_PACKAGES` env variable

### DIFF
--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -129,18 +129,6 @@ mixin _RunMixin on _Melos {
       // a defined script, this comma delimited list of package names is used
       // instead of any filters if detected.
       environment[envKeyMelosPackages] = packagesEnv;
-    } else if (config.ignore.isNotEmpty) {
-      final workspace = await MelosWorkspace.fromConfig(
-        config,
-        filter: PackageFilter(ignore: config.ignore),
-        logger: logger,
-      );
-      final packages = workspace.filteredPackages.values.toList();
-      // MELOS_PACKAGES environment is detected by melos itself when through
-      // a defined script, this comma delimited list of package names is used
-      // instead of any filters if detected.
-      environment[envKeyMelosPackages] =
-          packages.map((e) => e.name).toList().join(',');
     }
 
     final scriptSource = script.run;

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -71,7 +71,10 @@ mixin _RunMixin on _Melos {
     if (script.filter != null) {
       final workspace = await MelosWorkspace.fromConfig(
         config,
-        filter: script.filter,
+        filter: script.filter!.copyWithUpdatedIgnore([
+          ...script.filter!.ignore,
+          ...config.ignore,
+        ]),
         logger: logger,
       );
 
@@ -126,6 +129,18 @@ mixin _RunMixin on _Melos {
       // a defined script, this comma delimited list of package names is used
       // instead of any filters if detected.
       environment[envKeyMelosPackages] = packagesEnv;
+    } else if (config.ignore.isNotEmpty) {
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
+        filter: PackageFilter(ignore: config.ignore),
+        logger: logger,
+      );
+      final packages = workspace.filteredPackages.values.toList();
+      // MELOS_PACKAGES environment is detected by melos itself when through
+      // a defined script, this comma delimited list of package names is used
+      // instead of any filters if detected.
+      environment[envKeyMelosPackages] =
+          packages.map((e) => e.name).toList().join(',');
     }
 
     final scriptSource = script.run;

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -224,6 +224,23 @@ class PackageFilter {
     );
   }
 
+  PackageFilter copyWithUpdatedIgnore(List<Glob> updatedIgnore) {
+    return PackageFilter._(
+      dependsOn: dependsOn,
+      dirExists: dirExists,
+      fileExists: fileExists,
+      ignore: updatedIgnore,
+      includePrivatePackages: includePrivatePackages,
+      noDependsOn: noDependsOn,
+      nullSafe: nullSafe,
+      published: published,
+      scope: scope,
+      updatedSince: updatedSince,
+      includeDependencies: includeDependencies,
+      includeDependents: includeDependents,
+    );
+  }
+
   @override
   bool operator ==(Object other) =>
       other is PackageFilter &&


### PR DESCRIPTION
Fixes FlutterFire CI erroring trying to run tests for packages that are actually ignored in melos.yaml