### PR TITLE
fix: bump `platform` dependency to to 3.1.0 to support latest Flutter/Dart versions

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   meta: ^1.1.8
   mustache_template: ^2.0.0
   path: ^1.7.0
-  platform: ^3.0.0
+  platform: ^3.1.0
   pool: ^1.4.0
   pub_semver: ^2.0.0
   pubspec: ^2.0.1


### PR DESCRIPTION
Resolves: https://github.com/invertase/melos/issues/239.

platform 3.0.0 uses a deprecated member that was removed in flutter 2.10.0. platform 3.1.0 resolves this.