### PR TITLE
fix: run version cmd with `--depentens-versions` value from cli

### DIFF
--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -212,6 +212,7 @@ class VersionCommand extends MelosCommand {
         gitTag: tag,
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
+        updateDependentsVersions: updateDependentsVersions,
         preid: preid,
         asPrerelease: asPrerelease,
         asStableRelease: asStableRelease,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -23,7 +23,7 @@ mixin _VersionMixin on _RunMixin {
 
     if (updateDependentsVersions && !updateDependentsConstraints) {
       throw ArgumentError(
-        'Cannot use both updateDependentsVersions and updateDependentsConstraints.',
+        'Cannot use updateDependentsVersions without updateDependentsConstraints.',
       );
     }
 


### PR DESCRIPTION
Currently the value specified for `--depentens-versions` on the command line is not passed through to the `autoVersion` method.