### PR TITLE
fix: Run Process.runSync in another shell to get Dart version

### DIFF
--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -120,6 +120,7 @@ Version currentDartVersion(String dartTool) {
     ['--version'],
     stdoutEncoding: utf8,
     stderrEncoding: utf8,
+    runInShell: true,
   );
 
   if (result.exitCode != 0) {

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -404,7 +404,11 @@ Future<int> startProcess(
 
 bool isPubSubcommand({required MelosWorkspace workspace}) {
   try {
-    return Process.runSync(workspace.sdkTool('pub'), ['--version']).exitCode !=
+    return Process.runSync(
+          workspace.sdkTool('pub'),
+          ['--version'],
+          runInShell: true,
+        ).exitCode !=
         0;
   } on ProcessException {
     return true;

--- a/packages/melos/test/test_assets/dart_wrapper
+++ b/packages/melos/test/test_assets/dart_wrapper
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+dart "$@"

--- a/packages/melos/test/test_assets/dart_wrapper.bat
+++ b/packages/melos/test/test_assets/dart_wrapper.bat
@@ -1,0 +1,2 @@
+@ECHO off
+dart %*

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -1,10 +1,37 @@
+import 'dart:io';
+
 import 'package:melos/src/common/utils.dart';
 import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
 
 void main() {
+  group('currentDartVersion', () {
+    test('returns correct version', () {
+      // We assume that the test is executed with the version of Dart that
+      // is on the path.
+      expect(
+        currentDartVersion('dart'),
+        Version.parse(Platform.version.split(' ')[0]),
+      );
+    });
+
+    test('supports absolute paths', () {
+      // We assume that the test is executed with the version of Dart that
+      // is on the path, which is what the dart_wrapper uses. The wrapper
+      // just makes it easy to construct an absolute path.
+      final dartWrapper =
+          p.join(Directory.current.path, 'test/test_assets/dart_wrapper');
+      expect(
+        currentDartVersion(dartWrapper),
+        Version.parse(Platform.version.split(' ')[0]),
+      );
+    });
+  });
+
   group('pubCommandExecArgs', () {
     test('no sdk path specified', () {
       final workspace = VirtualWorkspaceBuilder('').build();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When trying to get the dart version, `dart --version` should be run inside a separate shell to avoid failing when running in a sub process.

The failing of this command is actually used here:
https://github.com/invertase/melos/blob/431ecb275bf7169d71f9c19e4593abd3274a46ca/packages/melos/lib/src/common/utils.dart#L404-L411

This bug was introduced in https://github.com/invertase/melos/commit/740050c4dd67938d0674ddd37f0291d52f331bd4 since it changed how to dart version is retrieved. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
