### PR TITLE
fix: use global options when running scripts

### DIFF
--- a/packages/melos/lib/src/command_runner/run.dart
+++ b/packages/melos/lib/src/command_runner/run.dart
@@ -52,6 +52,7 @@ class RunCommand extends MelosCommand {
 
     try {
       return await melos.run(
+        global: global,
         scriptName: scriptName,
         noSelect: noSelect,
         extraArgs: extraArgs,

--- a/packages/melos/lib/src/command_runner/script.dart
+++ b/packages/melos/lib/src/command_runner/script.dart
@@ -74,6 +74,7 @@ class ScriptCommand extends MelosCommand {
 
     try {
       return await melos.run(
+        global: global,
         scriptName: scriptName,
         noSelect: noSelect,
       );


### PR DESCRIPTION
## Description

This is a follow up for the PR adding support for SDK paths, to support `--sdk-path` with `melos run`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
