### PR TITLE
feat: VSCode workspace generator script

### DIFF
--- a/scripts/melos_workspace/.gitignore
+++ b/scripts/melos_workspace/.gitignore
@@ -1,0 +1,9 @@
+# Files and directories created by pub
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs
+build/
+
+# Directory created by dartdoc
+doc/api/

--- a/scripts/melos_workspace/CHANGELOG.md
+++ b/scripts/melos_workspace/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version, created by Stagehand

--- a/scripts/melos_workspace/README.md
+++ b/scripts/melos_workspace/README.md
@@ -1,0 +1,1 @@
+Generates a minimal VSCode workspace project file which includes all local direct/transitive dependencies of a melos target

--- a/scripts/melos_workspace/bin/melos_workspace.dart
+++ b/scripts/melos_workspace/bin/melos_workspace.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:melos_workspace/models/package_dependency.dart';
+import 'package:melos_workspace/models/workspace.dart';
+import 'package:melos_workspace/models/workspace_folder.dart';
+import 'package:path/path.dart' as path;
+
+const kArgPackageName = 'package';
+const kArgumentOutputPath = 'output';
+const kOutputIndentation = '\t';
+
+Future<void> main(List<String> arguments) async {
+  final parser = ArgParser()
+    ..addOption(
+      kArgPackageName,
+      help: 'Name of the target project to generate the workspace for.',
+      mandatory: true,
+      abbr: 'p',
+    )
+    ..addOption(
+      kArgumentOutputPath,
+      help: ''' 
+          Output directory path for the generated workspace file. 
+          Defaults to the current working directory.
+          ''',
+      mandatory: false,
+      abbr: 'o',
+    );
+
+  final argResults = parser.parse(arguments);
+
+  final packageName = argResults[kArgPackageName] as String;
+  final outputDirPath =
+      argResults[kArgumentOutputPath] as String? ?? Directory.current.path;
+
+  final melosCmdArgs = [
+    'list',
+    '--all',
+    '--include-dependencies',
+    '--json',
+    '--scope=$packageName',
+  ];
+
+  final result = await Process.run(
+    'melos',
+    melosCmdArgs,
+  ).then((result) => result.stdout);
+
+  /// Generate Models
+  final List folderJsons = json.decode(result);
+
+  final packages = folderJsons.map(
+    (json) => PackageDependency.fromJson(json),
+  );
+  final workspace = Workspace(
+    folders: packages
+        .map(
+          (package) => WorkspaceFolder(
+            name: package.name,
+            path: package.location,
+          ),
+        )
+        .toList(),
+  );
+
+  /// Prettify output
+  final prettyJson = const JsonEncoder.withIndent(kOutputIndentation).convert(
+    workspace.toJson(),
+  );
+
+  /// Write file to disk
+  final fileName = '$packageName.code-workspace';
+
+  final relativeFilePath = path.relative('$outputDirPath/$fileName');
+  final file = File(relativeFilePath);
+  await file.writeAsString(prettyJson);
+
+  print('Workspace file written to $relativeFilePath');
+}

--- a/scripts/melos_workspace/lib/melos_workspace.dart
+++ b/scripts/melos_workspace/lib/melos_workspace.dart
@@ -1,0 +1,3 @@
+export './models/package_dependency.dart';
+export './models/workspace.dart';
+export './models/workspace_folder.dart';

--- a/scripts/melos_workspace/lib/models/package_dependency.dart
+++ b/scripts/melos_workspace/lib/models/package_dependency.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'package_dependency.freezed.dart';
+part 'package_dependency.g.dart';
+
+@freezed
+class PackageDependency with _$PackageDependency {
+  @JsonSerializable()
+  const factory PackageDependency({
+    @JsonKey(name: 'name') required String name,
+    @JsonKey(name: 'content_type') required String contentType,
+    @JsonKey(name: 'private') required bool private,
+    @JsonKey(name: 'location') required String location,
+    @JsonKey(name: 'type') required int type,
+  }) = _PackageDependency;
+
+  factory PackageDependency.fromJson(Map<String, dynamic> json) =>
+      _$PackageDependencyFromJson(json);
+}

--- a/scripts/melos_workspace/lib/models/package_dependency.freezed.dart
+++ b/scripts/melos_workspace/lib/models/package_dependency.freezed.dart
@@ -1,0 +1,274 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'package_dependency.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+PackageDependency _$PackageDependencyFromJson(Map<String, dynamic> json) {
+  return _PackageDependency.fromJson(json);
+}
+
+/// @nodoc
+class _$PackageDependencyTearOff {
+  const _$PackageDependencyTearOff();
+
+  _PackageDependency call(
+      {@JsonKey(name: 'name') required String name,
+      @JsonKey(name: 'version') required String contentType,
+      @JsonKey(name: 'private') required bool private,
+      @JsonKey(name: 'location') required String location,
+      @JsonKey(name: 'type') required int type}) {
+    return _PackageDependency(
+      name: name,
+      contentType: contentType,
+      private: private,
+      location: location,
+      type: type,
+    );
+  }
+
+  PackageDependency fromJson(Map<String, Object?> json) {
+    return PackageDependency.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $PackageDependency = _$PackageDependencyTearOff();
+
+/// @nodoc
+mixin _$PackageDependency {
+  @JsonKey(name: 'name')
+  String get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'version')
+  String get contentType => throw _privateConstructorUsedError;
+  @JsonKey(name: 'private')
+  bool get private => throw _privateConstructorUsedError;
+  @JsonKey(name: 'location')
+  String get location => throw _privateConstructorUsedError;
+  @JsonKey(name: 'type')
+  int get type => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PackageDependencyCopyWith<PackageDependency> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PackageDependencyCopyWith<$Res> {
+  factory $PackageDependencyCopyWith(
+          PackageDependency value, $Res Function(PackageDependency) then) =
+      _$PackageDependencyCopyWithImpl<$Res>;
+  $Res call(
+      {@JsonKey(name: 'name') String name,
+      @JsonKey(name: 'version') String contentType,
+      @JsonKey(name: 'private') bool private,
+      @JsonKey(name: 'location') String location,
+      @JsonKey(name: 'type') int type});
+}
+
+/// @nodoc
+class _$PackageDependencyCopyWithImpl<$Res>
+    implements $PackageDependencyCopyWith<$Res> {
+  _$PackageDependencyCopyWithImpl(this._value, this._then);
+
+  final PackageDependency _value;
+  // ignore: unused_field
+  final $Res Function(PackageDependency) _then;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? contentType = freezed,
+    Object? private = freezed,
+    Object? location = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      contentType: contentType == freezed
+          ? _value.contentType
+          : contentType // ignore: cast_nullable_to_non_nullable
+              as String,
+      private: private == freezed
+          ? _value.private
+          : private // ignore: cast_nullable_to_non_nullable
+              as bool,
+      location: location == freezed
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$PackageDependencyCopyWith<$Res>
+    implements $PackageDependencyCopyWith<$Res> {
+  factory _$PackageDependencyCopyWith(
+          _PackageDependency value, $Res Function(_PackageDependency) then) =
+      __$PackageDependencyCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {@JsonKey(name: 'name') String name,
+      @JsonKey(name: 'version') String contentType,
+      @JsonKey(name: 'private') bool private,
+      @JsonKey(name: 'location') String location,
+      @JsonKey(name: 'type') int type});
+}
+
+/// @nodoc
+class __$PackageDependencyCopyWithImpl<$Res>
+    extends _$PackageDependencyCopyWithImpl<$Res>
+    implements _$PackageDependencyCopyWith<$Res> {
+  __$PackageDependencyCopyWithImpl(
+      _PackageDependency _value, $Res Function(_PackageDependency) _then)
+      : super(_value, (v) => _then(v as _PackageDependency));
+
+  @override
+  _PackageDependency get _value => super._value as _PackageDependency;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? contentType = freezed,
+    Object? private = freezed,
+    Object? location = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_PackageDependency(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      contentType: contentType == freezed
+          ? _value.contentType
+          : contentType // ignore: cast_nullable_to_non_nullable
+              as String,
+      private: private == freezed
+          ? _value.private
+          : private // ignore: cast_nullable_to_non_nullable
+              as bool,
+      location: location == freezed
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: type == freezed
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable()
+class _$_PackageDependency implements _PackageDependency {
+  const _$_PackageDependency(
+      {@JsonKey(name: 'name') required this.name,
+      @JsonKey(name: 'version') required this.contentType,
+      @JsonKey(name: 'private') required this.private,
+      @JsonKey(name: 'location') required this.location,
+      @JsonKey(name: 'type') required this.type});
+
+  factory _$_PackageDependency.fromJson(Map<String, dynamic> json) =>
+      _$$_PackageDependencyFromJson(json);
+
+  @override
+  @JsonKey(name: 'name')
+  final String name;
+  @override
+  @JsonKey(name: 'version')
+  final String contentType;
+  @override
+  @JsonKey(name: 'private')
+  final bool private;
+  @override
+  @JsonKey(name: 'location')
+  final String location;
+  @override
+  @JsonKey(name: 'type')
+  final int type;
+
+  @override
+  String toString() {
+    return 'PackageDependency(name: $name, contentType: $contentType, private: $private, location: $location, type: $type)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PackageDependency &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.contentType, contentType) ||
+                other.contentType == contentType) &&
+            (identical(other.private, private) || other.private == private) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, name, contentType, private, location, type);
+
+  @JsonKey(ignore: true)
+  @override
+  _$PackageDependencyCopyWith<_PackageDependency> get copyWith =>
+      __$PackageDependencyCopyWithImpl<_PackageDependency>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_PackageDependencyToJson(this);
+  }
+}
+
+abstract class _PackageDependency implements PackageDependency {
+  const factory _PackageDependency(
+      {@JsonKey(name: 'name') required String name,
+      @JsonKey(name: 'version') required String contentType,
+      @JsonKey(name: 'private') required bool private,
+      @JsonKey(name: 'location') required String location,
+      @JsonKey(name: 'type') required int type}) = _$_PackageDependency;
+
+  factory _PackageDependency.fromJson(Map<String, dynamic> json) =
+      _$_PackageDependency.fromJson;
+
+  @override
+  @JsonKey(name: 'name')
+  String get name;
+  @override
+  @JsonKey(name: 'version')
+  String get contentType;
+  @override
+  @JsonKey(name: 'private')
+  bool get private;
+  @override
+  @JsonKey(name: 'location')
+  String get location;
+  @override
+  @JsonKey(name: 'type')
+  int get type;
+  @override
+  @JsonKey(ignore: true)
+  _$PackageDependencyCopyWith<_PackageDependency> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/scripts/melos_workspace/lib/models/package_dependency.g.dart
+++ b/scripts/melos_workspace/lib/models/package_dependency.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'package_dependency.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_PackageDependency _$$_PackageDependencyFromJson(Map<String, dynamic> json) =>
+    _$_PackageDependency(
+      name: json['name'] as String,
+      contentType: json['version'] as String,
+      private: json['private'] as bool,
+      location: json['location'] as String,
+      type: json['type'] as int,
+    );
+
+Map<String, dynamic> _$$_PackageDependencyToJson(
+        _$_PackageDependency instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'version': instance.contentType,
+      'private': instance.private,
+      'location': instance.location,
+      'type': instance.type,
+    };

--- a/scripts/melos_workspace/lib/models/package_dependency.reflectable.dart
+++ b/scripts/melos_workspace/lib/models/package_dependency.reflectable.dart
@@ -1,0 +1,1 @@
+// No output from reflectable, 'package:reflectable/reflectable.dart' not used.

--- a/scripts/melos_workspace/lib/models/workspace.dart
+++ b/scripts/melos_workspace/lib/models/workspace.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'workspace_folder.dart';
+
+part 'workspace.freezed.dart';
+part 'workspace.g.dart';
+
+@freezed
+class Workspace with _$Workspace {
+  @JsonSerializable(
+    explicitToJson: true,
+  )
+  const factory Workspace({
+    @JsonKey(name: 'folders') required List<WorkspaceFolder> folders,
+  }) = _Workspace;
+
+  factory Workspace.fromJson(Map<String, dynamic> json) =>
+      _$WorkspaceFromJson(json);
+}

--- a/scripts/melos_workspace/lib/models/workspace.freezed.dart
+++ b/scripts/melos_workspace/lib/models/workspace.freezed.dart
@@ -1,0 +1,165 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'workspace.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Workspace _$WorkspaceFromJson(Map<String, dynamic> json) {
+  return _Workspace.fromJson(json);
+}
+
+/// @nodoc
+class _$WorkspaceTearOff {
+  const _$WorkspaceTearOff();
+
+  _Workspace call(
+      {@JsonKey(name: 'folders') required List<WorkspaceFolder> folders}) {
+    return _Workspace(
+      folders: folders,
+    );
+  }
+
+  Workspace fromJson(Map<String, Object?> json) {
+    return Workspace.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $Workspace = _$WorkspaceTearOff();
+
+/// @nodoc
+mixin _$Workspace {
+  @JsonKey(name: 'folders')
+  List<WorkspaceFolder> get folders => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WorkspaceCopyWith<Workspace> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WorkspaceCopyWith<$Res> {
+  factory $WorkspaceCopyWith(Workspace value, $Res Function(Workspace) then) =
+      _$WorkspaceCopyWithImpl<$Res>;
+  $Res call({@JsonKey(name: 'folders') List<WorkspaceFolder> folders});
+}
+
+/// @nodoc
+class _$WorkspaceCopyWithImpl<$Res> implements $WorkspaceCopyWith<$Res> {
+  _$WorkspaceCopyWithImpl(this._value, this._then);
+
+  final Workspace _value;
+  // ignore: unused_field
+  final $Res Function(Workspace) _then;
+
+  @override
+  $Res call({
+    Object? folders = freezed,
+  }) {
+    return _then(_value.copyWith(
+      folders: folders == freezed
+          ? _value.folders
+          : folders // ignore: cast_nullable_to_non_nullable
+              as List<WorkspaceFolder>,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WorkspaceCopyWith<$Res> implements $WorkspaceCopyWith<$Res> {
+  factory _$WorkspaceCopyWith(
+          _Workspace value, $Res Function(_Workspace) then) =
+      __$WorkspaceCopyWithImpl<$Res>;
+  @override
+  $Res call({@JsonKey(name: 'folders') List<WorkspaceFolder> folders});
+}
+
+/// @nodoc
+class __$WorkspaceCopyWithImpl<$Res> extends _$WorkspaceCopyWithImpl<$Res>
+    implements _$WorkspaceCopyWith<$Res> {
+  __$WorkspaceCopyWithImpl(_Workspace _value, $Res Function(_Workspace) _then)
+      : super(_value, (v) => _then(v as _Workspace));
+
+  @override
+  _Workspace get _value => super._value as _Workspace;
+
+  @override
+  $Res call({
+    Object? folders = freezed,
+  }) {
+    return _then(_Workspace(
+      folders: folders == freezed
+          ? _value.folders
+          : folders // ignore: cast_nullable_to_non_nullable
+              as List<WorkspaceFolder>,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$_Workspace implements _Workspace {
+  const _$_Workspace({@JsonKey(name: 'folders') required this.folders});
+
+  factory _$_Workspace.fromJson(Map<String, dynamic> json) =>
+      _$$_WorkspaceFromJson(json);
+
+  @override
+  @JsonKey(name: 'folders')
+  final List<WorkspaceFolder> folders;
+
+  @override
+  String toString() {
+    return 'Workspace(folders: $folders)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Workspace &&
+            const DeepCollectionEquality().equals(other.folders, folders));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(folders));
+
+  @JsonKey(ignore: true)
+  @override
+  _$WorkspaceCopyWith<_Workspace> get copyWith =>
+      __$WorkspaceCopyWithImpl<_Workspace>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WorkspaceToJson(this);
+  }
+}
+
+abstract class _Workspace implements Workspace {
+  const factory _Workspace(
+          {@JsonKey(name: 'folders') required List<WorkspaceFolder> folders}) =
+      _$_Workspace;
+
+  factory _Workspace.fromJson(Map<String, dynamic> json) =
+      _$_Workspace.fromJson;
+
+  @override
+  @JsonKey(name: 'folders')
+  List<WorkspaceFolder> get folders;
+  @override
+  @JsonKey(ignore: true)
+  _$WorkspaceCopyWith<_Workspace> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/scripts/melos_workspace/lib/models/workspace.g.dart
+++ b/scripts/melos_workspace/lib/models/workspace.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_Workspace _$$_WorkspaceFromJson(Map<String, dynamic> json) => _$_Workspace(
+      folders: (json['folders'] as List<dynamic>)
+          .map((e) => WorkspaceFolder.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$_WorkspaceToJson(_$_Workspace instance) =>
+    <String, dynamic>{
+      'folders': instance.folders.map((e) => e.toJson()).toList(),
+    };

--- a/scripts/melos_workspace/lib/models/workspace.reflectable.dart
+++ b/scripts/melos_workspace/lib/models/workspace.reflectable.dart
@@ -1,0 +1,1 @@
+// No output from reflectable, 'package:reflectable/reflectable.dart' not used.

--- a/scripts/melos_workspace/lib/models/workspace_folder.dart
+++ b/scripts/melos_workspace/lib/models/workspace_folder.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'workspace_folder.freezed.dart';
+part 'workspace_folder.g.dart';
+
+@freezed
+class WorkspaceFolder with _$WorkspaceFolder {
+  @JsonSerializable()
+  const factory WorkspaceFolder({
+    required String name,
+    required String path,
+  }) = _WorkspaceFolder;
+
+  factory WorkspaceFolder.fromJson(Map<String, dynamic> json) =>
+      _$WorkspaceFolderFromJson(json);
+}

--- a/scripts/melos_workspace/lib/models/workspace_folder.freezed.dart
+++ b/scripts/melos_workspace/lib/models/workspace_folder.freezed.dart
@@ -1,0 +1,194 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'workspace_folder.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+WorkspaceFolder _$WorkspaceFolderFromJson(Map<String, dynamic> json) {
+  return _WorkspaceFolder.fromJson(json);
+}
+
+/// @nodoc
+class _$WorkspaceFolderTearOff {
+  const _$WorkspaceFolderTearOff();
+
+  _WorkspaceFolder call(
+      {@JsonKey(name: 'name') required String name,
+      @JsonKey(name: 'path') required String path}) {
+    return _WorkspaceFolder(
+      name: name,
+      path: path,
+    );
+  }
+
+  WorkspaceFolder fromJson(Map<String, Object?> json) {
+    return WorkspaceFolder.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $WorkspaceFolder = _$WorkspaceFolderTearOff();
+
+/// @nodoc
+mixin _$WorkspaceFolder {
+  @JsonKey(name: 'name')
+  String get name => throw _privateConstructorUsedError;
+  @JsonKey(name: 'path')
+  String get path => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WorkspaceFolderCopyWith<WorkspaceFolder> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WorkspaceFolderCopyWith<$Res> {
+  factory $WorkspaceFolderCopyWith(
+          WorkspaceFolder value, $Res Function(WorkspaceFolder) then) =
+      _$WorkspaceFolderCopyWithImpl<$Res>;
+  $Res call(
+      {@JsonKey(name: 'name') String name, @JsonKey(name: 'path') String path});
+}
+
+/// @nodoc
+class _$WorkspaceFolderCopyWithImpl<$Res>
+    implements $WorkspaceFolderCopyWith<$Res> {
+  _$WorkspaceFolderCopyWithImpl(this._value, this._then);
+
+  final WorkspaceFolder _value;
+  // ignore: unused_field
+  final $Res Function(WorkspaceFolder) _then;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? path = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      path: path == freezed
+          ? _value.path
+          : path // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WorkspaceFolderCopyWith<$Res>
+    implements $WorkspaceFolderCopyWith<$Res> {
+  factory _$WorkspaceFolderCopyWith(
+          _WorkspaceFolder value, $Res Function(_WorkspaceFolder) then) =
+      __$WorkspaceFolderCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {@JsonKey(name: 'name') String name, @JsonKey(name: 'path') String path});
+}
+
+/// @nodoc
+class __$WorkspaceFolderCopyWithImpl<$Res>
+    extends _$WorkspaceFolderCopyWithImpl<$Res>
+    implements _$WorkspaceFolderCopyWith<$Res> {
+  __$WorkspaceFolderCopyWithImpl(
+      _WorkspaceFolder _value, $Res Function(_WorkspaceFolder) _then)
+      : super(_value, (v) => _then(v as _WorkspaceFolder));
+
+  @override
+  _WorkspaceFolder get _value => super._value as _WorkspaceFolder;
+
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? path = freezed,
+  }) {
+    return _then(_WorkspaceFolder(
+      name: name == freezed
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      path: path == freezed
+          ? _value.path
+          : path // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable()
+class _$_WorkspaceFolder implements _WorkspaceFolder {
+  const _$_WorkspaceFolder(
+      {@JsonKey(name: 'name') required this.name,
+      @JsonKey(name: 'path') required this.path});
+
+  factory _$_WorkspaceFolder.fromJson(Map<String, dynamic> json) =>
+      _$$_WorkspaceFolderFromJson(json);
+
+  @override
+  @JsonKey(name: 'name')
+  final String name;
+  @override
+  @JsonKey(name: 'path')
+  final String path;
+
+  @override
+  String toString() {
+    return 'WorkspaceFolder(name: $name, path: $path)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WorkspaceFolder &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.path, path) || other.path == path));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name, path);
+
+  @JsonKey(ignore: true)
+  @override
+  _$WorkspaceFolderCopyWith<_WorkspaceFolder> get copyWith =>
+      __$WorkspaceFolderCopyWithImpl<_WorkspaceFolder>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WorkspaceFolderToJson(this);
+  }
+}
+
+abstract class _WorkspaceFolder implements WorkspaceFolder {
+  const factory _WorkspaceFolder(
+      {@JsonKey(name: 'name') required String name,
+      @JsonKey(name: 'path') required String path}) = _$_WorkspaceFolder;
+
+  factory _WorkspaceFolder.fromJson(Map<String, dynamic> json) =
+      _$_WorkspaceFolder.fromJson;
+
+  @override
+  @JsonKey(name: 'name')
+  String get name;
+  @override
+  @JsonKey(name: 'path')
+  String get path;
+  @override
+  @JsonKey(ignore: true)
+  _$WorkspaceFolderCopyWith<_WorkspaceFolder> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/scripts/melos_workspace/lib/models/workspace_folder.g.dart
+++ b/scripts/melos_workspace/lib/models/workspace_folder.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'workspace_folder.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_WorkspaceFolder _$$_WorkspaceFolderFromJson(Map<String, dynamic> json) =>
+    _$_WorkspaceFolder(
+      name: json['name'] as String,
+      path: json['path'] as String,
+    );
+
+Map<String, dynamic> _$$_WorkspaceFolderToJson(_$_WorkspaceFolder instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'path': instance.path,
+    };

--- a/scripts/melos_workspace/lib/models/workspace_folder.reflectable.dart
+++ b/scripts/melos_workspace/lib/models/workspace_folder.reflectable.dart
@@ -1,0 +1,1 @@
+// No output from reflectable, 'package:reflectable/reflectable.dart' not used.

--- a/scripts/melos_workspace/pubspec.yaml
+++ b/scripts/melos_workspace/pubspec.yaml
@@ -1,0 +1,17 @@
+name: melos_workspace
+description: A simple command-line application.
+
+environment:
+  sdk: ">=2.14.0 <3.0.0"
+
+dependencies:
+  args:
+
+  freezed_annotation:
+  json_annotation: ^4.4.0
+  path:
+
+dev_dependencies:
+  freezed:
+  json_serializable:
+  build_runner:


### PR DESCRIPTION
I wrote this script package a while back which generates a VSCode project file out of the dependency tree reported by melos. I've found it pretty useful for larger projects that overwhelm the dart analyzer when too many folders (often unused ones) are open at the same time

Thought I would put this up and see if there's any interest in having such a script in this repo. No worries at all if it's not a good fit. 

If there is interest I can spend some time to clean it up a bit and make any changes requested.

Thank you to all who contribute to Melos 🙌 