### PR TITLE
feat: add repository host support for `GitLab`

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -25,6 +25,7 @@ The URL of where the git repository, which contains this project, is centrally h
 Supported hosts:
 
 - GitHub
+- GitLab (https://gitlab.com)
 
 ```yaml
 repository: https://github.com/invertase/melos

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -83,7 +83,7 @@ GitHubRepository(
   int get hashCode => owner.hashCode ^ name.hashCode;
 }
 
-/// A git repository, hosted by GitHub.
+/// A git repository, hosted by GitLab.
 class GitLabRepository extends HostedGitRepository {
   GitLabRepository({
     required this.owner,

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -83,8 +83,63 @@ GitHubRepository(
   int get hashCode => owner.hashCode ^ name.hashCode;
 }
 
+/// A git repository, hosted by GitHub.
+class GitLabRepository extends HostedGitRepository {
+  GitLabRepository({
+    required this.owner,
+    required this.name,
+  });
+
+  factory GitLabRepository.fromUrl(Uri uri) {
+    if (uri.scheme == 'https' && uri.host == 'gitlab.com') {
+      final match = RegExp(r'^\/((?:.+[\/]?))?\/(.+)\/?$').firstMatch(uri.path);
+      if (match != null) {
+        return GitLabRepository(
+          owner: match.group(1)!,
+          name: match.group(2)!,
+        );
+      }
+    }
+
+    throw FormatException('The URL $uri is not a valid GitLab repository URL.');
+  }
+
+  /// The username of the owner of this repository.
+  final String owner;
+
+  @override
+  final String name;
+
+  @override
+  late Uri url = Uri.parse('https://gitlab.com/$owner/$name/');
+
+  @override
+  Uri commitUrl(String id) => url.resolve('-/commit/$id');
+
+  @override
+  String toString() {
+    return '''
+GitLabRepository(
+  owner: $owner,
+  name: $name,
+)''';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GitHubRepository &&
+          other.runtimeType == runtimeType &&
+          other.owner == owner &&
+          other.name == name;
+
+  @override
+  int get hashCode => owner.hashCode ^ name.hashCode;
+}
+
 final _hostsToUrlParser = {
   'GitHub': (Uri url) => GitHubRepository.fromUrl(url),
+  'GitLab': (Uri url) => GitLabRepository.fromUrl(url),
 };
 
 /// Tries to parse [url] into a [HostedGitRepository].


### PR DESCRIPTION
This PR adds support for https://gitlab.com.

It does not support self-hosted instances at the moment. If I have missed anything that should be changed to support GitLab then I will obviously change that ;-).