### PR TITLE
fix: find packages in matched directories

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -53,15 +53,17 @@ sdkPath: .fvm/flutter_sdk
 
 > required
 
-A list of local packages Melos will use to execute commands against. The list can be
-of specific paths or a [glob](https://docs.python.org/3/library/glob.html) pattern expansion format.
+A list of paths to local packages that are included in the Melos workspace. Each entry can be
+specific path or a [glob] pattern.
 
 ```yaml
 packages:
-  # e.g. all packages inside the /packages directory
+  # e.g. include all packages inside the `packages` directory at any level
   - packages/**
-  # e.g. including the workspace root as a package
-  - "*"
+  # e.g. include all packages inside the `packages` directory that are direct children
+  - packages/*
+  # e.g. include the package in the workspace root
+  - .
 ```
 
 > You can also reduce the scope of packages on a per-command basis via the [`--scope` filter](/filters#scope) flag.
@@ -70,13 +72,13 @@ packages:
 
 > required
 
-A list of local packages Melos will ignore when executing commands in the workspace. The list can be
-of specific paths or a [glob](https://docs.python.org/3/library/glob.html) pattern expansion format.
+A list of paths to local packages that are exluded from the Melos workspace. Each entry can be
+specific path or a [glob] pattern.
 
 ```yaml
 ignore:
   # e.g. ignore example apps
-  - "packages/**/*example"
+  - "packages/**/example"
 ```
 
 > You can also expand the scope of ignored packages on a per-command basis via the [`--scope` filter](/filters#scope) flag.
@@ -195,3 +197,5 @@ command:
   version:
     updateGitTagRefs: true
 ```
+
+[glob]: https://docs.python.org/3/library/glob.html

--- a/melos.yaml
+++ b/melos.yaml
@@ -2,7 +2,7 @@ name: Melos
 repository: https://github.com/invertase/melos
 packages:
   - packages/**
-  - "*"
+  - .
 
 command:
   version:

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -550,10 +550,11 @@ You must have one of the following to be a valid Melos workspace:
   /// The hosted git repository which contains the workspace.
   final HostedGitRepository? repository;
 
-  /// A list of paths to packages that are included in the melos workspace.
+  /// A list of [Glob]s for paths that should be searched for packages.
   final List<Glob> packages;
 
-  /// A list of paths to exclude from the melos workspace.
+  /// A list of [Glob]s for paths that should be excluded from the search for
+  /// packages.
   final List<Glob> ignore;
 
   /// A list of scripts that can be executed with `melos run` or will be executed

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -151,6 +151,104 @@ The packages that caused the problem are:
       );
     });
 
+    group('locate packages', () {
+      group('in workspace root', () {
+        test('by matching pubspec.yaml', () async {
+          final workspaceDir = createTemporaryWorkspaceDirectory(
+            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+              const {
+                'name': 'test',
+                'packages': ['*']
+              },
+              path: path,
+            ),
+          );
+
+          await createProject(
+            workspaceDir,
+            const PubSpec(name: 'a'),
+            path: '.',
+          );
+
+          final workspace = await MelosWorkspace.fromConfig(
+            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+            logger: TestLogger().toMelosLogger(),
+          );
+
+          expect(workspace.allPackages['a'], isNotNull);
+        });
+
+        test('by matching package directory', () async {
+          final workspaceDir = createTemporaryWorkspaceDirectory(
+            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+              const {
+                'name': 'test',
+                'packages': ['.']
+              },
+              path: path,
+            ),
+          );
+
+          await createProject(
+            workspaceDir,
+            const PubSpec(name: 'a'),
+            path: '.',
+          );
+
+          final workspace = await MelosWorkspace.fromConfig(
+            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+            logger: TestLogger().toMelosLogger(),
+          );
+
+          expect(workspace.allPackages['a'], isNotNull);
+        });
+      });
+
+      group('in child directory', () {
+        test('by matching pubspec.yaml', () async {
+          final workspaceDir = createTemporaryWorkspaceDirectory(
+            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+              const {
+                'name': 'test',
+                'packages': ['packages/a/*']
+              },
+              path: path,
+            ),
+          );
+
+          await createProject(workspaceDir, const PubSpec(name: 'a'));
+
+          final workspace = await MelosWorkspace.fromConfig(
+            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+            logger: TestLogger().toMelosLogger(),
+          );
+
+          expect(workspace.allPackages['a'], isNotNull);
+        });
+
+        test('by matching package directory', () async {
+          final workspaceDir = createTemporaryWorkspaceDirectory(
+            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+              const {
+                'name': 'test',
+                'packages': ['packages/a']
+              },
+              path: path,
+            ),
+          );
+
+          await createProject(workspaceDir, const PubSpec(name: 'a'));
+
+          final workspace = await MelosWorkspace.fromConfig(
+            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+            logger: TestLogger().toMelosLogger(),
+          );
+
+          expect(workspace.allPackages['a'], isNotNull);
+        });
+      });
+    });
+
     group('sdkPath', () {
       test('use SDK path from environment variable', () async {
         withMockPlatform(


### PR DESCRIPTION
Before this change, the `packages` and `ignore` patterns had to match `pubspec.yaml` for a package to be found.

Now packages are also found if a pattern matches a directory that contains a package.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
