### PR TITLE
feat: add `exec` option to scripts

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -50,6 +50,47 @@ A short description, shown when using `melos run` with no argument.
 
 The command to execute.
 
+## `scripts/*/exec`
+
+Execute a script in multiple packages through `melos exec`.
+
+This options must either contain the command to execute in multiple packages or the options for the
+`melos exec` command.
+
+When using the default options for `melos exec`, it's easiest to specify the command in the `exec`
+option:
+
+```yaml
+scripts:
+  hello:
+    exec: echo 'Hello $(dirname $PWD)'
+```
+
+If you need to provide options for the `exec` command, specify them in the `exec` option and
+specify the command in the `run` option:
+
+```yaml
+scripts:
+  hello:
+    run: echo 'Hello $(dirname $PWD)'
+    exec:
+      concurrency: 1
+```
+
+See the [`select-package`](#scriptsselect-package) option for filtering the packages to execute
+the command in.
+
+## `scripts/*/exec/concurrency`
+
+Defines the max concurrency value of how many packages will execute the command in at any one time.
+Defaults to `5`.
+
+## `scripts/*/exec/failFast`
+
+Whether `exec` should fail fast and not execute the script in further packages if the script fails
+in an individual package.
+Defaults to `false`.
+
 ## `scripts/*/env`
 
 A map of environment variables that will be passed to the executed command.
@@ -64,7 +105,7 @@ The `hello_flutter` script below is only executed in Flutter packages:
 ```yaml
 scripts:
   hello_flutter:
-    run: melos exec -- "echo 'Hello $(dirname $PWD)'"
+    exec: echo 'Hello $(dirname $PWD)'
     select-package:
       flutter: true
 ```

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -77,7 +77,8 @@ packages:
   - packages/**
 
 scripts:
-  analyze: melos exec -- "dart analyze ."
+  analyze:
+    exec: dart analyze .
 ```
 
 Then execute the command by running `melos run analyze`.

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -31,7 +31,7 @@ mixin _RunMixin on _Melos {
     logger?.stdout('');
     logger?.stdout(AnsiStyles.yellow.bold('melos run ${script.name}'));
     logger?.stdout(
-      '   └> ${AnsiStyles.cyan.bold(script.run.replaceAll('\n', ''))}',
+      '   └> ${AnsiStyles.cyan.bold(script.effectiveRun.replaceAll('\n', ''))}',
     );
 
     if (exitCode != 0) {
@@ -146,7 +146,7 @@ mixin _RunMixin on _Melos {
       environment[envKeyMelosPackages] = packagesEnv;
     }
 
-    final scriptSource = script.run;
+    final scriptSource = script.effectiveRun;
     final scriptParts = scriptSource.split(' ');
 
     logger?.stdout(AnsiStyles.yellow.bold('melos run ${script.name}'));

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import 'package:melos/melos.dart';
 import 'package:melos/src/common/git_repository.dart';
 import 'package:melos/src/common/platform.dart';
-import 'package:melos/src/workspace_configs.dart';
+import 'package:melos/src/scripts.dart';
 import 'package:test/test.dart';
 
 import 'matchers.dart';
@@ -274,6 +275,69 @@ void main() {
     });
   });
 
+  group('Scripts', () {
+    group('exec', () {
+      test('supports specifying command through "exec"', () {
+        final scripts = Scripts.fromYaml(
+          createYamlMap({
+            'a': {
+              'exec': 'b',
+            },
+          }),
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.run, 'b');
+        expect(scripts['a']!.exec, ExecOptions());
+      });
+
+      test('supports specifying command through "run"', () {
+        final scripts = Scripts.fromYaml(
+          createYamlMap({
+            'a': {
+              'run': 'b',
+              'exec': <String, Object?>{},
+            },
+          }),
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.run, 'b');
+        expect(scripts['a']!.exec, ExecOptions());
+      });
+
+      test('supports specifying exec options', () {
+        final scripts = Scripts.fromYaml(
+          createYamlMap({
+            'a': {
+              'run': 'b',
+              'exec': {
+                'concurrency': 1,
+                'failFast': true,
+              },
+            },
+          }),
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.run, 'b');
+        expect(scripts['a']!.exec, ExecOptions(concurrency: 1, failFast: true));
+      });
+
+      test('throws when specifying command in "run" and "exec"', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'exec': 'b',
+                'run': 'c',
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ),
+          throwsA(isA<MelosConfigException>()),
+        );
+      });
+    });
+  });
+
   group('MelosWorkspaceConfig', () {
     test(
         'throws if commands.version.linkToCommits == true but repository is missing',
@@ -285,7 +349,7 @@ void main() {
           commands: const CommandConfigs(
             version: VersionCommandConfigs(linkToCommits: true),
           ),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         ),
         throwsMelosConfigException(),
       );
@@ -301,7 +365,7 @@ void main() {
           commands: const CommandConfigs(
             version: VersionCommandConfigs(linkToCommits: true),
           ),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         ),
         returnsNormally,
       );
@@ -314,7 +378,7 @@ void main() {
             createYamlMap({
               'packages': <Object?>['*']
             }),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -324,7 +388,7 @@ void main() {
         expect(
           () => MelosWorkspaceConfig.fromYaml(
             createYamlMap({'name': <Object?>[]}, defaults: configMapDefaults),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -335,7 +399,7 @@ void main() {
           expect(
             () => MelosWorkspaceConfig.fromYaml(
               createYamlMap({'name': name}, defaults: configMapDefaults),
-              path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+              path: testWorkspacePath,
             ),
             throwsMelosConfigException(),
           );
@@ -365,19 +429,19 @@ void main() {
       test('accepts valid dart package name', () {
         MelosWorkspaceConfig.fromYaml(
           createYamlMap({'name': 'hello_world'}, defaults: configMapDefaults),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         );
         MelosWorkspaceConfig.fromYaml(
           createYamlMap({'name': 'hello2'}, defaults: configMapDefaults),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         );
         MelosWorkspaceConfig.fromYaml(
           createYamlMap({'name': 'HELLO'}, defaults: configMapDefaults),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         );
         MelosWorkspaceConfig.fromYaml(
           createYamlMap({'name': 'hello-world'}, defaults: configMapDefaults),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         );
       });
 
@@ -385,7 +449,7 @@ void main() {
         expect(
           () => MelosWorkspaceConfig.fromYaml(
             createYamlMap({'name': 'package_name'}),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -398,7 +462,7 @@ void main() {
               {'packages': <Object?, Object?>{}},
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -413,7 +477,7 @@ void main() {
               },
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -426,7 +490,7 @@ void main() {
               {'packages': <Object?>[]},
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -439,7 +503,7 @@ void main() {
               {'ignore': <Object?, Object?>{}},
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -454,7 +518,7 @@ void main() {
               },
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -467,7 +531,7 @@ void main() {
               {'repository': 42},
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -481,7 +545,7 @@ void main() {
               {'repository': 'https://example.com'},
               defaults: configMapDefaults,
             ),
-            path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
@@ -493,7 +557,7 @@ void main() {
             {'repository': 'https://github.com/invertase/melos'},
             defaults: configMapDefaults,
           ),
-          path: currentPlatform.isWindows ? r'\\workspace' : '/workspace',
+          path: testWorkspacePath,
         );
         final repository = config.repository! as GitHubRepository;
 
@@ -503,6 +567,9 @@ void main() {
     });
   });
 }
+
+final testWorkspacePath =
+    currentPlatform.isWindows ? r'\\workspace' : '/workspace';
 
 Map<String, Object?> createYamlMap(
   Map<String, Object?> source, {


### PR DESCRIPTION
This change adds the `exec` option to scripts,  which simplifies writing scripts that are executed in multiple packages through `melos exec`.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
