### PR TITLE
fix: hosted dependency version regex

### DIFF
--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -105,7 +105,7 @@ RegExp dependencyVersionReplaceRegex(String dependencyName) {
   );
 }
 
-// https://regex101.com/r/ob8xRv/1
+// https://regex101.com/r/HIeQaI/1
 RegExp hostedDependencyVersionReplaceRegex(String dependencyName) {
   return RegExp(
     '''(^[ \t]*?(?<dependency>$dependencyName)[ \\t]*?:[ \\t]*?[\\s\\S]*?[ \\t]*?version:[ \\t]*?)(?<version>any|\\^.*|["'^<>=]*\\d\\.\\d\\.\\d['"._ \\t<>=\\d-\\w+]*|\$)\$''',

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -108,7 +108,7 @@ RegExp dependencyVersionReplaceRegex(String dependencyName) {
 // https://regex101.com/r/ob8xRv/1
 RegExp hostedDependencyVersionReplaceRegex(String dependencyName) {
   return RegExp(
-    '''(^[ \t]*?(?<dependency>$dependencyName)[ \\t]*?:[ \\t]*?[\\s\\S]*?[ \\t]*?version:[ \\t]*?)(?<version>any|["'^<>=]*\\d\\.\\d\\.\\d['"._ \\t<>=\\d-\\w+]*|\$)\$''',
+    '''(^[ \t]*?(?<dependency>$dependencyName)[ \\t]*?:[ \\t]*?[\\s\\S]*?[ \\t]*?version:[ \\t]*?)(?<version>any|\\^.*|["'^<>=]*\\d\\.\\d\\.\\d['"._ \\t<>=\\d-\\w+]*|\$)\$''',
     multiLine: true,
   );
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Currently, the regex captured wrong version of the package. As we can see, I tried to find the version of `xetia_core` package, the expected result is ^1.12.0 but the actual result is "^1.0.0".

![](https://user-images.githubusercontent.com/20693888/159510931-af9c520e-4efd-4d9c-90ac-9aa96688e0d4.png)

After this fix, the regex captured expected result as below:

<img width="728" alt="image" src="https://user-images.githubusercontent.com/20693888/159538851-4255485b-c9c9-4c22-b699-5244c531165a.png">


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
