### PR TITLE
docs: use `dart pub` instead of `pub` in `README.md`

### DIFF
--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -116,7 +116,7 @@ The following projects are using Melos:
 Install the latest Melos version as a global package via [Pub](https://pub.dev/).
 
 ```bash
-pub global activate melos
+dart pub global activate melos
 
 # Or alternatively to specify a specific version:
 # pub global activate melos 0.4.1


### PR DESCRIPTION
## Description
The `pub` command was removed. Instead, we should use `dart pub`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
