### PR TITLE
feat: add `--version` option to `version` command

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -7,7 +7,7 @@ description: "Learn more about the `version` command in Melos."
 
 > Supports all [Melos filtering](/filters) flags.
 
-Automatically version and generate changelogs for all packages. 
+Automatically version and generate changelogs for all packages.
 
 
 ```bash
@@ -107,4 +107,13 @@ chore(release): publish packages
 
 ```bash
 melos version --message="chore(release): publish new versions"
+```
+
+## --version (-V)
+
+Manually specify a version for a package. Can be used multiple times. Each value must be in the format "package:version". Applies only to Conventional Commits based versioning. Cannot be combined with --graduate or --prerelease flag.
+
+```bash
+melos version --version=foo:1.0.0
+melos version -V=foo:1.0.0
 ```

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -29,6 +29,7 @@ TODO docs on:
 - build versions
 - dependency versioning
 - bad commit messages?
+- manual versioning
 
 ## Publishing
 

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -116,6 +116,14 @@ class VersionCommand extends MelosCommand {
           'result in a version in the format "1.0.0-1.0.nullsafety.0". '
           'Applies only to Conventional Commits based versioning.',
     );
+    argParser.addMultiOption(
+      'version',
+      abbr: 'V',
+      help: 'Manually specify a version for a package. Can be used multiple '
+          'times. Each value must be in the format "package:version". '
+          'Applies only to Conventional Commits based versioning. Cannot be '
+          'combined with --graduate or --prerelease flag.',
+    );
   }
 
   @override
@@ -188,6 +196,19 @@ class VersionCommand extends MelosCommand {
       final force = argResults!['yes'] as bool;
       final versionPrivatePackages = argResults!['all'] as bool;
       final preid = argResults!['preid'] as String?;
+      final manualVersionArgs = argResults!['version'] as List<String>;
+      final manualVersions = Map.fromEntries(
+        manualVersionArgs.map((arg) {
+          final parts = arg.split(':');
+          if (parts.length != 2) {
+            throw ArgumentError(
+              'manual-version must be in the format "package:version".',
+            );
+          }
+
+          return MapEntry(parts[0], Version.parse(parts[1]));
+        }),
+      );
 
       if (asPrerelease && asStableRelease) {
         logger?.stdout(
@@ -218,6 +239,7 @@ class VersionCommand extends MelosCommand {
         asStableRelease: asStableRelease,
         message: commitMessage,
         versionPrivatePackages: versionPrivatePackages,
+        manualVersions: manualVersions,
       );
     }
   }

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -29,6 +29,9 @@ import 'versioning.dart' as versioning;
 
 /// Enum representing why the version has been changed when running 'version' command.
 enum PackageUpdateReason {
+  /// The user provided a new version.
+  manual,
+
   /// Changed due to a commit modifying code in this package.
   commit,
 
@@ -49,7 +52,20 @@ class MelosPendingPackageUpdate {
     this.graduate = false,
     this.preid,
     required this.logger,
-  });
+  })  : manualVersion = null,
+        userChangelogMessage = null;
+
+  MelosPendingPackageUpdate.manual(
+    this.workspace,
+    this.package,
+    this.commits,
+    this.manualVersion, {
+    this.userChangelogMessage,
+    required this.logger,
+  })  : reason = PackageUpdateReason.manual,
+        prerelease = false,
+        graduate = false,
+        preid = null;
 
   /// Commits that triggered this pending update. Can be empty if
   /// [PackageUpdateReason] is [PackageUpdateReason.dependency].
@@ -75,6 +91,15 @@ class MelosPendingPackageUpdate {
   /// The prerelease id that will be used for prereleases, e.g. "0.1.0-[preid].1".
   final String? preid;
 
+  /// The next version of the package, if it has been manually specified by the
+  /// user.
+  final Version? manualVersion;
+
+  /// Changelog message that the user provided directly.
+  ///
+  /// This is only used for manually versioned packages.
+  final String? userChangelogMessage;
+
   final Logger? logger;
 
   Changelog get changelog {
@@ -89,13 +114,14 @@ class MelosPendingPackageUpdate {
 
   /// Next pub version that will occur as part of this package update.
   Version get nextVersion {
-    return versioning.nextVersion(
-      currentVersion,
-      semverReleaseType,
-      graduate: graduate,
-      preid: preid,
-      prerelease: prerelease,
-    );
+    return manualVersion ??
+        versioning.nextVersion(
+          currentVersion,
+          semverReleaseType,
+          graduate: graduate,
+          preid: preid,
+          prerelease: prerelease,
+        );
   }
 
   /// Taking into account all the commits in this update, what is the highest [SemverReleaseType].
@@ -114,6 +140,15 @@ class MelosPendingPackageUpdate {
         return SemverReleaseType.minor;
       }
       return SemverReleaseType.major;
+    }
+
+    if (reason == PackageUpdateReason.manual && commits.isEmpty) {
+      // Users are allowed to specify a version manually, possibly without there
+      // being any commits since the last version bump.
+      // We don't compare the current and next version to find a
+      // SemverReleaseType because the user might not strictly adhere to the
+      // Semver rules.
+      return SemverReleaseType.patch;
     }
 
     return SemverReleaseType.values[commits

--- a/packages/melos/lib/src/common/workspace_changelog.dart
+++ b/packages/melos/lib/src/common/workspace_changelog.dart
@@ -58,12 +58,14 @@ class WorkspaceChangelog {
         .where((update) => update.reason == PackageUpdateReason.graduate);
     final packagesWithBreakingChanges = pendingPackageUpdates.where(
       (update) =>
-          update.reason == PackageUpdateReason.commit &&
+          (update.reason == PackageUpdateReason.commit ||
+              update.reason == PackageUpdateReason.manual) &&
           update.semverReleaseType == SemverReleaseType.major,
     );
     final packagesWithOtherChanges = pendingPackageUpdates.where(
       (update) =>
-          update.reason == PackageUpdateReason.commit &&
+          (update.reason == PackageUpdateReason.commit ||
+              update.reason == PackageUpdateReason.manual) &&
           update.semverReleaseType != SemverReleaseType.major,
     );
 


### PR DESCRIPTION
Closes #229

## Description

This change adds an option to the `version` command which allows the user to manually specify a version for a package. The option can be used multiple times.

The user is asked to provided a changelog message for packages for which a version has been manually specified. If there are no commits to describe the changes for such a package, the changelog message is mandatory. Otherwise it is optional.

Using the `--version` option for a package versions it regardless of whether it was included by the package filters or whether there are commits since the last version.

With this change the alternative invocation (`melos version <package> <version>`) becomes redundant and could be removed.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
