### PR TITLE
feat: allow prefixes before conventional commit type

### DIFF
--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -13,6 +13,9 @@ Your Git project must be using [Conventional Commits](https://www.conventionalco
 a widely used specification for commit messages which are readable by humans and machines. Melos parses
 messages and detects exactly what sort of version upgrade is required.
 
+Melos supports prefixes before the conventional commit type, this is useful since some collaborative
+version control systems have non-configurable prefixes when they merge pull requests.
+
 ### Not using Conventional Commits?
 
 If an existing Git project is already established and does not use Conventional Commits, it is still

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -13,9 +13,9 @@ Your Git project must be using [Conventional Commits](https://www.conventionalco
 a widely used specification for commit messages which are readable by humans and machines. Melos parses
 messages and detects exactly what sort of version upgrade is required.
 
-Melos supports the `Merge ...` and `Merged ...` prefixes before the conventional commit type, this is
-useful since some collaborative version control systems use these non-configurable prefixes when they
-merge pull requests.
+Melos supports prefixes (like the `Merge ...` and `Merged ...` for example) before the conventional
+commit type, this is useful since some collaborative version control systems use these
+non-configurable prefixes when they merge pull requests.
 
 ### Not using Conventional Commits?
 

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -13,8 +13,9 @@ Your Git project must be using [Conventional Commits](https://www.conventionalco
 a widely used specification for commit messages which are readable by humans and machines. Melos parses
 messages and detects exactly what sort of version upgrade is required.
 
-Melos supports prefixes before the conventional commit type, this is useful since some collaborative
-version control systems have non-configurable prefixes when they merge pull requests.
+Melos supports the `Merge ...` and `Merged ...` prefixes before the conventional commit type, this is
+useful since some collaborative version control systems use these non-configurable prefixes when they
+merge pull requests.
 
 ### Not using Conventional Commits?
 

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -16,7 +16,7 @@
  */
 
 final _conventionalCommitRegex = RegExp(
-  r'^(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merged? \w+)',
+  r'(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merged? \w+)',
 );
 
 final _breakingChangeRegex =

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -16,7 +16,7 @@
  */
 
 final _conventionalCommitRegex = RegExp(
-  r'(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merged? \w+)',
+  r'(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merge \w+)',
 );
 
 final _breakingChangeRegex =

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -16,7 +16,7 @@
  */
 
 final _conventionalCommitRegex = RegExp(
-  r'(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merge \w+)',
+  r'^(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merged? \w+)',
 );
 
 final _breakingChangeRegex =

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -16,7 +16,7 @@
  */
 
 final _conventionalCommitRegex = RegExp(
-  r'^(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merge \w+)',
+  r'(?<type>build|chore|ci|docs|feat|fix|bug|perf|refactor|revert|style|test)(?<scope>\([a-zA-Z0-9_,\s\*]+\)?((?=:\s?)|(?=!:\s?)))?(?<breaking>!)?(?<description>:\s?.*)?|^(?<merge>Merge \w+)',
 );
 
 final _breakingChangeRegex =

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -93,7 +93,7 @@ void main() {
     test(
       'correctly parses commit with prefix before conventional commit type',
       () {
-        final commitMessage = 'Merged PR 404: feat(scope): new feature';
+        const commitMessage = 'Merged PR 404: feat(scope): new feature';
         final conventionalCommit = ConventionalCommit.tryParse(commitMessage);
         expect(conventionalCommit?.type, 'feat');
         expect(conventionalCommit?.scopes, ['scope']);

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -85,7 +85,7 @@ void main() {
         isNotNull,
       );
       expect(
-        ConventionalCommit.tryParse('Merged branch (test): fix(test): tests'),
+        ConventionalCommit.tryParse('Merged branch test to main: fix: test'),
         isNotNull,
       );
     });

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -77,7 +77,7 @@ void main() {
     test('accepts commit messages with prefix before conventional commit type',
         () {
       expect(
-        ConventionalCommit.tryParse('Merged PR 404: feat: new thing'),
+        ConventionalCommit.tryParse('Merged PR 404: feat(scope): new feature'),
         isNotNull,
       );
       expect(
@@ -89,6 +89,17 @@ void main() {
         isNotNull,
       );
     });
+
+    test(
+      'correctly parses commit with prefix before conventional commit type',
+      () {
+        final commitMessage = 'Merged PR 404: feat(scope): new feature';
+        final conventionalCommit = ConventionalCommit.tryParse(commitMessage);
+        expect(conventionalCommit?.type, 'feat');
+        expect(conventionalCommit?.scopes, ['scope']);
+        expect(conventionalCommit?.description, 'new feature');
+      },
+    );
 
     test('correctly handles messages with a `*` scope', () {
       final commit = ConventionalCommit.tryParse(commitMessageStarScope);

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -85,7 +85,7 @@ void main() {
         isNotNull,
       );
       expect(
-        ConventionalCommit.tryParse('Merged branch test to main: fix: test'),
+        ConventionalCommit.tryParse('Merged branch develop to main: fix: test'),
         isNotNull,
       );
     });

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -74,6 +74,23 @@ void main() {
       expect(ConventionalCommit.tryParse('feat(foo): new thing'), isNotNull);
     });
 
+    test('accepts commit messages with prefix before conventional commit type',
+        () {
+      expect(
+        ConventionalCommit.tryParse('Merged PR 404: feat: new thing'),
+        isNotNull,
+      );
+      expect(
+        ConventionalCommit.tryParse(
+            'Merge pull request #404: feat(foo):new thing'),
+        isNotNull,
+      );
+      expect(
+        ConventionalCommit.tryParse('Merged branch (test): fix(test): tests'),
+        isNotNull,
+      );
+    });
+
     test('correctly handles messages with a `*` scope', () {
       final commit = ConventionalCommit.tryParse(commitMessageStarScope);
       expect(commit, isNotNull);

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -81,8 +81,7 @@ void main() {
         isNotNull,
       );
       expect(
-        ConventionalCommit.tryParse(
-            'Merge pull request #404: feat(foo):new thing'),
+        ConventionalCommit.tryParse('Merge pull request #404: feat(foo):bar'),
         isNotNull,
       );
       expect(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR solves #258 by removing the first `^` from the check in `_conventionalCommitRegex`.
This enables users to use Melos on hosted git repositories where the system adds non-configurable prefixes when merging pull requests.

Example from Azure DevOps which uses `Merged`:

```
Merged PR 404: fix: Use correct path for signing
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
