### PR TITLE
feat: verbose logging now logs package commit messages when versioning

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -185,6 +185,14 @@ Hint: try running "melos version --all" to include private packages.
       updateDependentsConstraints: updateDependentsConstraints,
     );
 
+    // show commit message
+    for (final element in pendingPackageUpdates) {
+      logger.trace(AnsiStyles.yellow.bold(element.package.name));
+      for (final e in element.commits) {
+        logger.trace('   ${e.message}');
+      }
+    }
+
     final shouldContinue = force || promptBool();
     if (!shouldContinue) {
       logger.stdout(AnsiStyles.red('Operation was canceled.'));


### PR DESCRIPTION
Closes #202 