### PR TITLE
docs: Add ApptiveGrid Flutter to projects using Melos

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,7 @@ The following projects are using Melos:
 - [ApptiveGrid/apptive_grid_flutter](https://github.com/ApptiveGrid/apptive_grid_flutter)
 
 > Submit a PR if you'd like to add your project to the list.
-> Update the [README.md](https://github.com/invertase/melos/edit/main/packages/melos/README.md) and the
+> Update the 
 > [docs](https://github.com/invertase/melos/edit/main/docs/index.mdx).
 
 ## License


### PR DESCRIPTION
Now that the ApptiveGrid Packages are public on Github I felt like it was time to put them in here.


Also I noticed that the List of projects is not in the main readme anymore so maybe it might be good to remove that prompt/reference from the documentation page?
