### PR TITLE
docs: Fix docs about `--manual-version (-V)`

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -116,5 +116,5 @@ Manually specify a version change for a package. Can be used multiple times. Eac
 ```bash
 melos version --manual-version=foo:patch
 melos version --manual-version=foo:1.0.0
-melos version -V=foo:1.0.0
+melos version -Vfoo:1.0.0
 ```


### PR DESCRIPTION
When using the shorthand syntax (`-V`), you don't use the equals (the shorthand is always a single character).
When using the complete syntax with `--`, the `=` is required (as documented).

![image](https://user-images.githubusercontent.com/882703/160963601-867d310c-ad49-4ecf-bdac-e7c3440abc1a.png)

## Description

Just updating a typo in the docs.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
