### PR TITLE
feat: add flag to show relative paths when using `list` (FR #246)

### DIFF
--- a/docs/commands/list.mdx
+++ b/docs/commands/list.mdx
@@ -31,6 +31,15 @@ melos list --all
 melos list -a
 ```
 
+## --relative (-r)
+
+When printing output, use package paths relative to the root of the workspace. Defaults to `false` (or full paths).
+
+```bash
+melos list --relative
+melos list -r
+```
+
 ## --parsable (-p)
 
 Show parsable output instead of columnified view. Defaults to `false`.

--- a/packages/melos/lib/src/command_runner/list.dart
+++ b/packages/melos/lib/src/command_runner/list.dart
@@ -41,6 +41,13 @@ class ListCommand extends MelosCommand {
       help: 'Show parsable output instead of columnified view.',
     );
     argParser.addFlag(
+      'relative',
+      abbr: 'r',
+      negatable: false,
+      help:
+          'When printing output, use package paths relative to the root of the workspace.',
+    );
+    argParser.addFlag(
       'json',
       negatable: false,
       help: 'Show information as a JSON array.',
@@ -76,6 +83,7 @@ class ListCommand extends MelosCommand {
     final all = argResults!['all'] as bool;
     final parsable = argResults!['parsable'] as bool;
     final json = argResults!['json'] as bool;
+    final relative = argResults!['relative'] as bool;
     final graph = argResults!['graph'] as bool;
     final gviz = argResults!['gviz'] as bool;
 
@@ -92,6 +100,7 @@ class ListCommand extends MelosCommand {
       showPrivatePackages: all,
       long: long,
       filter: parsePackageFilter(config.path),
+      relativePaths: relative,
       kind: kind,
     );
   }

--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -7,6 +7,7 @@ mixin _ListMixin on _Melos {
   Future<void> list({
     bool showPrivatePackages = false,
     bool long = false,
+    bool relativePaths = false,
     PackageFilter? filter,
     ListOutputKind kind = ListOutputKind.column,
   }) async {
@@ -19,6 +20,7 @@ mixin _ListMixin on _Melos {
         return _listParsable(
           workspace,
           long: long,
+          relativePaths: relativePaths,
           showPrivatePackages: showPrivatePackages,
         );
       case ListOutputKind.column:
@@ -31,6 +33,7 @@ mixin _ListMixin on _Melos {
         return _listJson(
           workspace,
           showPrivatePackages: showPrivatePackages,
+          relativePaths: relativePaths,
           long: long,
         );
       case ListOutputKind.gviz:
@@ -102,21 +105,24 @@ mixin _ListMixin on _Melos {
   void _listParsable(
     MelosWorkspace workspace, {
     required bool showPrivatePackages,
+    required bool relativePaths,
     required bool long,
   }) {
     for (final package in workspace.filteredPackages.values) {
       if (package.isPrivate && !showPrivatePackages) continue;
+      final packagePath =
+          relativePaths ? package.pathRelativeToWorkspace : package.path;
       if (long) {
         logger?.stdout(
           <Object>[
-            package.path,
+            packagePath,
             package.name,
             package.version,
             if (package.isPrivate) 'PRIVATE',
           ].join(':'),
         );
       } else {
-        logger?.stdout(package.path);
+        logger?.stdout(packagePath);
       }
     }
   }
@@ -124,18 +130,21 @@ mixin _ListMixin on _Melos {
   void _listJson(
     MelosWorkspace workspace, {
     required bool showPrivatePackages,
+    required bool relativePaths,
     required bool long,
   }) {
     final jsonArrayItems = <Map<String, Object?>>[];
 
     for (final package in workspace.filteredPackages.values) {
       if (!showPrivatePackages && package.isPrivate) continue;
+      final packagePath =
+          relativePaths ? package.pathRelativeToWorkspace : package.path;
 
       final jsonObject = {
         'name': package.name,
         'version': package.version.toString(),
         'private': package.isPrivate,
-        'location': package.path,
+        'location': packagePath,
         'type': package.type.index
       };
 

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -206,6 +206,69 @@ c 0.0.0 packages/c
           );
         }),
       );
+
+      test(
+        'relativePaths flag prints relative paths only if true',
+        withMockFs(() async {
+          final workspaceDir = createMockWorkspaceFs(
+            packages: [
+              MockPackageFs(name: 'a'),
+              MockPackageFs(name: 'b'),
+              MockPackageFs(name: 'c'),
+            ],
+          );
+
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
+          await melos.list(
+            kind: ListOutputKind.parsable,
+            showPrivatePackages: true,
+            relativePaths: true,
+          );
+
+          expect(
+            logger.output,
+            equalsIgnoringAnsii(
+              '''
+packages/a
+packages/b
+packages/c
+''',
+            ),
+          );
+        }),
+      );
+
+      test(
+        'full package path is printed by default if relativePaths is false or not set',
+        withMockFs(() async {
+          final workspaceDir = createMockWorkspaceFs(
+            packages: [
+              MockPackageFs(name: 'a'),
+              MockPackageFs(name: 'b'),
+              MockPackageFs(name: 'c'),
+            ],
+          );
+
+          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final melos = Melos(logger: logger, config: config);
+          await melos.list(
+            kind: ListOutputKind.parsable,
+            showPrivatePackages: true,
+          );
+
+          expect(
+            logger.output,
+            equalsIgnoringAnsii(
+              '''
+/melos_workspace/packages/a
+/melos_workspace/packages/b
+/melos_workspace/packages/c
+''',
+            ),
+          );
+        }),
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Feature implementation for #246.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
