### PR TITLE
feat: Add --diff filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ To solve these (and many other) problems, some projects will organize their code
 To setup and use this melos mono repo locally for the purposes of contributing, clone it and run the following commands from the root of the repository:
 
 ```bash
-# Remove previous instances of melos:
-dart pub global deactivate melos
+# Install melos if it's not already installed:
+dart pub global activate melos
 
 # Activate 'melos' from path:
-dart pub global activate --source="path" . --executable="melos"
+melos activate
 
 # Confirm you now using a local development version:
 melos --help

--- a/docs/filters.mdx
+++ b/docs/filters.mdx
@@ -52,6 +52,18 @@ Only include packages that have been changed since the specified `ref`, e.g. a c
 melos exec --since=<commit hash> -- flutter build ios
 ```
 
+## --diff
+
+Only include packages that are different between the current working tree and the specified `ref`, e.g. a commit sha or git tag, or between two different refs.
+
+```bash
+# Run `flutter build ios` on all packages that are different between current branch and the specified commit hash
+melos exec --diff=<commit hash> -- flutter build ios
+
+# Run `flutter build ios` on all packages that are different between remote `main` branch and HEAD
+melos exec --diff=origin/main...HEAD -- flutter build ios
+```
+
 ## --dir-exists
 
 Include only packages where a specific directory exists inside the package.

--- a/melos.yaml
+++ b/melos.yaml
@@ -43,3 +43,11 @@ scripts:
     description: Run `flutter format` checks for all packages.
 
   version: dart run scripts/generate_version.dart
+
+  activate:
+    description: Activate the local version of melos for development.
+    run: dart pub global activate --source="path" . --executable="melos" --overwrite
+
+  activate:pub:
+    description: Activate the published version of melos.
+    run: dart pub global activate melos

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -12,7 +12,13 @@ export 'src/common/exception.dart' show CancelledException, MelosException;
 export 'src/common/validation.dart' show MelosConfigException;
 export 'src/global_options.dart' show GlobalOptions;
 export 'src/logging.dart' show MelosLogger, ToMelosLoggerExtension;
-export 'src/package.dart' show Package, PackageFilter, PackageMap, PackageType;
+export 'src/package.dart'
+    show
+        Package,
+        PackageFilter,
+        PackageMap,
+        PackageType,
+        InvalidPackageFilterException;
 export 'src/workspace.dart' show IdeWorkspace, MelosWorkspace;
 export 'src/workspace_configs.dart'
     show

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -92,6 +92,13 @@ abstract class MelosCommand extends Command<void> {
           '`ref`, e.g. a commit sha or git tag.',
     );
 
+    argParser.addOption(
+      filterOptionDiff,
+      valueHelp: 'ref',
+      help: 'Only include packages that are different between current branch '
+          'and the specified `ref`, e.g. a commit sha or git tag.',
+    );
+
     argParser.addMultiOption(
       filterOptionDirExists,
       valueHelp: 'dirRelativeToPackageRoot',
@@ -149,6 +156,7 @@ abstract class MelosCommand extends Command<void> {
 
     final since =
         sinceEnabled ? argResults![filterOptionSince] as String? : null;
+    final diff = argResults![filterOptionDiff] as String?;
     final scope = argResults![filterOptionScope] as List<String>? ?? [];
     final ignore = argResults![filterOptionIgnore] as List<String>? ?? [];
 
@@ -161,6 +169,7 @@ abstract class MelosCommand extends Command<void> {
           .toList()
         ..addAll(config.ignore),
       updatedSince: since,
+      diff: diff,
       includePrivatePackages: argResults![filterOptionPrivate] as bool?,
       published: argResults![filterOptionPublished] as bool?,
       nullSafe: argResults![filterOptionNullsafety] as bool?,

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -89,7 +89,7 @@ abstract class MelosCommand extends Command<void> {
       filterOptionSince,
       valueHelp: 'ref',
       help: 'Only include packages that have been changed since the specified '
-          '`ref`, e.g. a commit sha or git tag.',
+          '`ref`, e.g. a commit sha or git tag. Cannot be used with --diff.',
     );
 
     argParser.addOption(
@@ -97,7 +97,7 @@ abstract class MelosCommand extends Command<void> {
       valueHelp: 'ref',
       help: 'Only include packages that are different between current working '
           'tree and the specified `ref`, e.g. a commit sha or git tag, '
-          'or between two different refs.',
+          'or between two different refs. Cannot be used with --since.',
     );
 
     argParser.addMultiOption(

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -95,8 +95,9 @@ abstract class MelosCommand extends Command<void> {
     argParser.addOption(
       filterOptionDiff,
       valueHelp: 'ref',
-      help: 'Only include packages that are different between current branch '
-          'and the specified `ref`, e.g. a commit sha or git tag.',
+      help: 'Only include packages that are different between current working '
+          'tree and the specified `ref`, e.g. a commit sha or git tag, '
+          'or between two different refs.',
     );
 
     argParser.addMultiOption(

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -351,8 +351,7 @@ Future<bool> gitHasDiffInPackage(
   required MelosLogger logger,
 }) async {
   logger.trace(
-    '[GIT] Getting diff for package ${package.name} between '
-    '@ and "$diff".',
+    '[GIT] Getting $diff diff for package ${package.name}.',
   );
 
   final processResult = await gitExecuteCommand(

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -344,3 +344,28 @@ Future<bool> gitIsBehindUpstream({
 
   return isBehind;
 }
+
+Future<bool> gitHasDiffInPackage(
+  Package package, {
+  required String diff,
+  required MelosLogger logger,
+}) async {
+  logger.trace(
+    '[GIT] Getting diff for package ${package.name} between '
+    '@ and "$diff".',
+  );
+
+  final processResult = await gitExecuteCommand(
+    arguments: [
+      '--no-pager',
+      'diff',
+      '--name-status',
+      diff,
+      '--',
+      '.',
+    ],
+    workingDirectory: package.path,
+    logger: logger,
+  );
+  return (processResult.stdout as String).isNotEmpty;
+}

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -42,6 +42,7 @@ const filterOptionIgnore = 'ignore';
 const filterOptionDirExists = 'dir-exists';
 const filterOptionFileExists = 'file-exists';
 const filterOptionSince = 'since';
+const filterOptionDiff = 'diff';
 const filterOptionNullsafety = 'nullsafety';
 const filterOptionNoPrivate = 'no-private';
 const filterOptionPrivate = 'private';

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -185,7 +185,7 @@ class PackageFilter {
   /// Filter package based on whether they received changed since a specific git commit/tag ID.
   final String? updatedSince;
 
-  /// Filter package based on whether they received changed different between current branch and a specific git commit/tag ID.
+  /// Filter package based on whether they are different between specific git commit/tag ID.
   final String? diff;
 
   /// Include/Exclude packages with `publish_to: none`.

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -277,6 +277,12 @@ class Script {
       path: filtersPath,
     );
 
+    final diff = assertIsA<String?>(
+      value: yaml[filterOptionDiff],
+      key: filterOptionDiff,
+      path: filtersPath,
+    );
+
     final excludePrivatePackagesTmp = assertIsA<bool?>(
       value: yaml[filterOptionNoPrivate],
       key: filterOptionNoPrivate,
@@ -329,6 +335,7 @@ class Script {
       dependsOn: dependsOn,
       noDependsOn: noDependsOn,
       updatedSince: updatedSince,
+      diff: diff,
       includePrivatePackages: includePrivatePackages,
       published: published,
       nullSafe: nullSafe,


### PR DESCRIPTION
## Description

We found it extremely helpful to have the possibility to run melos on packages that are different between branches. As the `since` option does not really work with the difference I propose to introduce a `diff` option that will call `git diff` instead of `git log`.

The usage might be:
```sh
melos list --diff=some_branch
```
or
```sh
melos list --diff=origin/main...HEAD
```

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
