### PR TITLE
feat: git hosted package dependencies

### DIFF
--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -54,7 +54,7 @@ Once satisfied with your pending releases, release them to [pub.dev](https://pub
 melos publish --no-dry-run
 ```
 
-## Not publishing to pub.dev
+## Git hosted packages
 
 If your packages are private and don't publish to [pub.dev](https://pub.dev), you can use the tag generated as git reference in your `pubspec.yaml` file and Melos will ensure the versions are updated accordingly.
 

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -53,3 +53,26 @@ Once satisfied with your pending releases, release them to [pub.dev](https://pub
 ```dart
 melos publish --no-dry-run
 ```
+
+## Not publishing to pub.dev
+
+If your packages are private and don't publish to [pub.dev](https://pub.dev), you can use the tag generated as git reference in your `pubspec.yaml` file and Melos will ensure the versions are updated accordingly.
+
+Example:
+```yaml
+dependencies:
+  internal_dep:
+    git:
+      url: git@github.com:org/repo.git
+      path: packages/internal_dep
+      ref: internal_dep-v0.0.1
+
+# to be updated to
+
+dependencies:
+  internal_dep:
+    git:
+      url: git@github.com:org/repo.git
+      path: packages/internal_dep
+      ref: internal_dep-v0.0.2
+```

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -443,8 +443,11 @@ Hint: try running "melos version --all" to include private packages.
     final contents = await pubspec.readAsString();
     String updatedContents;
 
-    if (package.pubSpec.dependencies[dependencyName] is GitReference ||
-        package.pubSpec.devDependencies[dependencyName] is GitReference) {
+    final gitReference =
+        package.pubSpec.dependencies[dependencyName] is GitReference ||
+            package.pubSpec.devDependencies[dependencyName] is GitReference;
+
+    if (gitReference) {
       updatedContents = contents.replaceAllMapped(
           dependencyTagReplaceRegex(dependencyName), (Match match) {
         return '${match.group(1)}$dependencyName-v${dependencyVersion.toString().substring(1)}';

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -105,6 +105,13 @@ RegExp dependencyVersionReplaceRegex(String dependencyName) {
   );
 }
 
+RegExp dependencyTagReplaceRegex(String dependencyName) {
+  return RegExp(
+    '''(?<tag_ref>^\\s+ref\\s?:\\s?)(?<opening_quote>["']?)(?<tag>$dependencyName-v[\\d]+\\.[\\d]+\\.[\\d]+)(?<closing_quote>['"]?)\$''',
+    multiLine: true,
+  );
+}
+
 class PackageFilter {
   PackageFilter({
     this.scope = const [],


### PR DESCRIPTION
## Description
This change implements the feature request #159 

When packages are hosted on git (ie, not published). When we call `melos version` the package's `pubspec.yaml` git ref tags should be updated to the latest git tag created.



## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
