### PR TITLE
feat: add support for Dart/Flutter SDK at custom `sdkPath`

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -31,6 +31,16 @@ Supported hosts:
 repository: https://github.com/invertase/melos
 ```
 
+## `sdkPath`
+
+Path to the Dart/Flutter SDK that should be used, unless overridden though the command line.
+
+Relative paths are resolved relative to the `melos.yaml` file.
+
+```yaml
+sdkPath: .fvm/flutter_sdk
+```
+
 ## `packages`
 
 > required

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -37,6 +37,8 @@ Path to the Dart/Flutter SDK that should be used.
 
 Relative paths are resolved relative to the `melos.yaml` file.
 
+To use the system-wide SDK, provide the special value "auto".
+
 If the SDK path is specified though multiple mechanisms, the precedence from highest to lowest is:
 
 1. `--sdk-path` global command line option

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -33,9 +33,15 @@ repository: https://github.com/invertase/melos
 
 ## `sdkPath`
 
-Path to the Dart/Flutter SDK that should be used, unless overridden though the command line.
+Path to the Dart/Flutter SDK that should be used.
 
 Relative paths are resolved relative to the `melos.yaml` file.
+
+If the SDK path is specified though multiple mechanisms, the precedence from highest to lowest is:
+
+1. `--sdk-path` global command line option
+2. `MELOS_SDK_PATH` environment variable
+3. `sdkPath` in `melos.yaml`
 
 ```yaml
 sdkPath: .fvm/flutter_sdk

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -48,3 +48,8 @@ Note, this 'parent package' functionality only currently works when the 'child p
 ### `MELOS_PACKAGES`
 
 Define a comma delimited list of package names that Melos should focus on. This bypasses all filtering flags if defined.
+
+### `MELOS_SDK_PATH`
+
+The path to the Dart/Flutter SDK to use. This environment variable has precedence over the `sdkPath`
+option in `melos.yaml`, but is overridden by the command line option `--sdk-path`.

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -10,6 +10,7 @@ export 'src/commands/runner.dart'
         ListOutputKind;
 export 'src/common/exception.dart' show CancelledException, MelosException;
 export 'src/common/validation.dart' show MelosConfigException;
+export 'src/global_options.dart' show GlobalOptions;
 export 'src/package.dart' show Package, PackageFilter, PackageMap, PackageType;
 export 'src/workspace.dart' show IdeWorkspace, MelosWorkspace;
 export 'src/workspace_configs.dart'

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -54,7 +54,8 @@ class MelosCommandRunner extends CommandRunner<void> {
       globalOptionSdkPath,
       help: 'Path to the Dart/Flutter SDK that should be used. This command '
           'line option has precedence over the `sdkPath` option in the '
-          '`melos.yaml` configuration file. If the special value "auto" is '
+          '`melos.yaml` configuration file and the `MELOS_SDK_PATH` '
+          'environment variable. If the special value "auto" is '
           'given, the `sdkPath` setting in `melos.yaml` is ignored and '
           'the SDK is determined from the environment.',
     );

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -55,9 +55,8 @@ class MelosCommandRunner extends CommandRunner<void> {
       help: 'Path to the Dart/Flutter SDK that should be used. This command '
           'line option has precedence over the `sdkPath` option in the '
           '`melos.yaml` configuration file and the `MELOS_SDK_PATH` '
-          'environment variable. If the special value "auto" is '
-          'given, the `sdkPath` setting in `melos.yaml` is ignored and '
-          'the SDK is determined from the environment.',
+          'environment variable. To use the system-wide SDK, provide '
+          'the special value "auto".',
     );
 
     addCommand(ExecCommand(config));

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -17,6 +17,7 @@
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+
 import 'command_runner/bootstrap.dart';
 import 'command_runner/clean.dart';
 import 'command_runner/exec.dart';
@@ -35,7 +36,7 @@ import 'workspace_configs.dart';
 /// ```dart
 /// final melos = MelosCommandRunner();
 ///
-/// await melos.run(['boostrap']);
+/// await melos.run(['bootstrap']);
 /// ```
 class MelosCommandRunner extends CommandRunner<void> {
   MelosCommandRunner(MelosWorkspaceConfig config)
@@ -45,9 +46,17 @@ class MelosCommandRunner extends CommandRunner<void> {
           usageLineLength: terminalWidth,
         ) {
     argParser.addFlag(
-      'verbose',
+      globalOptionVerbose,
       negatable: false,
       help: 'Enable verbose logging.',
+    );
+    argParser.addOption(
+      globalOptionSdkPath,
+      help: 'Path to the Dart/Flutter SDK that should be used. This command '
+          'line option has precedence over the `sdkPath` option in the '
+          '`melos.yaml` configuration file. If the special value "auto" is '
+          'given, the `sdkPath` setting in `melos.yaml` is ignored and '
+          'the SDK is determined from the environment.',
     );
 
     addCommand(ExecCommand(config));

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -4,6 +4,7 @@ import 'package:cli_util/cli_logging.dart';
 
 import '../common/glob.dart';
 import '../common/utils.dart';
+import '../global_options.dart';
 import '../package.dart';
 import '../workspace_configs.dart';
 
@@ -12,8 +13,10 @@ abstract class MelosCommand extends Command<void> {
 
   final MelosWorkspaceConfig config;
 
-  Logger? get logger =>
-      globalResults!['verbose'] as bool ? Logger.verbose() : Logger.standard();
+  /// The global Melos options parsed from the command line.
+  late final global = _parseGlobalOptions();
+
+  Logger? get logger => global.verbose ? Logger.verbose() : Logger.standard();
 
   /// The `melos.yaml` configuration for this command.
   /// see [ArgParser.allowTrailingOptions]
@@ -25,6 +28,13 @@ abstract class MelosCommand extends Command<void> {
     usageLineLength: terminalWidth,
     allowTrailingOptions: allowTrailingOptions,
   );
+
+  GlobalOptions _parseGlobalOptions() {
+    return GlobalOptions(
+      verbose: globalResults![globalOptionVerbose]! as bool,
+      sdkPath: globalResults![globalOptionSdkPath] as String?,
+    );
+  }
 
   void setupPackageFilterParser() {
     argParser.addFlag(

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -43,6 +43,7 @@ class BootstrapCommand extends MelosCommand {
     final melos = Melos(logger: logger, config: config);
 
     return melos.bootstrap(
+      global: global,
       filter: parsePackageFilter(config.path),
     );
   }

--- a/packages/melos/lib/src/command_runner/clean.dart
+++ b/packages/melos/lib/src/command_runner/clean.dart
@@ -38,6 +38,7 @@ class CleanCommand extends MelosCommand {
     final melos = Melos(logger: logger, config: config);
 
     await melos.clean(
+      global: global,
       filter: parsePackageFilter(config.path),
     );
   }

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -63,6 +63,7 @@ class ExecCommand extends MelosCommand {
       execArgs,
       concurrency: concurrency,
       failFast: failFast,
+      global: global,
       filter: packageFilter,
     );
   }

--- a/packages/melos/lib/src/command_runner/list.dart
+++ b/packages/melos/lib/src/command_runner/list.dart
@@ -91,6 +91,7 @@ class ListCommand extends MelosCommand {
 
     return melos.list(
       long: long,
+      global: global,
       filter: parsePackageFilter(config.path),
       relativePaths: relative,
       kind: kind,

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -61,6 +61,7 @@ class PublishCommand extends MelosCommand {
     final filter = parsePackageFilter(config.path);
 
     return melos.publish(
+      global: global,
       filter: filter,
       dryRun: dryRun,
       force: yes,

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -217,6 +217,7 @@ class VersionCommand extends MelosCommand {
       }
 
       await melos.version(
+        global: global,
         filter: parsePackageFilter(config.path),
         force: force,
         gitTag: tag,

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -5,15 +5,20 @@ final _warningLabel = AnsiStyles.yellow('WARNING');
 final _checkLabel = AnsiStyles.greenBright('✓');
 
 mixin _BootstrapMixin on _CleanMixin {
-  Future<void> bootstrap({PackageFilter? filter}) async {
-    final workspace = await createWorkspace(filter: filter);
+  Future<void> bootstrap({GlobalOptions? global, PackageFilter? filter}) async {
+    final workspace = await createWorkspace(global: global, filter: filter);
 
     return _runLifecycle(
       workspace,
       ScriptLifecycle.bootstrap,
       () async {
-        final pubCommandForLogging =
-            "${workspace.isFlutterWorkspace ? "flutter " : "dart "}pub get";
+        final pubCommandForLogging = [
+          ...pubCommandExecArgs(
+            useFlutter: workspace.isFlutterWorkspace,
+            workspace: workspace,
+          ),
+          'get'
+        ].join(' ');
 
         logger?.stdout(AnsiStyles.yellow.bold('melos bootstrap'));
         logger?.stdout('   └> ${AnsiStyles.cyan.bold(workspace.path)}\n');
@@ -61,7 +66,7 @@ mixin _BootstrapMixin on _CleanMixin {
   Future<void> _linkPackagesWithPubspecOverrides(
     MelosWorkspace workspace,
   ) async {
-    if (!isPubspecOverridesSupported) {
+    if (!workspace.isPubspecOverridesSupported) {
       logger?.stderr(
         '$_warningLabel: Dart 2.17.0 or greater is required to use Melos with '
         'pubspec overrides.',
@@ -88,7 +93,7 @@ mixin _BootstrapMixin on _CleanMixin {
         );
       },
       parallelism: workspace.config.commands.bootstrap.runPubGetInParallel &&
-              canRunPubGetConcurrently
+              workspace.canRunPubGetConcurrently
           ? null
           : 1,
     ).drain<void>();
@@ -167,7 +172,7 @@ mixin _BootstrapMixin on _CleanMixin {
           return package;
         },
         parallelism: workspace.config.commands.bootstrap.runPubGetInParallel &&
-                canRunPubGetConcurrently
+                workspace.canRunPubGetConcurrently
             ? null
             : 1,
       );
@@ -177,10 +182,14 @@ mixin _BootstrapMixin on _CleanMixin {
     Package package, {
     bool inTemporaryProject = false,
   }) async {
-    final pubGetArgs = ['pub', 'get'];
-    final execArgs = package.isFlutterPackage
-        ? ['flutter', ...pubGetArgs]
-        : [if (utils.isPubSubcommand()) 'dart', ...pubGetArgs];
+    final execArgs = [
+      ...pubCommandExecArgs(
+        useFlutter: package.isFlutterApp,
+        workspace: workspace,
+      ),
+      'get',
+    ];
+
     final executable = currentPlatform.isWindows ? 'cmd' : '/bin/sh';
     final packagePath = inTemporaryProject
         ? join(workspace.melosToolPath, package.pathRelativeToWorkspace)

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -184,7 +184,7 @@ mixin _BootstrapMixin on _CleanMixin {
   }) async {
     final execArgs = [
       ...pubCommandExecArgs(
-        useFlutter: package.isFlutterApp,
+        useFlutter: package.isFlutterPackage,
         workspace: workspace,
       ),
       'get',

--- a/packages/melos/lib/src/commands/clean.dart
+++ b/packages/melos/lib/src/commands/clean.dart
@@ -1,8 +1,8 @@
 part of 'runner.dart';
 
 mixin _CleanMixin on _Melos {
-  Future<void> clean({PackageFilter? filter}) async {
-    final workspace = await createWorkspace(filter: filter);
+  Future<void> clean({GlobalOptions? global, PackageFilter? filter}) async {
+    final workspace = await createWorkspace(global: global, filter: filter);
 
     return _runLifecycle(
       workspace,

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -3,11 +3,12 @@ part of 'runner.dart';
 mixin _ExecMixin on _Melos {
   Future<void> exec(
     List<String> execArgs, {
+    GlobalOptions? global,
     PackageFilter? filter,
     int concurrency = 5,
     bool failFast = false,
   }) async {
-    final workspace = await createWorkspace(filter: filter);
+    final workspace = await createWorkspace(global: global, filter: filter);
     final packages = workspace.filteredPackages.values;
 
     await _execForAllPackages(

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -35,6 +35,9 @@ mixin _ExecMixin on _Melos {
       'MELOS_PACKAGE_VERSION': (package.version).toString(),
       'MELOS_PACKAGE_PATH': package.path,
       'MELOS_ROOT_PATH': workspace.path,
+      if (workspace.sdkPath != null) envKeyMelosSdkPath: workspace.sdkPath!,
+      if (workspace.childProcessPath != null)
+        'PATH': workspace.childProcessPath!,
     };
 
     // TODO what if it's not called 'example'?
@@ -67,8 +70,9 @@ mixin _ExecMixin on _Melos {
       environment.remove('MELOS_PARENT_PACKAGE_NAME');
       environment.remove('MELOS_PARENT_PACKAGE_VERSION');
       environment.remove('MELOS_PARENT_PACKAGE_PATH');
-      environment.remove('MELOS_PACKAGES');
-      environment.remove('MELOS_TERMINAL_WIDTH');
+      environment.remove(envKeyMelosPackages);
+      environment.remove(envKeyMelosSdkPath);
+      environment.remove(envKeyMelosTerminalWidth);
     }
 
     return startProcess(

--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -5,12 +5,13 @@ enum ListOutputKind { json, parsable, graph, gviz, column }
 
 mixin _ListMixin on _Melos {
   Future<void> list({
+    GlobalOptions? global,
     bool long = false,
     bool relativePaths = false,
     PackageFilter? filter,
     ListOutputKind kind = ListOutputKind.column,
   }) async {
-    final workspace = await createWorkspace(filter: filter);
+    final workspace = await createWorkspace(global: global, filter: filter);
 
     switch (kind) {
       case ListOutputKind.graph:

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -2,13 +2,14 @@ part of 'runner.dart';
 
 mixin _PublishMixin on _ExecMixin {
   Future<void> publish({
+    GlobalOptions? global,
     PackageFilter? filter,
     bool dryRun = true,
     bool gitTagVersion = true,
     // yes
     bool force = false,
   }) async {
-    final workspace = await createWorkspace(filter: filter);
+    final workspace = await createWorkspace(global: global, filter: filter);
 
     logger?.stdout(
       AnsiStyles.yellow.bold('melos publish${dryRun ? " --dry-run" : ''}'),
@@ -142,8 +143,7 @@ mixin _PublishMixin on _ExecMixin {
       'Publishing ${unpublishedPackages.length} packages to registry:',
     );
     final execArgs = [
-      if (isPubSubcommand()) 'dart',
-      'pub',
+      ...pubCommandExecArgs(useFlutter: false, workspace: workspace),
       'publish',
     ];
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -84,7 +84,7 @@ mixin _RunMixin on _Melos {
         ]),
         logger: logger,
       )
-        ..validate(commandSdkPath: config.sdkPath);
+        ..validate();
 
       final packages = workspace.filteredPackages.values.toList();
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -83,7 +83,8 @@ mixin _RunMixin on _Melos {
           ...config.ignore,
         ]),
         logger: logger,
-      );
+      )
+        ..validate();
 
       final packages = workspace.filteredPackages.values.toList();
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -84,7 +84,7 @@ mixin _RunMixin on _Melos {
         ]),
         logger: logger,
       )
-        ..validate();
+        ..validate(commandSdkPath: config.sdkPath);
 
       final packages = workspace.filteredPackages.values.toList();
 

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -99,7 +99,7 @@ abstract class _Melos {
       filter: filterWithEnv,
       logger: logger,
     ))
-      ..validate();
+      ..validate(commandSdkPath: global?.sdkPath);
   }
 
   Future<void> _runLifecycle(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -28,6 +28,7 @@ import '../common/utils.dart';
 import '../common/utils.dart' as utils;
 import '../common/versioning.dart' as versioning;
 import '../common/workspace_changelog.dart';
+import '../global_options.dart';
 import '../package.dart';
 import '../prompts/prompt.dart' as prompts;
 import '../scripts.dart';
@@ -72,7 +73,10 @@ abstract class _Melos {
   Logger? get logger;
   MelosWorkspaceConfig get config;
 
-  Future<MelosWorkspace> createWorkspace({PackageFilter? filter}) async {
+  Future<MelosWorkspace> createWorkspace({
+    GlobalOptions? global,
+    PackageFilter? filter,
+  }) async {
     var filterWithEnv = filter;
 
     if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
@@ -89,11 +93,13 @@ abstract class _Melos {
       );
     }
 
-    return MelosWorkspace.fromConfig(
+    return (await MelosWorkspace.fromConfig(
       config,
+      global: global,
       filter: filterWithEnv,
       logger: logger,
-    );
+    ))
+      ..validate();
   }
 
   Future<void> _runLifecycle(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -99,7 +99,7 @@ abstract class _Melos {
       filter: filterWithEnv,
       logger: logger,
     ))
-      ..validate(commandSdkPath: global?.sdkPath);
+      ..validate();
   }
 
   Future<void> _runLifecycle(

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -4,6 +4,7 @@ mixin _VersionMixin on _RunMixin {
   /// Version packages automatically based on the git history or with manually
   /// specified versions.
   Future<void> version({
+    GlobalOptions? global,
     PackageFilter? filter,
     bool asPrerelease = false,
     bool asStableRelease = false,
@@ -36,6 +37,7 @@ mixin _VersionMixin on _RunMixin {
     }
 
     final workspace = await createWorkspace(
+      global: global,
       // We ignore `since` package list filtering on the 'version' command as it
       // already filters it itself, filtering here would map dependant version fail
       // as it won't be aware of any packages that have been filtered out here

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -67,6 +67,8 @@ String describeEnum(Object value) => value.toString().split('.').last;
 // This can be user defined or can come from package selection in `melos run`.
 const envKeyMelosPackages = 'MELOS_PACKAGES';
 
+const envKeyMelosSdkPath = 'MELOS_SDK_PATH';
+
 const envKeyMelosTerminalWidth = 'MELOS_TERMINAL_WIDTH';
 
 final melosPackageUri = Uri.parse('package:melos/melos.dart');
@@ -171,6 +173,20 @@ String printablePath(String path) {
   return p.posix
       .prettyUri(p.posix.normalize(path))
       .replaceAll(RegExp(r'[\/\\]+'), '/');
+}
+
+String get pathEnvVarSeparator => currentPlatform.isWindows ? ';' : ':';
+
+String addToPathEnvVar({
+  required String directory,
+  required String currentPath,
+  bool prepend = false,
+}) {
+  if (prepend) {
+    return '$directory$pathEnvVarSeparator$currentPath';
+  } else {
+    return '$currentPath$pathEnvVarSeparator$directory';
+  }
 }
 
 Future<String> getMelosRoot() async {

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -127,7 +127,10 @@ Version currentDartVersion(String dartTool) {
 
   final versionOutput = result.stdout as String;
   final versionString =
-      _dartSdkVersionRegexp.matchAsPrefix(versionOutput)!.group(1)!;
+      _dartSdkVersionRegexp.matchAsPrefix(versionOutput)?.group(1);
+  if (versionString == null) {
+    throw Exception('Unable to parse Dart version from:\n$versionOutput');
+  }
 
   return Version.parse(versionString);
 }

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -117,6 +117,7 @@ Version currentDartVersion(String dartTool) {
     dartTool,
     ['--version'],
     stdoutEncoding: utf8,
+    stderrEncoding: utf8,
   );
 
   if (result.exitCode != 0) {
@@ -125,7 +126,11 @@ Version currentDartVersion(String dartTool) {
     );
   }
 
-  final versionOutput = result.stdout as String;
+  // Older Dart SDK versions output to stderr instead of stdout.
+  final stdout = result.stdout as String;
+  final stderr = result.stderr as String;
+  final versionOutput = stdout.trim().isEmpty ? stderr : stdout;
+
   final versionString =
       _dartSdkVersionRegexp.matchAsPrefix(versionOutput)?.group(1);
   if (versionString == null) {

--- a/packages/melos/lib/src/common/validation.dart
+++ b/packages/melos/lib/src/common/validation.dart
@@ -98,7 +98,7 @@ class MelosConfigException implements MelosException {
     Object? key,
     int? index,
     String? path,
-  }) : this('${_descriptor(key: key, index: index, path: path)} is is required but missing');
+  }) : this('${_descriptor(key: key, index: index, path: path)} is required but missing');
 
   MelosConfigException.invalidType({
     required Object expectedType,

--- a/packages/melos/lib/src/global_options.dart
+++ b/packages/melos/lib/src/global_options.dart
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/// Global options that apply to all Melos commands.
+class GlobalOptions {
+  const GlobalOptions({
+    this.verbose = false,
+    this.sdkPath,
+  });
+
+  /// Whether to print verbose output.
+  final bool verbose;
+
+  /// Path to the Dart/Flutter SDK that should be used.
+  final String? sdkPath;
+
+  Map<String, Object?> toJson() {
+    return {
+      'verbose': verbose,
+      'sdkPath': sdkPath,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlobalOptions &&
+          other.runtimeType == runtimeType &&
+          other.verbose == verbose &&
+          other.sdkPath == sdkPath;
+
+  @override
+  int get hashCode => verbose.hashCode ^ sdkPath.hashCode;
+
+  @override
+  String toString() {
+    return '''
+GlobalOptions(
+  verbose: $verbose,
+  sdkPath: $sdkPath,
+)''';
+  }
+}

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -814,6 +814,7 @@ class Package {
   /// This is determined by ensuring all the following conditions are met:
   ///  a) the package depends on the Flutter SDK.
   ///  b) the package does not define itself as a Flutter plugin inside pubspec.yaml.
+  ///  c) a lib/main.dart file exists in the package.
   bool get isFlutterApp {
     // Must directly depend on the Flutter SDK.
     if (!isFlutterPackage) return false;
@@ -821,7 +822,7 @@ class Package {
     // Must not have a Flutter plugin definition in it's pubspec.yaml.
     if (pubSpec.flutter?.plugin != null) return false;
 
-    return true;
+    return File(joinAll([path, 'lib', 'main.dart'])).existsSync();
   }
 
   bool get isAddToApp {

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -814,7 +814,6 @@ class Package {
   /// This is determined by ensuring all the following conditions are met:
   ///  a) the package depends on the Flutter SDK.
   ///  b) the package does not define itself as a Flutter plugin inside pubspec.yaml.
-  ///  c) a lib/main.dart file exists in the package.
   bool get isFlutterApp {
     // Must directly depend on the Flutter SDK.
     if (!isFlutterPackage) return false;
@@ -822,7 +821,7 @@ class Package {
     // Must not have a Flutter plugin definition in it's pubspec.yaml.
     if (pubSpec.flutter?.plugin != null) return false;
 
-    return File(joinAll([path, 'lib', 'main.dart'])).existsSync();
+    return true;
   }
 
   bool get isAddToApp {

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -186,7 +186,7 @@ class PackageFilter {
   /// Include/Exclude packages with `publish_to: none`.
   final bool? includePrivatePackages;
 
-  /// Include/exlude packages that are up-to-date on pub.dev
+  /// Include/exclude packages that are up-to-date on pub.dev
   final bool? published;
 
   /// Include/exclude packages that are null-safe.

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -265,12 +265,6 @@ String? resolveSdkPath({
     return null;
   }
 
-  /// Intentionally passing empty sdk-path from command should be treated as
-  /// pulling command from path.
-  if (commandSdkPath != null && commandSdkPath.isEmpty) {
-    return null;
-  }
-
   /// If the sdk path is a relative one, prepend the workspace path
   /// to make it a valid full absolute path now.
   if (sdkPath != null && p.isRelative(sdkPath)) {

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -131,8 +131,13 @@ class MelosWorkspace {
   /// such as pub install.
   late final String melosToolPath = p.join(path, '.dart_tool', 'melos_tool');
 
-  void validate() {
-    if (sdkPath != null) {
+  /// Validate the workspace sdk setting.
+  /// If commandSdkPath is not null then we skip validation of the workspace sdk path
+  /// because the commandSdkPath has precedence over the the workspace one.
+  void validate({
+    required String? commandSdkPath,
+  }) {
+    if (sdkPath != null && commandSdkPath == null) {
       final dartTool = sdkTool('dart');
       if (!File(dartTool).existsSync()) {
         throw MelosConfigException(

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -134,10 +134,8 @@ class MelosWorkspace {
   /// Validate the workspace sdk setting.
   /// If commandSdkPath is not null then we skip validation of the workspace sdk path
   /// because the commandSdkPath has precedence over the the workspace one.
-  void validate({
-    required String? commandSdkPath,
-  }) {
-    if (sdkPath != null && commandSdkPath == null) {
+  void validate() {
+    if (sdkPath != null) {
       final dartTool = sdkTool('dart');
       if (!File(dartTool).existsSync()) {
         throw MelosConfigException(

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -22,11 +22,14 @@ import 'package:cli_util/cli_logging.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
-import '../melos.dart';
 import 'common/intellij_project.dart';
 import 'common/platform.dart';
 import 'common/pub_dependency_list.dart';
 import 'common/utils.dart' as utils;
+import 'common/validation.dart';
+import 'global_options.dart';
+import 'package.dart';
+import 'workspace_configs.dart';
 
 class IdeWorkspace {
   IdeWorkspace._(this._workspace);
@@ -147,9 +150,10 @@ class MelosWorkspace {
           prepend: true,
         );
 
-  /// Validate the workspace sdk setting.
-  /// If commandSdkPath is not null then we skip validation of the workspace sdk path
-  /// because the commandSdkPath has precedence over the the workspace one.
+  /// Validates this workspace against the environment.
+  ///
+  /// By making this a separate method we can create workspaces for testing
+  /// which are not strictly valid.
   void validate() {
     if (sdkPath != null) {
       final dartTool = sdkTool('dart');
@@ -267,8 +271,8 @@ class MelosWorkspace {
   }
 }
 
-/// Takes the raw sdkPaths from the workspace config file and the command line
-/// and resolves the final path.
+/// Takes the raw SDK paths from the workspace config file, the environment
+/// variable and the command line and resolves the final path.
 ///
 /// The path provided through the command line takes precedence over the path
 /// from the config file.

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -262,6 +262,12 @@ String? resolveSdkPath({
     return null;
   }
 
+  /// Intentionally passing empty sdk-path from command should be treated as
+  /// pulling command from path.
+  if (commandSdkPath != null && commandSdkPath.isEmpty) {
+    return null;
+  }
+
   /// If the sdk path is a relative one, prepend the workspace path
   /// to make it a valid full absolute path now.
   if (sdkPath != null && p.isRelative(sdkPath)) {

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -572,7 +572,7 @@ You must have one of the following to be a valid Melos workspace:
   final CommandConfigs commands;
 
   /// Path to the Dart/Flutter SDK that should be used, unless overridden though
-  /// the command line.
+  /// the command line option or the environment variable.
   final String? sdkPath;
 
   /// Validates this workspace configuration for consistency.

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -359,6 +359,7 @@ class MelosWorkspaceConfig {
   MelosWorkspaceConfig({
     required this.path,
     required this.name,
+    this.sdkPath,
     this.repository,
     required this.packages,
     this.ignore = const [],
@@ -438,10 +439,16 @@ class MelosWorkspaceConfig {
       map: yaml,
     );
 
+    final sdkPath = assertKeyIsA<String?>(
+      key: 'sdkPath',
+      map: yaml,
+    );
+
     return MelosWorkspaceConfig(
       path: path,
       name: name,
       repository: repository,
+      sdkPath: sdkPath,
       packages: packages
           .map((package) => createGlob(package, currentDirectoryPath: path))
           .toList(),
@@ -563,6 +570,10 @@ You must have one of the following to be a valid Melos workspace:
   ///
   /// This allows customizing the default behavior of melos commands.
   final CommandConfigs commands;
+
+  /// Path to the Dart/Flutter SDK that should be used, unless overridden though
+  /// the command line.
+  final String? sdkPath;
 
   /// Validates this workspace configuration for consistency.
   void _validate() {

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -251,7 +251,7 @@ Generating IntelliJ IDE files...
           },
           usePubspecOverrides: true,
         ),
-        skip: !isPubspecOverridesSupported,
+        skip: !isPubspecOverridesSupported(),
       );
 
       test(
@@ -263,7 +263,7 @@ Generating IntelliJ IDE files...
           },
           usePubspecOverrides: true,
         ),
-        skip: !isPubspecOverridesSupported,
+        skip: !isPubspecOverridesSupported(),
       );
 
       group('mergeMelosPubspecOverrides', () {

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -84,7 +84,7 @@ void main() {
         workspace: workspace,
       );
 
-      await melos.bootstrap();
+      await runMelosBootstrap(melos, logger);
 
       expect(
         logger.output,
@@ -177,7 +177,7 @@ Generating IntelliJ IDE files...
         config: config,
       );
 
-      await melos.bootstrap();
+      await runMelosBootstrap(melos, logger);
 
       expect(
         logger.output,
@@ -457,7 +457,7 @@ dependency_overrides:
       );
 
       await expectLater(
-        melos.bootstrap(),
+        runMelosBootstrap(melos, logger),
         throwsA(
           isA<BootstrapException>()
               .having((e) => e.package.name, 'package.name', 'a'),
@@ -487,6 +487,16 @@ e-Because a depends on package_that_does_not_exists any which doesn't exist (cou
 
     test('can supports package filter', () {}, skip: true);
   });
+}
+
+Future<void> runMelosBootstrap(Melos melos, TestLogger logger) async {
+  try {
+    await melos.bootstrap();
+  } on BootstrapException {
+    // ignore: avoid_print
+    print(logger.output);
+    rethrow;
+  }
 }
 
 /// Tests whether dependencies are resolved correctly.
@@ -581,13 +591,7 @@ Future<void> dependencyResolutionTest(
     config: config,
   );
 
-  try {
-    await melos.bootstrap();
-  } on BootstrapException {
-    // ignore: avoid_print
-    print(logger.output);
-    rethrow;
-  }
+  await runMelosBootstrap(melos, logger);
 
   await Future.wait<void>(packages.keys.map(validatePackage));
 }

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -457,7 +457,7 @@ dependency_overrides:
       );
 
       await expectLater(
-        runMelosBootstrap(melos, logger),
+        melos.bootstrap(),
         throwsA(
           isA<BootstrapException>()
               .having((e) => e.package.name, 'package.name', 'a'),

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -77,7 +77,12 @@ void main() {
 
       final logger = TestLogger();
       final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(config);
       final melos = Melos(logger: logger, config: config);
+      final pubExecArgs = pubCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
+      );
 
       await melos.bootstrap();
 
@@ -88,7 +93,7 @@ void main() {
 melos bootstrap
    └> ${workspaceDir.path}
 
-Running "dart pub get" in workspace packages...
+Running "${pubExecArgs.join(' ')} get" in workspace packages...
   ✓ a
     └> packages/a
 
@@ -441,9 +446,14 @@ dependency_overrides:
 
       final logger = TestLogger();
       final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(config);
       final melos = Melos(
         logger: logger,
         config: config,
+      );
+      final pubExecArgs = pubCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
       );
 
       await expectLater(
@@ -461,7 +471,7 @@ dependency_overrides:
 melos bootstrap
    └> ${workspaceDir.path}
 
-Running "dart pub get" in workspace packages...
+Running "${pubExecArgs.join(' ')} get" in workspace packages...
   - a
     └> packages/a
 e-    └> Failed to install.

--- a/packages/melos/test/mock_workspace_fs.dart
+++ b/packages/melos/test/mock_workspace_fs.dart
@@ -32,7 +32,6 @@ Directory createMockWorkspaceFs({
   Iterable<MockPackageFs> packages = const [],
   bool setCwdToWorkspace = true,
   bool? intellij,
-  String? sdkPath,
 }) {
   assert(
     IOOverrides.current is MockFs,
@@ -45,7 +44,6 @@ Directory createMockWorkspaceFs({
     workspaceName,
     workspacePackagesGlobs,
     intellij: intellij,
-    sdkPath: sdkPath,
   );
 
   // Sythesize a "package" (enough to satisfy our test requirements) for each
@@ -69,7 +67,6 @@ void _createMelosConfig(
   String workspaceName,
   Iterable<String> workspacePackagesGlobs, {
   required bool? intellij,
-  String? sdkPath,
 }) {
   final melosYaml = File(join(workspaceRoot, 'melos.yaml'));
 
@@ -82,15 +79,6 @@ packages:
 ${_yamlStringList(workspacePackagesGlobs)}
 ''',
   );
-
-  if (sdkPath != null && sdkPath.isNotEmpty) {
-    melosYaml.writeAsStringSync(
-      '''
-sdkPath: $sdkPath
-''',
-      mode: FileMode.append,
-    );
-  }
 
   if (intellij != null) {
     melosYaml.writeAsStringSync(

--- a/packages/melos/test/mock_workspace_fs.dart
+++ b/packages/melos/test/mock_workspace_fs.dart
@@ -32,6 +32,7 @@ Directory createMockWorkspaceFs({
   Iterable<MockPackageFs> packages = const [],
   bool setCwdToWorkspace = true,
   bool? intellij,
+  String? sdkPath,
 }) {
   assert(
     IOOverrides.current is MockFs,
@@ -44,6 +45,7 @@ Directory createMockWorkspaceFs({
     workspaceName,
     workspacePackagesGlobs,
     intellij: intellij,
+    sdkPath: sdkPath,
   );
 
   // Sythesize a "package" (enough to satisfy our test requirements) for each
@@ -67,6 +69,7 @@ void _createMelosConfig(
   String workspaceName,
   Iterable<String> workspacePackagesGlobs, {
   required bool? intellij,
+  String? sdkPath,
 }) {
   final melosYaml = File(join(workspaceRoot, 'melos.yaml'));
 
@@ -79,6 +82,15 @@ packages:
 ${_yamlStringList(workspacePackagesGlobs)}
 ''',
   );
+
+  if (sdkPath != null && sdkPath.isNotEmpty) {
+    melosYaml.writeAsStringSync(
+      '''
+sdkPath: $sdkPath
+''',
+      mode: FileMode.append,
+    );
+  }
 
   if (intellij != null) {
     melosYaml.writeAsStringSync(

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -231,6 +231,7 @@ class VirtualWorkspaceBuilder {
     this.melosYaml, {
     this.path = '/workspace',
     this.defaultPackagesPath = 'packages',
+    this.sdkPath,
     Logger? logger,
   }) : logger = logger ?? TestLogger() {
     if (currentPlatform.isWindows) {
@@ -250,6 +251,9 @@ class VirtualWorkspaceBuilder {
 
   /// The logger to build the workspace with.
   final Logger logger;
+
+  /// Optional Dart/Flutter SDK path.
+  final String? sdkPath;
 
   Map<String, Object?> get _defaultWorkspaceConfig => {
         'name': 'virtual-workspace',
@@ -289,6 +293,7 @@ class VirtualWorkspaceBuilder {
       allPackages: packageMap,
       filteredPackages: packageMap,
       logger: logger,
+      sdkPath: sdkPath,
     );
   }
 

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -1,0 +1,48 @@
+import 'package:melos/src/common/utils.dart';
+import 'package:path/path.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+void main() {
+  group('pubCommandExecArgs', () {
+    test('no sdk path specified', () {
+      final workspace = VirtualWorkspaceBuilder('').build();
+
+      expect(
+        pubCommandExecArgs(
+          workspace: workspace,
+          useFlutter: true,
+        ),
+        ['flutter', 'pub'],
+      );
+      expect(
+        pubCommandExecArgs(
+          workspace: workspace,
+          useFlutter: false,
+        ),
+        ['dart', 'pub'],
+      );
+    });
+
+    test('with sdk path specified', () {
+      final sdkPath = join('flutter_sdks', 'stable');
+      final workspace = VirtualWorkspaceBuilder('', sdkPath: sdkPath).build();
+
+      expect(
+        pubCommandExecArgs(
+          workspace: workspace,
+          useFlutter: true,
+        ),
+        [join(sdkPath, 'bin', 'flutter'), 'pub'],
+      );
+      expect(
+        pubCommandExecArgs(
+          workspace: workspace,
+          useFlutter: false,
+        ),
+        [join(sdkPath, 'bin', 'dart'), 'pub'],
+      );
+    });
+  });
+}

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -21,7 +21,7 @@ void main() {
           workspace: workspace,
           useFlutter: false,
         ),
-        ['dart', 'pub'],
+        [if (isPubSubcommand(workspace: workspace)) 'dart', 'pub'],
       );
     });
 

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -410,68 +410,6 @@ The packages that caused the problem are:
       });
     });
 
-    group('validate', () {
-      test(
-        'should not throw if no command sdk path is passed and workspace sdk path is valid',
-        withMockFs(() async {
-          const String? commandSdkPath = null;
-
-          final mockWorkspaceRootDir = createMockWorkspaceFs(
-            packages: [
-              MockPackageFs(name: 'a'),
-              MockPackageFs(name: 'b'),
-            ],
-          );
-
-          final aDir = Directory('${mockWorkspaceRootDir.path}/packages/a');
-          final config = await MelosWorkspaceConfig.fromDirectory(aDir);
-          final workspace = await MelosWorkspace.fromConfig(
-            config,
-            logger: TestLogger(),
-          );
-
-          expect(
-            () => workspace.validate(
-              commandSdkPath: commandSdkPath,
-            ),
-            returnsNormally,
-          );
-        }),
-      );
-
-      test(
-        'should not throw if a valid command sdk path is passed and workspace sdk path is not valid',
-        withMockFs(() async {
-          const commandSdkPath = '.sdk';
-
-          final mockWorkspaceRootDir = createMockWorkspaceFs(
-            packages: [
-              MockPackageFs(name: 'a'),
-              MockPackageFs(name: 'b'),
-            ],
-            sdkPath: '/some/invalid/path/to/sdk',
-          );
-
-          Directory('${mockWorkspaceRootDir.path}/.sdk').createSync();
-          File('${mockWorkspaceRootDir.path}/.sdk/dart').createSync();
-
-          final aDir = Directory('${mockWorkspaceRootDir.path}/packages/a');
-          final config = await MelosWorkspaceConfig.fromDirectory(aDir);
-          final workspace = await MelosWorkspace.fromConfig(
-            config,
-            logger: TestLogger(),
-          );
-
-          expect(
-            () => workspace.validate(
-              commandSdkPath: commandSdkPath,
-            ),
-            returnsNormally,
-          );
-        }),
-      );
-    });
-
     group('resolveSdkPath', () {
       final workspacePath = p.normalize('/workspace');
       final configSdkPath = p.normalize('/sdks/config');

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -410,6 +410,68 @@ The packages that caused the problem are:
       });
     });
 
+    group('validate', () {
+      test(
+        'should not throw if no command sdk path is passed and workspace sdk path is valid',
+        withMockFs(() async {
+          const String? commandSdkPath = null;
+
+          final mockWorkspaceRootDir = createMockWorkspaceFs(
+            packages: [
+              MockPackageFs(name: 'a'),
+              MockPackageFs(name: 'b'),
+            ],
+          );
+
+          final aDir = Directory('${mockWorkspaceRootDir.path}/packages/a');
+          final config = await MelosWorkspaceConfig.fromDirectory(aDir);
+          final workspace = await MelosWorkspace.fromConfig(
+            config,
+            logger: TestLogger(),
+          );
+
+          expect(
+            () => workspace.validate(
+              commandSdkPath: commandSdkPath,
+            ),
+            returnsNormally,
+          );
+        }),
+      );
+
+      test(
+        'should not throw if a valid command sdk path is passed and workspace sdk path is not valid',
+        withMockFs(() async {
+          const commandSdkPath = '.sdk';
+
+          final mockWorkspaceRootDir = createMockWorkspaceFs(
+            packages: [
+              MockPackageFs(name: 'a'),
+              MockPackageFs(name: 'b'),
+            ],
+            sdkPath: '/some/invalid/path/to/sdk',
+          );
+
+          Directory('${mockWorkspaceRootDir.path}/.sdk').createSync();
+          File('${mockWorkspaceRootDir.path}/.sdk/dart').createSync();
+
+          final aDir = Directory('${mockWorkspaceRootDir.path}/packages/a');
+          final config = await MelosWorkspaceConfig.fromDirectory(aDir);
+          final workspace = await MelosWorkspace.fromConfig(
+            config,
+            logger: TestLogger(),
+          );
+
+          expect(
+            () => workspace.validate(
+              commandSdkPath: commandSdkPath,
+            ),
+            returnsNormally,
+          );
+        }),
+      );
+    });
+
     group('resolveSdkPath', () {
       final workspacePath = p.normalize('/workspace');
       final configSdkPath = p.normalize('/sdks/config');

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -477,7 +477,7 @@ The packages that caused the problem are:
             commandSdkPath: null,
             workspacePath: workspacePath,
           ),
-          commandSdkPath,
+          envSdkPath,
         );
       });
 
@@ -510,7 +510,7 @@ The packages that caused the problem are:
             commandSdkPath: null,
             workspacePath: workspacePath,
           ),
-          configSdkPath,
+          envSdkPath,
         );
         expect(
           resolveSdkPath(

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -17,6 +17,7 @@
 import 'dart:io';
 
 import 'package:melos/src/common/glob.dart';
+import 'package:melos/src/common/utils.dart';
 import 'package:melos/src/package.dart';
 import 'package:melos/src/workspace.dart';
 import 'package:melos/src/workspace_configs.dart';
@@ -405,6 +406,110 @@ The packages that caused the problem are:
               isNot(containsDuplicates),
             );
           }),
+        );
+      });
+    });
+
+    group('resolveSdkPath', () {
+      final workspacePath = p.normalize('/workspace');
+      final configSdkPath = p.normalize('/sdks/config');
+      final commandSdkPath = p.normalize('/sdks/command-line');
+
+      test('should return null if no sdk path is provided', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: null,
+            commandSdkPath: null,
+            workspacePath: workspacePath,
+          ),
+          null,
+        );
+      });
+
+      test('commandSdkPath has precedence over configSdkPath', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: configSdkPath,
+            commandSdkPath: commandSdkPath,
+            workspacePath: workspacePath,
+          ),
+          commandSdkPath,
+        );
+      });
+
+      test('use configSdkPath if commandSdkPath is not specified', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: configSdkPath,
+            commandSdkPath: null,
+            workspacePath: workspacePath,
+          ),
+          configSdkPath,
+        );
+      });
+
+      test('allow trailing path separator in sdk paths', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: null,
+            commandSdkPath: p.join(commandSdkPath, ''),
+            workspacePath: workspacePath,
+          ),
+          commandSdkPath,
+        );
+        expect(
+          resolveSdkPath(
+            configSdkPath: p.join(configSdkPath, ''),
+            commandSdkPath: null,
+            workspacePath: workspacePath,
+          ),
+          configSdkPath,
+        );
+      });
+
+      test('create absolute path from a relative sdk path', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: null,
+            commandSdkPath: 'sdk',
+            workspacePath: workspacePath,
+          ),
+          p.join(workspacePath, 'sdk'),
+        );
+        expect(
+          resolveSdkPath(
+            configSdkPath: 'sdk',
+            commandSdkPath: null,
+            workspacePath: workspacePath,
+          ),
+          p.join(workspacePath, 'sdk'),
+        );
+      });
+
+      test('return null if sdk path is `auto`', () {
+        expect(
+          resolveSdkPath(
+            configSdkPath: autoSdkPathOptionValue,
+            commandSdkPath: null,
+            workspacePath: workspacePath,
+          ),
+          null,
+        );
+        expect(
+          resolveSdkPath(
+            configSdkPath: null,
+            commandSdkPath: autoSdkPathOptionValue,
+            workspacePath: workspacePath,
+          ),
+          null,
+        );
+        expect(
+          resolveSdkPath(
+            configSdkPath: autoSdkPathOptionValue,
+            commandSdkPath: autoSdkPathOptionValue,
+            workspacePath: workspacePath,
+          ),
+          null,
         );
       });
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR adds support for specifying the path to a Dart/Flutter SDK, instead of relying on what's in the path. 
This makes melos compatible with flutter version manager (fvm).

The SDK path can be specified though the following mechanisms, in order of highest to lowest precedence:

1. `--sdk-path` command line option
2. `MELOS_SDK_PATH` environment variable
3. `sdkPath` in `melos.yaml`

Closes #81

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
