### PR TITLE
refactor: enable more lint rules

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -34,6 +34,7 @@ linter:
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
+    - avoid_final_parameters
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
     - avoid_init_to_null
@@ -70,16 +71,20 @@ linter:
     - cast_nullable_to_non_nullable
     - close_sinks
     - comment_references
+    - conditional_uri_does_not_exist
     - constant_identifier_names
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
+    - depend_on_referenced_packages
     - deprecated_consistency
     - diagnostic_describe_all_properties
     - directives_ordering
+    - discarded_futures
     - do_not_use_environment
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
+    - eol_at_end_of_file
     - exhaustive_cases
     - file_names
     - flutter_style_todos
@@ -99,9 +104,12 @@ linter:
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
+    - no_leading_underscores_for_library_prefixes
+    - no_leading_underscores_for_local_identifiers
     - no_logic_in_create_state
     - no_runtimeType_toString
     - non_constant_identifier_names
+    - noop_primitive_operations
     - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
@@ -129,6 +137,7 @@ linter:
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
+    - prefer_final_parameters
     - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
     - prefer_function_declarations_over_variables
@@ -155,7 +164,9 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
+    - secure_pubspec_urls
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_child_properties_last
     - sort_constructors_first
@@ -170,11 +181,14 @@ linter:
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
+    - unnecessary_constructor_name
     - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
+    - unnecessary_late
     - unnecessary_new
     - unnecessary_null_aware_assignments
+    - unnecessary_null_aware_operator_on_extension_on_nullable
     - unnecessary_null_checks
     - unnecessary_null_in_if_null_operators
     - unnecessary_nullable_for_final_variable_declarations
@@ -185,9 +199,13 @@ linter:
     - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
+    - unnecessary_to_list_in_spreads
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously
+    - use_colored_box
+    - use_decorated_box
+    - use_enums
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools
@@ -199,6 +217,8 @@ linter:
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers
+    - use_super_parameters
+    - use_test_throws_matchers
     - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -70,11 +70,6 @@ linter:
     # especially as a library.
     avoid_catches_without_on_clauses: false
 
-    # Boring as it sometimes force a line of 81 characters to be split in two.
-    # As long as we try to respect that 80 characters limit, going slightly
-    # above is fine.
-    lines_longer_than_80_chars: false
-
     # Conflicts with disabling `implicit-dynamic`
     avoid_annotating_with_dynamic: false
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,13 +16,14 @@
 
 include: all_lint_rules.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
   errors:
     # Otherwise cause the import of all_lint_rules to warn because of some rules conflicts.
     # We explicitly enabled even conflicting rules and are fixing the conflict
-    # in this file
+    # in this file.
     included_file_warning: ignore
 
 linter:
@@ -31,16 +32,8 @@ linter:
     public_member_api_docs: false
 
     always_put_control_body_on_new_line: false
-    comment_references: true
-    prefer_constructors_over_static_methods: true
-    prefer_final_fields: true
-    omit_local_variable_types: true
-    avoid_equals_and_hash_code_on_mutable_classes: false
 
-    #############
-    # Conflicts with 'unecessary_final'
-    prefer_final_locals: true
-
+    # Deos not always make code more readable.
     cascade_invocations: false
 
     # Conflicts with `prefer_single_quotes`
@@ -54,7 +47,7 @@ linter:
     always_specify_types: false
 
     # Incompatible with `prefer_final_locals`
-    # Having immutable local variables makes larger functions more predictible
+    # Having immutable local variables makes larger functions more predictable
     # so we will use `prefer_final_locals` instead.
     unnecessary_final: false
 
@@ -88,9 +81,6 @@ linter:
     # conflicts with `prefer_relative_imports`
     always_use_package_imports: false
 
-    # Disabled for now until NNBD as it otherwise conflicts with `missing_return`
-    no_default_cases: false
-
     # False positive, null checks don't need a message
     prefer_asserts_with_message: false
 
@@ -100,8 +90,9 @@ linter:
     # Too many false positive (builders)
     diagnostic_describe_all_properties: false
 
-    # false positives (setter-like functions)
-    avoid_positional_boolean_parameters: false
-
     # Does not apply to providers
     prefer_const_constructors_in_immutables: false
+
+    # Not a common style and would add a lot of verbosity to function signature.
+    # 'parameter_assignments' already enforces this to an extent.
+    prefer_final_parameters: false

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -39,9 +39,9 @@ enum SemverReleaseType {
   major,
 }
 
-/// A representation of a parsed conventional commit message.
-/// Parsing is based upon the Conventional Commits 1.0.0 specification available
-/// at https://www.conventionalcommits.org/en/v1.0.0/
+/// A representation of a parsed conventional commit message. Parsing is based
+/// upon the Conventional Commits 1.0.0 specification available at
+/// https://www.conventionalcommits.org/en/v1.0.0/
 class ConventionalCommit {
   ConventionalCommit._({
     required this.header,
@@ -57,7 +57,7 @@ class ConventionalCommit {
 
   /// Create a new [ConventionalCommit] from a commit message [String].
   ///
-  /// ```dart
+  /// ```dart main
   /// var message = '''
   /// type(scope)!: commit message description
   ///
@@ -185,13 +185,14 @@ class ConventionalCommit {
   /// The type specified in this commit, e.g. `feat`.
   final String? type;
 
-  /// Whether this commit was a breaking change, e.g. `!` was specified after the scopes in the commit message.
+  /// Whether this commit was a breaking change, e.g. `!` was specified after
+  /// the scopes in the commit message.
   final bool isBreakingChange;
 
-  /// The description of the breaking change, e.g. the text after BREAKING CHANGE: <description>.
-  /// Will be null if [isBreakingChange] is false. Defaults to [description] if
-  /// the `BREAKING CHANGE:` footer format was not used, e.g. only `!` after the
-  /// commit type was specified..
+  /// The description of the breaking change, e.g. the text after BREAKING
+  /// CHANGE: <description>. Will be null if [isBreakingChange] is false.
+  /// Defaults to [description] if the `BREAKING CHANGE:` footer format was not
+  /// used, e.g. only `!` after the commit type was specified.
   final String? breakingChangeDescription;
 
   /// Whether this commit was a merge commit, e.g. `Merge #24 into main`
@@ -200,23 +201,24 @@ class ConventionalCommit {
   /// Commit message description (text after the scopes).
   final String? description;
 
-  /// The original commit message header (this is normally the first line of the commit message.)
+  /// The original commit message header (this is normally the first line of the
+  /// commit message.)
   final String header;
 
-  /// An optional body describing the change in more detail.
-  /// Note this can contain multiple paragraphs separated by new lines.
+  /// An optional body describing the change in more detail. Note this can
+  /// contain multiple paragraphs separated by new lines.
   final String? body;
 
   /// Footers other than BREAKING CHANGE: <description> may be provided and
-  /// follow a convention similar to git trailer format.
-  /// A footer’s token MUST use "-" in place of whitespace characters,
-  /// e.g., Acked-by (this helps differentiate the footer section from a
-  /// multi-paragraph body). An exception is made for BREAKING CHANGE, which
-  /// MAY also be used as a token.
+  /// follow a convention similar to git trailer format. A footer’s token MUST
+  /// use "-" in place of whitespace characters, e.g., Acked-by (this helps
+  /// differentiate the footer section from a multi-paragraph body). An
+  /// exception is made for BREAKING CHANGE, which MAY also be used as a token.
   final List<String> footers;
 
   // TODO(Salakar): this api should probably not be in this package
-  /// Whether this commit should trigger a version bump in it's residing package.
+  /// Whether this commit should trigger a version bump in it's residing
+  /// package.
   bool get isVersionableCommit {
     if (isMergeCommit) return false;
     return isBreakingChange ||
@@ -232,7 +234,8 @@ class ConventionalCommit {
   }
 
   // TODO(Salakar): this api should probably not be in this package
-  /// Returns the [SemverReleaseType] for this commit, e.g. [SemverReleaseType.major].
+  /// Returns the [SemverReleaseType] for this commit, e.g.
+  /// [SemverReleaseType.major].
   SemverReleaseType get semverReleaseType {
     if (isBreakingChange) {
       return SemverReleaseType.major;

--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -39,9 +39,10 @@ enum SemverReleaseType {
   major,
 }
 
-/// A representation of a parsed conventional commit message. Parsing is based
-/// upon the Conventional Commits 1.0.0 specification available at
-/// https://www.conventionalcommits.org/en/v1.0.0/
+/// A representation of a parsed conventional commit message.
+///
+/// Parsing is based upon the Conventional Commits 1.0.0 specification available
+/// at https://www.conventionalcommits.org/en/v1.0.0/
 class ConventionalCommit {
   ConventionalCommit._({
     required this.header,
@@ -190,9 +191,11 @@ class ConventionalCommit {
   final bool isBreakingChange;
 
   /// The description of the breaking change, e.g. the text after BREAKING
-  /// CHANGE: <description>. Will be null if [isBreakingChange] is false.
-  /// Defaults to [description] if the `BREAKING CHANGE:` footer format was not
-  /// used, e.g. only `!` after the commit type was specified.
+  /// CHANGE: <description>.
+  ///
+  /// Will be null if [isBreakingChange] is false. Defaults to [description] if
+  /// the `BREAKING CHANGE:` footer format was not used, e.g. only `!` after the
+  /// commit type was specified.
   final String? breakingChangeDescription;
 
   /// Whether this commit was a merge commit, e.g. `Merge #24 into main`
@@ -205,15 +208,18 @@ class ConventionalCommit {
   /// commit message.)
   final String header;
 
-  /// An optional body describing the change in more detail. Note this can
-  /// contain multiple paragraphs separated by new lines.
+  /// An optional body describing the change in more detail.
+  ///
+  /// Note this can contain multiple paragraphs separated by new lines.
   final String? body;
 
   /// Footers other than BREAKING CHANGE: <description> may be provided and
-  /// follow a convention similar to git trailer format. A footer’s token MUST
-  /// use "-" in place of whitespace characters, e.g., Acked-by (this helps
-  /// differentiate the footer section from a multi-paragraph body). An
-  /// exception is made for BREAKING CHANGE, which MAY also be used as a token.
+  /// follow a convention similar to git trailer format.
+  ///
+  /// A footer’s token MUST use "-" in place of whitespace characters, e.g.,
+  /// Acked-by (this helps differentiate the footer section from a
+  /// multi-paragraph body). An exception is made for BREAKING CHANGE, which MAY
+  /// also be used as a token.
   final List<String> footers;
 
   // TODO(Salakar): this api should probably not be in this package

--- a/packages/melos/bin/melos.dart
+++ b/packages/melos/bin/melos.dart
@@ -26,8 +26,8 @@ Future<void> main(List<String> arguments) async {
     if (!isUpToDate) {
       final latestVersion = await pubUpdater.getLatestVersion(packageName);
       final shouldUpdate = utils.promptBool(
-        message:
-            'There is a new version of $packageName available ($latestVersion). Would you like to update?',
+        message: 'There is a new version of $packageName available '
+            '($latestVersion). Would you like to update?',
         defaultsTo: true,
       );
       if (shouldUpdate) {

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -33,7 +33,7 @@ import 'workspace_configs.dart';
 ///
 /// To run a command, do:
 ///
-/// ```dart
+/// ```dart main
 /// final melos = MelosCommandRunner();
 ///
 /// await melos.run(['bootstrap']);
@@ -42,7 +42,8 @@ class MelosCommandRunner extends CommandRunner<void> {
   MelosCommandRunner(MelosWorkspaceConfig config)
       : super(
           'melos',
-          'A CLI tool for managing Dart & Flutter projects with multiple packages.',
+          'A CLI tool for managing Dart & Flutter projects with multiple '
+              'packages.',
           usageLineLength: terminalWidth,
         ) {
     argParser.addFlag(

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -20,8 +20,8 @@ abstract class MelosCommand extends Command<void> {
   late final logger =
       MelosLogger(global.verbose ? Logger.verbose() : Logger.standard());
 
-  /// The `melos.yaml` configuration for this command.
-  /// see [ArgParser.allowTrailingOptions]
+  /// The `melos.yaml` configuration for this command. see
+  /// [ArgParser.allowTrailingOptions]
   bool get allowTrailingOptions => true;
 
   /// Overridden to support line wrapping when printing usage.

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -19,7 +19,6 @@ import 'dart:async';
 
 import '../commands/runner.dart';
 import '../workspace_configs.dart';
-
 import 'base.dart';
 
 class BootstrapCommand extends MelosCommand {
@@ -35,8 +34,8 @@ class BootstrapCommand extends MelosCommand {
 
   @override
   final String description =
-      'Initialize the workspace, link local packages together and install remaining package dependencies. '
-      'Supports all package filtering options.';
+      'Initialize the workspace, link local packages together and install '
+      'remaining package dependencies. Supports all package filtering options.';
 
   @override
   FutureOr<void>? run() {

--- a/packages/melos/lib/src/command_runner/clean.dart
+++ b/packages/melos/lib/src/command_runner/clean.dart
@@ -17,7 +17,6 @@
 
 import '../commands/runner.dart';
 import '../workspace_configs.dart';
-
 import 'base.dart';
 
 class CleanCommand extends MelosCommand {
@@ -30,8 +29,8 @@ class CleanCommand extends MelosCommand {
 
   @override
   final String description = 'Clean this workspace and all packages. '
-      'This deletes the temporary pub & ide files such as ".packages" & ".flutter-plugins". '
-      'Supports all package filtering options.';
+      'This deletes the temporary pub & ide files such as ".packages" & '
+      '".flutter-plugins". Supports all package filtering options.';
 
   @override
   Future<void> run() async {

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -29,7 +29,8 @@ class ExecCommand extends MelosCommand {
       'fail-fast',
       abbr: 'f',
       help:
-          'Whether exec should fail fast and not execute the script in further packages if the script fails in a individual package.',
+          'Whether exec should fail fast and not execute the script in further '
+          'packages if the script fails in a individual package.',
     );
   }
 
@@ -41,7 +42,8 @@ class ExecCommand extends MelosCommand {
 
   @override
   final String description =
-      'Execute an arbitrary command in each package. Supports all package filtering options.';
+      'Execute an arbitrary command in each package. Supports all package '
+      'filtering options.';
 
   @override
   Future<void> run() async {

--- a/packages/melos/lib/src/command_runner/list.dart
+++ b/packages/melos/lib/src/command_runner/list.dart
@@ -39,7 +39,8 @@ class ListCommand extends MelosCommand {
       abbr: 'r',
       negatable: false,
       help:
-          'When printing output, use package paths relative to the root of the workspace.',
+          'When printing output, use package paths relative to the root of the '
+          'workspace.',
     );
     argParser.addFlag(
       'json',
@@ -66,7 +67,8 @@ class ListCommand extends MelosCommand {
 
   @override
   final String description =
-      'List local packages in various output formats. Supports all package filtering options.';
+      'List local packages in various output formats. Supports all package '
+      'filtering options.';
 
   @override
   final String invocation = 'melos list';

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -48,8 +48,8 @@ class PublishCommand extends MelosCommand {
 
   @override
   final String description =
-      'Publish any unpublished packages or package versions in your repository to pub.dev. '
-      'Dry run is on by default.';
+      'Publish any unpublished packages or package versions in your repository '
+      'to pub.dev. Dry run is on by default.';
 
   @override
   Future<void> run() async {

--- a/packages/melos/lib/src/command_runner/run.dart
+++ b/packages/melos/lib/src/command_runner/run.dart
@@ -24,8 +24,9 @@ class RunCommand extends MelosCommand {
     argParser.addFlag(
       'no-select',
       negatable: false,
-      help:
-          'Skips the prompt to select a package (if defined in the script configuration). Filters defined in the scripts "select-package" options will however still be applied.',
+      help: 'Skips the prompt to select a package (if defined in the script '
+          'configuration). Filters defined in the scripts "select-package" '
+          'options will however still be applied.',
     );
   }
 

--- a/packages/melos/lib/src/command_runner/script.dart
+++ b/packages/melos/lib/src/command_runner/script.dart
@@ -28,8 +28,9 @@ class ScriptCommand extends MelosCommand {
     argParser.addFlag(
       'no-select',
       negatable: false,
-      help:
-          'Skips the prompt to select a package (if defined in the script configuration). Filters defined in the scripts "select-package" options will however still be applied.',
+      help: 'Skips the prompt to select a package (if defined in the script '
+          'configuration). Filters defined in the scripts "select-package" '
+          'options will however still be applied.',
     );
   }
 

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -54,9 +54,10 @@ class VersionCommand extends MelosCommand {
       abbr: 'g',
       negatable: false,
       help:
-          'Graduate current prerelease versioned packages to stable versions, e.g. '
-          '"0.10.0-dev.1" would become "0.10.0". Cannot be combined with prerelease '
-          'flag. Applies only to Conventional Commits based versioning.',
+          'Graduate current prerelease versioned packages to stable versions, '
+          'e.g. "0.10.0-dev.1" would become "0.10.0". Cannot be combined with '
+          'prerelease flag. Applies only to Conventional Commits based '
+          'versioning.',
     );
     argParser.addFlag(
       'changelog',
@@ -88,7 +89,8 @@ class VersionCommand extends MelosCommand {
       defaultsTo: true,
       help:
           'By default, melos version will commit changes to pubspec.yaml files '
-          'and tag the release. Pass --no-git-tag-version to disable the behavior.',
+          'and tag the release. Pass --no-git-tag-version to disable the '
+          'behaviour.',
     );
     argParser.addOption(
       'message',
@@ -136,14 +138,17 @@ class VersionCommand extends MelosCommand {
 
   @override
   final String description =
-      'Automatically version and generate changelogs based on the Conventional Commits specification. Supports all package filtering options.';
+      'Automatically version and generate changelogs based on the Conventional '
+      'Commits specification. Supports all package filtering options.';
 
   @override
-  // ignore: leading_newlines_in_multiline_strings
-  final String invocation = ' ${AnsiStyles.bold('melos version')}\n'
-      '          Version packages automatically using the Conventional Commits specification.\n\n'
-      '        ${AnsiStyles.bold('melos version')} <package name> <major|patch|minor|build|exactVersion>\n'
-      '          Manually update the version of a package, and update all packages that depend on it.\n';
+  final String invocation = '''
+ ${AnsiStyles.bold('melos version')}
+          Version packages automatically using the Conventional Commits specification.
+
+        ${AnsiStyles.bold('melos version')} <package name> <major|patch|minor|build|exactVersion>
+          Manually update the version of a package, and update all packages that depend on it.
+''';
 
   @override
   Future<void> run() async {

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -362,7 +362,7 @@ Future<void> _generateTemporaryProjects(MelosWorkspace workspace) async {
         );
 
         // If this package is an an add-to-app module, all plugins that are
-        // dependencies of the package must have their android main classes 
+        // dependencies of the package must have their android main classes
         // copied to the temporary workspace, otherwise pub get fails.
         if (package.isAddToApp &&
             otherPackage.isFlutterPlugin &&

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -343,8 +343,8 @@ Future<void> _generateTemporaryProjects(MelosWorkspace workspace) async {
           transformPathDependenciesToAbsolute(pubspec.dependencyOverrides),
     );
 
-    // Traversing all packages so that transitive dependencies for the bootstraped
-    // packages are setup properly.
+    // Traversing all packages so that transitive dependencies for the
+    // bootstraped packages are setup properly.
     for (final otherPackage in workspace.allPackages.values) {
       final otherPackagePath = utils.relativePath(
         join(workspace.melosToolPath, otherPackage.pathRelativeToWorkspace),
@@ -362,8 +362,8 @@ Future<void> _generateTemporaryProjects(MelosWorkspace workspace) async {
         );
 
         // If this package is an an add-to-app module, all plugins that are
-        // dependencies of the package must have their android main classes copied
-        // to the temporary workspace, otherwise pub get fails.
+        // dependencies of the package must have their android main classes 
+        // copied to the temporary workspace, otherwise pub get fails.
         if (package.isAddToApp &&
             otherPackage.isFlutterPlugin &&
             otherPackage.flutterPluginSupportsAndroid &&

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -58,8 +58,8 @@ mixin _ExecMixin on _Melos {
       }
     }
     if (environment.containsKey('MELOS_TEST')) {
-      // TODO(rrousselGit) refactor this to not have to manually maitain the list
-      // of env variables to remove
+      // TODO(rrousselGit) refactor this to not have to manually maitain the
+      // list of env variables to remove
       environment.remove('MELOS_TEST');
       environment.remove('MELOS_ROOT_PATH');
       environment.remove('MELOS_SCRIPT');

--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -209,19 +209,22 @@ mixin _ListMixin on _Melos {
     for (final package in workspace.filteredPackages.values) {
       for (final dep in package.dependenciesInWorkspace.values) {
         buffer.add(
-          '  ${package.name} -> ${dep.name} [style="filled"; color="${getColor(dep.name)}"];',
+          '  ${package.name} -> ${dep.name} '
+          '[style="filled"; color="${getColor(dep.name)}"];',
         );
       }
 
       for (final dep in package.devDependenciesInWorkspace.values) {
         buffer.add(
-          '  ${package.name} -> ${dep.name} [style="dashed"; color="${getColor(dep.name)}"];',
+          '  ${package.name} -> ${dep.name} '
+          '[style="dashed"; color="${getColor(dep.name)}"];',
         );
       }
 
       for (final dep in package.dependencyOverridesInWorkspace.values) {
         buffer.add(
-          '  ${package.name} -> ${dep.name} [style="dotted"; color="${getColor(dep.name)}"];',
+          '  ${package.name} -> ${dep.name} '
+          '[style="dotted"; color="${getColor(dep.name)}"];',
         );
       }
     }

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -46,9 +46,13 @@ mixin _RunMixin on _Melos {
 
     final scriptChoices = scripts.map((script) {
       final styledName = AnsiStyles.cyan(script.name);
-      final styledDescription = script.description != null
-          ? '\n    └> ${AnsiStyles.gray(script.description!.trim().split('\n').join('\n       '))}'
-          : '';
+      final styledDescription = script.description?.let((description) {
+            final formattedDescription = AnsiStyles.gray(
+              description.trim().split('\n').join('\n       '),
+            );
+            return '\n    └> $formattedDescription';
+          }) ??
+          '';
       return '$styledName$styledDescription';
     }).toList();
 
@@ -185,7 +189,8 @@ class ScriptNotFoundException implements MelosException {
   @override
   String toString() {
     final builder = StringBuffer(
-      "ScriptNotFoundException: The script $scriptName could not be found in the 'melos.yaml' file.",
+      'ScriptNotFoundException: The script $scriptName could not be found in '
+      "the 'melos.yaml' file.",
     );
 
     for (final scriptName in availableScriptNames) {
@@ -201,7 +206,8 @@ class NoScriptException implements MelosException {
 
   @override
   String toString() {
-    return "NoScriptException: This workspace has no scripts defined in it's 'melos.yaml' file.";
+    return "NoScriptException: This workspace has no scripts defined in it's "
+        "'melos.yaml' file.";
   }
 }
 

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -84,7 +84,8 @@ abstract class _Melos {
     if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
       // MELOS_PACKAGES environment variable is a comma delimited list of
       // package names - used instead of filters if it is present.
-      // This can be user defined or can come from package selection in `melos run`.
+      // This can be user defined or can come from package selection in
+      // `melos run`.
       filterWithEnv = PackageFilter(
         scope: currentPlatform.environment[envKeyMelosPackages]!
             .split(',')

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -399,7 +399,7 @@ mixin _VersionMixin on _RunMixin {
     // allows all versions guaranteed to be backwards compatible with the
     // specified version.
     // For example, ^1.2.3 is equivalent to '>=1.2.3 <2.0.0', and ^0.1.2 is
-    //equivalent to '>=0.1.2 <0.2.0'.
+    // equivalent to '>=0.1.2 <0.2.0'.
     var versionConstraint = VersionConstraint.compatibleWith(version);
 
     // For nullsafety releases we use a >=currentVersion <nextMajorVersion

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -117,7 +117,7 @@ mixin _VersionMixin on _RunMixin {
           MelosPendingPackageUpdate(
             workspace,
             package,
-            [],
+            const [],
             PackageUpdateReason.graduate,
             graduate: asStableRelease,
             prerelease: asPrerelease,
@@ -226,7 +226,7 @@ mixin _VersionMixin on _RunMixin {
           MelosPendingPackageUpdate(
             workspace,
             package,
-            [],
+            const [],
             PackageUpdateReason.dependency,
             // Dependent packages that should have graduated would have already
             // gone through graduation logic above. So graduate should use the default
@@ -549,8 +549,6 @@ mixin _VersionMixin on _RunMixin {
                       return 'dependency was updated';
                     case PackageUpdateReason.graduate:
                       return 'graduate to stable';
-                    default:
-                      return 'unknown';
                   }
                 })(),
               ),

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -26,7 +26,8 @@ mixin _VersionMixin on _RunMixin {
 
     if (updateDependentsVersions && !updateDependentsConstraints) {
       throw ArgumentError(
-        'Cannot use updateDependentsVersions without updateDependentsConstraints.',
+        'Cannot use updateDependentsVersions without '
+        'updateDependentsConstraints.',
       );
     }
 
@@ -39,9 +40,9 @@ mixin _VersionMixin on _RunMixin {
     final workspace = await createWorkspace(
       global: global,
       // We ignore `since` package list filtering on the 'version' command as it
-      // already filters it itself, filtering here would map dependant version fail
-      // as it won't be aware of any packages that have been filtered out here
-      // because of the 'since' filter.
+      // already filters it itself, filtering here would map dependant version
+      // fail as it won't be aware of any packages that have been filtered out
+      // here because of the 'since' filter.
       filter: filter?.copyWithUpdatedSince(null),
     );
 
@@ -137,7 +138,8 @@ mixin _VersionMixin on _RunMixin {
       dependentPackagesToVersion
           .addAll(packageUnscoped.dependentsInWorkspace.values);
 
-      // Add dependentsInWorkspace dependents in the workspace until no more are added.
+      // Add dependentsInWorkspace dependents in the workspace until no more are
+      // added.
       var packagesAdded = 1;
       while (packagesAdded != 0) {
         final packagesCountBefore = dependentPackagesToVersion.length;
@@ -229,13 +231,15 @@ mixin _VersionMixin on _RunMixin {
             const [],
             PackageUpdateReason.dependency,
             // Dependent packages that should have graduated would have already
-            // gone through graduation logic above. So graduate should use the default
-            // of 'false' here so as not to graduate anything that was specifically
-            // excluded.
+            // gone through graduation logic above. So graduate should use the
+            // default of 'false' here so as not to graduate anything that was
+            // specifically excluded.
             // graduate: false,
             prerelease: asPrerelease,
-            // TODO Should dependent packages also get the same preid, can we expose this as an option?
-            // TODO In the case of "nullsafety" it doesn't make sense for dependent packages to also become nullsafety preid versions.
+            // TODO Should dependent packages also get the same preid, can we
+            // expose this as an option?
+            // TODO In the case of "nullsafety" it doesn't make sense for
+            // dependent packages to also become nullsafety preid versions.
             // preid: preid,
             logger: logger,
           ),
@@ -254,8 +258,8 @@ mixin _VersionMixin on _RunMixin {
         label: false,
       );
       logger.hint(
-        'Try running "melos list" with the same filtering options to see a list '
-        'of packages that were included.',
+        'Try running "melos list" with the same filtering options to see a '
+        'list of packages that were included.',
       );
       logger.hint(
         'Try running "melos version --all" to include private packages',
@@ -265,7 +269,8 @@ mixin _VersionMixin on _RunMixin {
 
     logger.log(
       AnsiStyles.magentaBright(
-        'The following ${packageNameStyle(pendingPackageUpdates.length.toString())} '
+        'The following '
+        '${packageNameStyle(pendingPackageUpdates.length.toString())} '
         'packages will be updated:\n',
       ),
     );
@@ -390,14 +395,16 @@ mixin _VersionMixin on _RunMixin {
       );
     }
 
-    // By default dependency constraint using caret syntax to ensure the range allows
-    // all versions guaranteed to be backwards compatible with the specified version.
-    // For example, ^1.2.3 is equivalent to '>=1.2.3 <2.0.0', and ^0.1.2 is equivalent to '>=0.1.2 <0.2.0'.
+    // By default dependency constraint using caret syntax to ensure the range
+    // allows all versions guaranteed to be backwards compatible with the
+    // specified version.
+    // For example, ^1.2.3 is equivalent to '>=1.2.3 <2.0.0', and ^0.1.2 is
+    //equivalent to '>=0.1.2 <0.2.0'.
     var versionConstraint = VersionConstraint.compatibleWith(version);
 
-    // For nullsafety releases we use a >=currentVersion <nextMajorVersion constraint
-    // to allow nullsafety prerelease id versions to function similar to semver without
-    // the actual major, minor & patch versions changing.
+    // For nullsafety releases we use a >=currentVersion <nextMajorVersion
+    // constraint to allow nullsafety prerelease id versions to function similar
+    // to semver without the actual major, minor & patch versions changing.
     // e.g. >=1.2.0-1.0.nullsafety.0 <1.2.0-2.0.nullsafety.0
     if (version.toString().contains('.nullsafety.')) {
       final nextMajorFromCurrentVersion =
@@ -473,7 +480,8 @@ mixin _VersionMixin on _RunMixin {
         workspace.config.commands.version.updateGitTagRefs) {
       updatedContents = contents.replaceAllMapped(
           dependencyTagReplaceRegex(dependencyName), (Match match) {
-        return '${match.group(1)}$dependencyName-v${dependencyVersion.toString().substring(1)}';
+        return '${match.group(1)}$dependencyName-'
+            'v${dependencyVersion.toString().substring(1)}';
       });
     } else {
       updatedContents = contents.replaceAllMapped(
@@ -539,7 +547,8 @@ mixin _VersionMixin on _RunMixin {
                                         .indexOf('.') +
                                     1,
                               );
-                      return 'updated with ${AnsiStyles.underline(semverType)} changes';
+                      return 'updated with ${AnsiStyles.underline(semverType)} '
+                          'changes';
                     case PackageUpdateReason.dependency:
                       if (pendingUpdate.reason ==
                               PackageUpdateReason.dependency &&
@@ -567,7 +576,8 @@ mixin _VersionMixin on _RunMixin {
     required bool updateChangelog,
     required MelosWorkspace workspace,
   }) async {
-    // Note: not pooling & parrellelzing rights to avoid possible file contention.
+    // Note: not pooling & parallelizing rights to avoid possible file
+    // contention.
     await Future.forEach(pendingPackageUpdates,
         (MelosPendingPackageUpdate pendingPackageUpdate) async {
       // Update package pubspec version.
@@ -589,9 +599,9 @@ mixin _VersionMixin on _RunMixin {
           return _setDependentPackageVersionConstraint(
             package,
             pendingPackageUpdate.package.name,
-            // Note if we're not updating dependent versions then we use the current
-            // version rather than the next version as the next version would never
-            // have been applied.
+            // Note if we're not updating dependent versions then we use the
+            // current version rather than the next version as the next version
+            // would never have been applied.
             (pendingPackageUpdate.reason == PackageUpdateReason.dependency &&
                     !updateDependentsVersions)
                 ? pendingPackageUpdate.package.version
@@ -616,7 +626,8 @@ mixin _VersionMixin on _RunMixin {
         workspace.config.commands.version.workspaceChangelog) {
       final today = DateTime.now();
       final dateSlug =
-          "${today.year.toString()}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}";
+          "${today.year.toString()}-${today.month.toString().padLeft(2, '0')}-"
+          "${today.day.toString().padLeft(2, '0')}";
       final workspaceChangelog = WorkspaceChangelog(
         workspace,
         dateSlug,
@@ -681,7 +692,8 @@ mixin _VersionMixin on _RunMixin {
         return;
       }
 
-      // TODO '--tag-version-prefix' support (if we decide to support it later) would pass prefix named arg to gitTagForPackageVersion:
+      // TODO '--tag-version-prefix' support (if we decide to support it later)
+      // would pass prefix named arg to gitTagForPackageVersion:
       final tag = gitTagForPackageVersion(
         pendingPackageUpdate.package.name,
         pendingPackageUpdate.nextVersion.toString(),
@@ -761,7 +773,8 @@ mixin _VersionMixin on _RunMixin {
         );
       });
 
-      // TODO this is a temporary workaround for committing generated dart files.
+      // TODO this is a temporary workaround for committing generated dart
+      // files.
       // TODO remove once options exposed for this in a later release.
       if (pendingPackageUpdate.package.name == 'melos') {
         await gitAdd(

--- a/packages/melos/lib/src/common/exception.dart
+++ b/packages/melos/lib/src/common/exception.dart
@@ -10,11 +10,13 @@ class CancelledException implements MelosException {
 
 class RestrictedBranchException implements MelosException {
   RestrictedBranchException(this.allowedBranch, this.currentBranch);
+
   final String allowedBranch;
   final String currentBranch;
+
   @override
-  String toString() {
-    return 'RestrictedBranchException: This command is configured in melos.yaml to only be '
-        'allowed to run on the "$allowedBranch" but the current branch is "$currentBranch".';
-  }
+  String toString() =>
+      'RestrictedBranchException: This command is configured in melos.yaml '
+      'to only be allowed to run on the "$allowedBranch" but the current '
+      'branch is "$currentBranch".';
 }

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -27,7 +27,8 @@ enum TagReleaseType {
   stable,
 }
 
-/// Generate a filter pattern for a package name, useful for listing tags for a package.
+/// Generate a filter pattern for a package name, useful for listing tags for a
+/// package.
 String gitTagFilterPattern(
   String packageName,
   TagReleaseType tagReleaseType, {
@@ -80,7 +81,9 @@ Future<ProcessResult> gitExecuteCommand({
   return processResult;
 }
 
-/// Return a list of git tags for a Melos package, in date created descending order.
+/// Return a list of git tags for a Melos package, in date created descending
+/// order.
+///
 /// Optionally specify [tagReleaseType] to specify [TagReleaseType].
 Future<List<String>> gitTagsForPackage(
   Package package, {
@@ -101,8 +104,10 @@ Future<List<String>> gitTagsForPackage(
       .where((e) => e.isNotEmpty)
       .where((tag) {
     if (tagReleaseType == TagReleaseType.stable) {
-      // TODO(Salakar) This is probably not the best way to determine if a tag is pre-release or not.
-      //   should we parse it, extract the version and pass it through to pub_semver?
+      // TODO(Salakar) This is probably not the best way to determine if a tag
+      // is pre-release or not.
+      // Should we parse it, extract the version and pass it through to
+      // pub_semver?
       return !tag.contains('-$preid.');
     }
     return true;
@@ -124,6 +129,7 @@ Future<bool> gitTagExists(
 }
 
 /// Create a tag, if it does not already exist.
+///
 /// Returns true if tag was successfully created.
 Future<bool> gitTagCreate(
   String tag,
@@ -158,10 +164,16 @@ Future<bool> gitTagCreate(
   );
 }
 
-/// Return the latest git tag for a Melos package. Latest determined in the following order;
-///     1) The current package version exists as a tag?
-///  OR 2) The latest tag sorted by listing tags in created date descending order.
-///        Note: If the current version is a prerelease then only prerelease tags are requested.
+/// Return the latest git tag for a Melos package.
+///
+/// The latest tag is determined in the following order:
+///
+/// - 1.  The current package version exists as a tag? OR
+/// - 2.  The latest tag sorted by listing tags in created date descending
+///       order.
+///
+///       Note: If the current version is a prerelease then only prerelease tags
+///       are requested.
 Future<String?> gitLatestTagForPackage(
   Package package, {
   String preid = 'dev',
@@ -184,7 +196,8 @@ Future<String?> gitLatestTagForPackage(
     return currentVersionTag;
   }
 
-  // If the current version is a prerelease then only prerelease tags are requested.
+  // If the current version is a prerelease then only prerelease tags are
+  // requested.
   final tagReleaseType = package.version.isPreRelease
       ? TagReleaseType.prerelease
       : TagReleaseType.all;
@@ -228,8 +241,9 @@ Future<void> gitCommit(
 }
 
 /// Returns a list of [GitCommit]s for a Melos package.
-/// Optionally specify [since] to start after a specified commit or tag. Defaults
-/// to the latest release tag.
+///
+/// Optionally specify [since] to start after a specified commit or tag.
+/// Defaults to the latest release tag.
 Future<List<GitCommit>> gitCommitsForPackage(
   Package package, {
   String? since,
@@ -303,8 +317,8 @@ Future<void> gitRemoteUpdate({
   );
 }
 
-/// Determine if the local git repository is behind on commits from it's
-/// remote branch.
+/// Determine if the local git repository is behind on commits from it's remote
+/// branch.
 Future<bool> gitIsBehindUpstream({
   required String workingDirectory,
   String remote = 'origin',

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -15,7 +15,10 @@
  *
  */
 
+import 'package:meta/meta.dart';
+
 /// A hosted git repository.
+@immutable
 abstract class HostedGitRepository {
   const HostedGitRepository();
 
@@ -33,8 +36,9 @@ abstract class HostedGitRepository {
 }
 
 /// A git repository, hosted by GitHub.
+@immutable
 class GitHubRepository extends HostedGitRepository {
-  GitHubRepository({
+  const GitHubRepository({
     required this.owner,
     required this.name,
   });
@@ -60,7 +64,7 @@ class GitHubRepository extends HostedGitRepository {
   final String name;
 
   @override
-  late Uri url = Uri.parse('https://github.com/$owner/$name/');
+  Uri get url => Uri.parse('https://github.com/$owner/$name/');
 
   @override
   Uri commitUrl(String id) => url.resolve('commit/$id');
@@ -90,6 +94,7 @@ GitHubRepository(
 }
 
 /// A git repository, hosted by GitLab.
+@immutable
 class GitLabRepository extends HostedGitRepository {
   GitLabRepository({
     required this.owner,
@@ -117,7 +122,7 @@ class GitLabRepository extends HostedGitRepository {
   final String name;
 
   @override
-  late Uri url = Uri.parse('https://gitlab.com/$owner/$name/');
+  Uri get url => Uri.parse('https://gitlab.com/$owner/$name/');
 
   @override
   Uri commitUrl(String id) => url.resolve('-/commit/$id');

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -60,13 +60,15 @@ class IntellijProject {
   }
 
   /// Path to the .idea/.name file in the current workspace.
-  /// This file generated with the workspace name as its contents. IntelliJ
-  /// uses this to change the project display name the IDE.
+  ///
+  /// This file generated with the workspace name as its contents. IntelliJ uses
+  /// this to change the project display name the IDE.
   String get pathDotName {
     return joinAll([pathDotIdea, '.name']);
   }
 
   /// Path to the .idea/modules.xml file in the current workspace.
+  ///
   /// This file is generated with a module for each discovered package in the
   /// current workspace.
   String get pathModulesXml {
@@ -118,6 +120,7 @@ class IntellijProject {
   }
 
   /// Reads a file template from the templates directory.
+  ///
   /// Additionally keeps a cache to reduce reads.
   Future<String> readFileTemplate(
     String fileName, {
@@ -145,6 +148,7 @@ class IntellijProject {
   }
 
   /// Create a .name file using the workspace name.
+  ///
   /// This gets picked up by the IDE and is used for display purposes.
   Future<void> writeNameFile() {
     return forceWriteToFile(pathDotName, _workspace.config.name);

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -158,7 +158,6 @@ class IntellijProject {
       case PackageType.flutterApp:
         return 'flutter_app_module.iml';
       case PackageType.dartPackage:
-      default:
         return 'dart_package_module.iml';
     }
   }

--- a/packages/melos/lib/src/common/io.dart
+++ b/packages/melos/lib/src/common/io.dart
@@ -173,7 +173,8 @@ extension DirectoryUtils on Directory {
             break;
           }
 
-          // We can ignore the link case here because [FileSystemEntity.typeSync] resolves links by default.
+          // We can ignore the link case here because
+          // [FileSystemEntity.typeSync] resolves links by default.
           // ignore: exhaustive_cases
           switch (FileSystemEntity.typeSync(entity.path)) {
             case FileSystemEntityType.directory:
@@ -203,11 +204,10 @@ extension DirectoryUtils on Directory {
 
 /// Tries to resiliently perform [operation].
 ///
-/// Some file system operations can intermittently fail on Windows because
-/// other processes are locking a file. We've seen this with virus scanners
-/// when we try to delete or move something while it's being scanned. To
-/// mitigate that, on Windows, this will retry the operation a few times if it
-/// fails.
+/// Some file system operations can intermittently fail on Windows because other
+/// processes are locking a file. We've seen this with virus scanners when we
+/// try to delete or move something while it's being scanned. To mitigate that,
+/// on Windows, this will retry the operation a few times if it fails.
 ///
 /// For some operations it makes sense to handle ERROR_DIR_NOT_EMPTY
 /// differently. They can pass [ignoreEmptyDir] = `true`.
@@ -270,7 +270,8 @@ bool _isDirectoryNotEmptyException(FileSystemException e) {
       // #define	ENOTEMPTY	39	/* Directory not empty */
       // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno.h#n20
       (Platform.isLinux && errorCode == 39) ||
-          // On Windows this may fail with ERROR_DIR_NOT_EMPTY or ERROR_ALREADY_EXISTS
+          // On Windows this may fail with ERROR_DIR_NOT_EMPTY or
+          // ERROR_ALREADY_EXISTS
           // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
           (Platform.isWindows && (errorCode == 145 || errorCode == 183)) ||
           // On MacOS rename will fail with ENOTEMPTY if directory exists.

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -18,6 +18,7 @@
 import 'dart:math' as math;
 
 import 'package:conventional_commit/conventional_commit.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../logging.dart';
@@ -42,8 +43,9 @@ enum PackageUpdateReason {
   graduate,
 }
 
+@immutable
 class MelosPendingPackageUpdate {
-  MelosPendingPackageUpdate(
+  const MelosPendingPackageUpdate(
     this.workspace,
     this.package,
     this.commits,
@@ -170,10 +172,10 @@ class MelosPendingPackageUpdate {
   }
 
   @override
+  int get hashCode => package.name.hashCode;
+
+  @override
   String toString() {
     return 'MelosPendingPackageUpdate(packageName: ${package.name}, semverType: $semverReleaseType, currentVersion: $currentVersion, nextVersion: $nextVersion)';
   }
-
-  @override
-  int get hashCode => package.name.hashCode;
 }

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -28,7 +28,8 @@ import 'changelog.dart';
 import 'git_commit.dart';
 import 'versioning.dart' as versioning;
 
-/// Enum representing why the version has been changed when running 'version' command.
+/// Enum representing why the version has been changed when running 'version'
+/// command.
 enum PackageUpdateReason {
   /// The user provided a new version.
   manual,
@@ -86,11 +87,12 @@ class MelosPendingPackageUpdate {
   /// Whether the next package version will be made a prerelease version.
   final bool prerelease;
 
-  /// If true and the package is currently a prerelease version, the next package version
-  /// will graduate to a stable, non-prerelease version.
+  /// If true and the package is currently a prerelease version, the next
+  /// package version will graduate to a stable, non-prerelease version.
   final bool graduate;
 
-  /// The prerelease id that will be used for prereleases, e.g. "0.1.0-[preid].1".
+  /// The prerelease id that will be used for prereleases, e.g.
+  /// "0.1.0-[preid].1".
   final String? preid;
 
   /// The next version of the package, if it has been manually specified by the
@@ -126,7 +128,8 @@ class MelosPendingPackageUpdate {
         );
   }
 
-  /// Taking into account all the commits in this update, what is the highest [SemverReleaseType].
+  /// Taking into account all the commits in this update, what is the highest
+  /// [SemverReleaseType].
   ///
   /// Is `null` for manually versioned packages.
   SemverReleaseType? get semverReleaseType {
@@ -136,7 +139,8 @@ class MelosPendingPackageUpdate {
 
     if (reason == PackageUpdateReason.dependency) {
       // Version bumps for dependencies should be patches.
-      // If the dependencies had breaking changes then this package should have had commits to update it separately.
+      // If the dependencies had breaking changes then this package should have
+      // had commits to update it separately.
       return SemverReleaseType.patch;
     }
 
@@ -176,6 +180,11 @@ class MelosPendingPackageUpdate {
 
   @override
   String toString() {
-    return 'MelosPendingPackageUpdate(packageName: ${package.name}, semverType: $semverReleaseType, currentVersion: $currentVersion, nextVersion: $nextVersion)';
+    return 'MelosPendingPackageUpdate('
+        'packageName: ${package.name}, '
+        'semverType: $semverReleaseType, '
+        'currentVersion: $currentVersion, '
+        'nextVersion: $nextVersion'
+        ')';
   }
 }

--- a/packages/melos/lib/src/common/platform.dart
+++ b/packages/melos/lib/src/common/platform.dart
@@ -24,7 +24,7 @@ const currentPlatformZoneKey = #currentPlatform;
 
 /// The system's platform. Should be used in place of `dart:io`'s [Platform].
 ///
-/// Can be stubbed during tests by setting a the [currentPlatformZoneKey] zone value
-/// a [Platform] instance.
+/// Can be stubbed during tests by setting a the [currentPlatformZoneKey] zone
+/// value a [Platform] instance.
 Platform get currentPlatform =>
     Zone.current[currentPlatformZoneKey] as Platform? ?? const LocalPlatform();

--- a/packages/melos/lib/src/common/pub_dependency_list.dart
+++ b/packages/melos/lib/src/common/pub_dependency_list.dart
@@ -16,6 +16,7 @@
  */
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:string_scanner/string_scanner.dart';
 
@@ -27,33 +28,33 @@ class PubDependencyList extends VersionedEntry {
   ) : super.copy(entry);
 
   factory PubDependencyList.parse(String input) {
-    final _scanner = StringScanner(input);
+    final scanner = StringScanner(input);
 
     final sdks = <String, Version>{};
 
     void scanSdk() {
-      _scanner.expect(_sdkLine, name: 'SDK');
-      final entry = VersionedEntry.fromMatch(_scanner.lastMatch!);
+      scanner.expect(_sdkLine, name: 'SDK');
+      final entry = VersionedEntry.fromMatch(scanner.lastMatch!);
       assert(!sdks.containsKey(entry.name));
       sdks[entry.name] = entry.version;
     }
 
     do {
       scanSdk();
-    } while (_scanner.matches(_sdkLine));
+    } while (scanner.matches(_sdkLine));
 
-    _scanner.expect(_sourcePackageLine, name: 'Source package');
-    final sourcePackage = VersionedEntry.fromMatch(_scanner.lastMatch!);
+    scanner.expect(_sourcePackageLine, name: 'Source package');
+    final sourcePackage = VersionedEntry.fromMatch(scanner.lastMatch!);
 
     final sections =
         <String, Map<VersionedEntry, Map<String, VersionConstraint>>>{};
 
-    while (_scanner.scan(_emptyLine)) {
-      final section = _scanSection(_scanner);
+    while (scanner.scan(_emptyLine)) {
+      final section = _scanSection(scanner);
       sections[section.key] = section.value;
     }
 
-    assert(_scanner.isDone, '${_scanner.position} of ${input.length}');
+    assert(scanner.isDone, '${scanner.position} of ${input.length}');
 
     return PubDependencyList._(
       sourcePackage,
@@ -107,8 +108,9 @@ MapEntry<String, Map<VersionedEntry, Map<String, VersionConstraint>>>
   return MapEntry(header, entries);
 }
 
+@immutable
 class VersionedEntry {
-  VersionedEntry(this.name, this.version);
+  const VersionedEntry(this.name, this.version);
 
   VersionedEntry.copy(VersionedEntry other)
       : name = other.name,
@@ -125,11 +127,11 @@ class VersionedEntry {
   final Version version;
 
   @override
-  int get hashCode => name.hashCode;
-
-  @override
   bool operator ==(Object other) =>
       other is VersionedEntry && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 
   @override
   String toString() => '$name @ $version';

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -426,10 +426,9 @@ void sortPackagesTopologically(List<Package> packages) {
   }
 }
 
-/// Given a workspace and package, this assembles the correct command
-/// to run pub / dart pub / flutter pub.
-/// Takes into account a potential sdk path being provided.
-/// If no sdk path is provided then it will assume to use the pub
+/// Given a workspace and package, this assembles the correct command to run pub
+/// / dart pub / flutter pub. Takes into account a potential sdk path being
+/// provided. If no sdk path is provided then it will assume to use the pub
 /// command available in PATH.
 List<String> pubCommandExecArgs({
   required bool useFlutter,

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -427,9 +427,10 @@ void sortPackagesTopologically(List<Package> packages) {
 }
 
 /// Given a workspace and package, this assembles the correct command to run pub
-/// / dart pub / flutter pub. Takes into account a potential sdk path being
-/// provided. If no sdk path is provided then it will assume to use the pub
-/// command available in PATH.
+/// / dart pub / flutter pub.
+///
+/// Takes into account a potential sdk path being provided. If no sdk path is
+/// provided then it will assume to use the pub command available in PATH.
 List<String> pubCommandExecArgs({
   required bool useFlutter,
   required MelosWorkspace workspace,

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -289,30 +289,28 @@ Future<int> startProcess(
   final workingDirectoryPath = workingDirectory ?? Directory.current.path;
   final executable = currentPlatform.isWindows ? 'cmd' : '/bin/sh';
   final filteredArgs = execArgs.map((arg) {
-    var _arg = arg;
-
     // Remove empty args.
-    if (_arg.trim().isEmpty) {
+    if (arg.trim().isEmpty) {
       return null;
     }
 
     // Attempt to make line continuations Windows & Linux compatible.
-    if (_arg.trim() == r'\') {
-      return currentPlatform.isWindows ? _arg.replaceAll(r'\', '^') : _arg;
+    if (arg.trim() == r'\') {
+      return currentPlatform.isWindows ? arg.replaceAll(r'\', '^') : arg;
     }
-    if (_arg.trim() == '^') {
-      return currentPlatform.isWindows ? _arg : _arg.replaceAll('^', r'\');
+    if (arg.trim() == '^') {
+      return currentPlatform.isWindows ? arg : arg.replaceAll('^', r'\');
     }
 
     // Inject MELOS_* variables if any.
     environment.forEach((key, value) {
       if (key.startsWith('MELOS_')) {
-        _arg = _arg.replaceAll('\$$key', value);
-        _arg = _arg.replaceAll(key, value);
+        arg = arg.replaceAll('\$$key', value);
+        arg = arg.replaceAll(key, value);
       }
     });
 
-    return _arg;
+    return arg;
   }).where((element) => element != null);
 
   final execProcess = await Process.start(
@@ -336,7 +334,7 @@ Future<int> startProcess(
   if (prefix != null && prefix.isNotEmpty) {
     final pluginPrefixTransformer =
         StreamTransformer<String, String>.fromHandlers(
-      handleData: (String data, EventSink sink) {
+      handleData: (data, sink) {
         const lineSplitter = LineSplitter();
         var lines = lineSplitter.convert(data);
         lines = lines
@@ -423,7 +421,7 @@ void sortPackagesTopologically(List<Package> packages) {
       // `ordered` is in reverse ordering to our desired publish precedence.
       return ordered.indexOf(b.name).compareTo(ordered.indexOf(a.name));
     });
-  } on CycleException {
+  } on CycleException<String> {
     // Cannot sort packages with inter-dependencies. Leave as-is.
   }
 }

--- a/packages/melos/lib/src/common/validation.dart
+++ b/packages/melos/lib/src/common/validation.dart
@@ -98,7 +98,10 @@ class MelosConfigException implements MelosException {
     Object? key,
     int? index,
     String? path,
-  }) : this('${_descriptor(key: key, index: index, path: path)} is required but missing');
+  }) : this(
+          '${_descriptor(key: key, index: index, path: path)} '
+          'is required but missing',
+        );
 
   MelosConfigException.invalidType({
     required Object expectedType,
@@ -106,7 +109,10 @@ class MelosConfigException implements MelosException {
     int? index,
     required Object? value,
     String? path,
-  }) : this('${_descriptor(key: key, index: index, path: path)} is expected to be a $expectedType but got $value');
+  }) : this(
+          '${_descriptor(key: key, index: index, path: path)} '
+          'is expected to be a $expectedType but got $value',
+        );
 
   static String _descriptor({Object? key, String? path, int? index}) {
     if (key != null) {

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -43,9 +43,10 @@ Version nextStableVersion(
     }
   }
 
-  // Although semantic versioning doesn't promise any compatibility between versions prior to 1.0.0,
-  // the Dart community convention is to treat those versions semantically as well. The interpretation
-  // of each number is just shifted down one slot:
+  // Although semantic versioning doesn't promise any compatibility between
+  // versions prior to 1.0.0, the Dart community convention is to treat those
+  // versions semantically as well. The interpretation of each number is just
+  // shifted down one slot:
   //   - going from 0.1.2 to 0.2.0 indicates a breaking change
   //   - going to 0.1.3 indicates a new feature
   //   - going to 0.1.2+1 indicates a change that doesn't affect the public API
@@ -76,14 +77,16 @@ Version nextPrereleaseVersion(
     final currentPre = currentVersion.preRelease.length == 2
         ? currentVersion.preRelease[1] as int
         : -1;
-    // Note we preserve the current prereleases preid if no preid option specified.
-    // So 1.0.0-nullsafety.0 would become ...-nullsafety.X rather than use the default preid "dev".
+    // Note we preserve the current prereleases preid if no preid option
+    // specified. So 1.0.0-nullsafety.0 would become ...-nullsafety.X rather
+    //than use the default preid "dev".
     var nextPreidInt = currentPre + 1;
     final nextPreidName = preid ?? currentVersion.preRelease[0] as String;
 
     // Reset the preid int if preid name has changed,
     // e.g. was "...dev.3" and is now a "nullsafety" preid so the next
-    // prerelease version becomes "...nullsafety.0" instead of "...nullsafety.4".
+    // prerelease version becomes "...nullsafety.0" instead of
+    // "...nullsafety.4".
     if (nextPreidName != currentVersion.preRelease[0]) {
       nextPreidInt = 0;
     }
@@ -117,15 +120,17 @@ Version nextVersion(
   final shouldGraduate = graduate;
   var shouldMakePreRelease = prerelease;
   if (currentVersion.preRelease.isNotEmpty) {
-    // If the current version then we should make a prerelease, unless graduating
-    // the version is explicitly requested.
+    // If the current version then we should make a prerelease, unless
+    // graduating the version is explicitly requested.
     shouldMakePreRelease = !shouldGraduate;
     // Extract the existing preid from prerelease list if no preid provided.
     // We do this to preserve the current preid so it's not overridden with the
     // default 'dev' preid.
     if (preid == null) {
-      //  - Versions in the format `0.8.0-nullsafety.1` have 2 pre release items, so we extract 'nullsafety' preid.
-      //  - Versions in the format `0.2.0-1.2.nullsafety.4` have 2 pre release items, so we extract 'nullsafety' preid.
+      //  - Versions in the format `0.8.0-nullsafety.1` have 2 pre release
+      //    items, so we extract 'nullsafety' preid.
+      //  - Versions in the format `0.2.0-1.2.nullsafety.4` have 2 pre release
+      //    items, so we extract 'nullsafety' preid.
       requestedPreidOrDefault = currentVersion.preRelease.length == 2
           ? currentVersion.preRelease[0] as String
           : currentVersion.preRelease[2] as String;
@@ -176,8 +181,9 @@ Version nextVersion(
   if (!currentVersion.isPreRelease &&
       shouldMakePreRelease &&
       requestedPreidOrDefault == 'nullsafety') {
-    // Going from non-null to a first nullsafety release then the convention here
-    // is that a major version is created regardless of the requested release type.
+    // Going from non-null to a first nullsafety release then the convention
+    // here is that a major version is created regardless of the requested
+    // release type.
     final nextMajorStable =
         nextStableVersion(currentVersion, SemverReleaseType.major);
 
@@ -209,8 +215,9 @@ Version nextVersion(
     if (currentVersion.preRelease[0] == 'nullsafety') {
       baseVersion = currentVersion;
     } else if (currentVersion.major == 0) {
-      // Bump the 'major' version again if the preids changed (e.g. dev to nullsafety)
-      // and the current version is not yet full semver (>= 1.0.0), e.g.:
+      // Bump the 'major' version again if the preids changed
+      // (e.g. dev to nullsafety) and the current version is not yet full
+      //semver (>= 1.0.0), e.g.:
       // `0.1.0-dev.5` should become `0.2.0-1.0.nullsafety.0`
       // and not `0.1.0-1.0.nullsafety.0`.
       // >=1.0.0 is already handled by [nextStableVersion].
@@ -233,8 +240,9 @@ Version nextVersion(
       currentVersion.preRelease.length == 4 &&
       currentVersion.preRelease[2] == 'nullsafety' &&
       requestedPreidOrDefault == 'nullsafety') {
-    // e.g. for 0.2.0-1.2.nullsafety.4 then currentVersion.preRelease is in the format:
-    // [1, 2, nullsafety, 4] so this equates to [major, minor, preid, patch].
+    // e.g. for 0.2.0-1.2.nullsafety.4 then currentVersion.preRelease is in the
+    // format: [1, 2, nullsafety, 4] so this equates to
+    // [major, minor, preid, patch].
     var nextPreMajor = currentVersion.preRelease[0] as int;
     var nextPreMinor = currentVersion.preRelease[1] as int;
     var nextPrePatch = currentVersion.preRelease[3] as int;
@@ -266,8 +274,9 @@ Version nextVersion(
   // Unhandled versioning behaviour.
   throw UnsupportedError(
     'Incrementing the version $currentVersion with the following options '
-    '(graduate: $graduate, preid: $preid, prerelease: $prerelease, releaseType: $releaseType) '
-    'is not supported by Melos, please raise an issue on GitHub if this is unexpected behaviour.',
+    '(graduate: $graduate, preid: $preid, prerelease: $prerelease, '
+    'releaseType: $releaseType) is not supported by Melos, please raise an '
+    'issue on GitHub if this is unexpected behaviour.',
   );
 }
 

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -217,7 +217,7 @@ Version nextVersion(
     } else if (currentVersion.major == 0) {
       // Bump the 'major' version again if the preids changed
       // (e.g. dev to nullsafety) and the current version is not yet full
-      //semver (>= 1.0.0), e.g.:
+      // semver (>= 1.0.0), e.g.:
       // `0.1.0-dev.5` should become `0.2.0-1.0.nullsafety.0`
       // and not `0.1.0-1.0.nullsafety.0`.
       // >=1.0.0 is already handled by [nextStableVersion].

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -39,7 +39,6 @@ Version nextStableVersion(
       case SemverReleaseType.minor:
         return currentVersion.nextMinor;
       case SemverReleaseType.patch:
-      default:
         return currentVersion.nextPatch;
     }
   }
@@ -56,7 +55,6 @@ Version nextStableVersion(
     case SemverReleaseType.minor:
       return currentVersion.nextPatch;
     case SemverReleaseType.patch:
-    default:
       // Bump the build number, or set it if it does not exist.
       final currentBuild =
           currentVersion.build.length == 1 ? currentVersion.build[0] as int : 0;
@@ -251,7 +249,6 @@ Version nextVersion(
         nextPrePatch = 0;
         break;
       case SemverReleaseType.patch:
-      default:
         nextPrePatch++;
         break;
     }

--- a/packages/melos/lib/src/common/workspace_changelog.dart
+++ b/packages/melos/lib/src/common/workspace_changelog.dart
@@ -36,9 +36,12 @@ class WorkspaceChangelog {
   final MelosLogger logger;
   final List<MelosPendingPackageUpdate> pendingPackageUpdates;
 
-  String get _changelogFileHeader {
-    return '# Change Log\n\nAll notable changes to this project will be documented in this file.\nSee [Conventional Commits](https://conventionalcommits.org) for commit guidelines.\n';
-  }
+  String get _changelogFileHeader => '''
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+''';
 
   String _packageVersionTitle(MelosPendingPackageUpdate update) {
     return '`${update.package.name}` - `v${update.nextVersion}`';
@@ -76,11 +79,12 @@ class WorkspaceChangelog {
       body.writeln(' - There are no breaking changes in this release.');
     } else {
       for (final update in packagesWithBreakingChanges) {
-        body.writeln(
-          // ignore: missing_whitespace_between_adjacent_strings
-          ' - [${_packageVersionTitle(update)}]'
-          '(${_packageVersionMarkdownAnchor(update)})',
+        body.write(' - ');
+        body.writeLink(
+          _packageVersionTitle(update),
+          uri: _packageVersionMarkdownAnchor(update),
         );
+        body.writeln();
       }
     }
     body.writeln();
@@ -90,11 +94,12 @@ class WorkspaceChangelog {
       body.writeln(' - There are no other changes in this release.');
     } else {
       for (final update in packagesWithOtherChanges) {
-        body.writeln(
-          // ignore: missing_whitespace_between_adjacent_strings
-          ' - [${_packageVersionTitle(update)}]'
-          '(${_packageVersionMarkdownAnchor(update)})',
+        body.write(' - ');
+        body.writeLink(
+          _packageVersionTitle(update),
+          uri: _packageVersionMarkdownAnchor(update),
         );
+        body.writeln();
       }
     }
     if (graduatedPackages.isNotEmpty) {
@@ -105,9 +110,7 @@ class WorkspaceChangelog {
       );
       body.writeln();
       for (final update in graduatedPackages) {
-        body.writeln(
-          ' - ${_packageVersionTitle(update)}',
-        );
+        body.writeln(' - ${_packageVersionTitle(update)}');
       }
     }
     if (dependencyOnlyPackages.isNotEmpty) {
@@ -122,9 +125,7 @@ class WorkspaceChangelog {
       );
       body.writeln();
       for (final update in dependencyOnlyPackages) {
-        body.writeln(
-          ' - ${_packageVersionTitle(update)}',
-        );
+        body.writeln(' - ${_packageVersionTitle(update)}');
       }
     }
     if (packagesWithOtherChanges.isNotEmpty ||

--- a/packages/melos/lib/src/common/workspace_changelog.dart
+++ b/packages/melos/lib/src/common/workspace_changelog.dart
@@ -45,7 +45,11 @@ class WorkspaceChangelog {
   }
 
   String _packageVersionMarkdownAnchor(MelosPendingPackageUpdate update) {
-    return '#${_packageVersionTitle(update).replaceAll(' ', '-').replaceAll(RegExp('[^a-zA-Z_0-9-]'), '')}';
+    // ignore: prefer_interpolation_to_compose_strings
+    return '#' +
+        _packageVersionTitle(update)
+            .replaceAll(' ', '-')
+            .replaceAll(RegExp('[^a-zA-Z_0-9-]'), '');
   }
 
   String get markdown {
@@ -73,7 +77,9 @@ class WorkspaceChangelog {
     } else {
       for (final update in packagesWithBreakingChanges) {
         body.writeln(
-          ' - [${_packageVersionTitle(update)}](${_packageVersionMarkdownAnchor(update)})',
+          // ignore: missing_whitespace_between_adjacent_strings
+          ' - [${_packageVersionTitle(update)}]'
+          '(${_packageVersionMarkdownAnchor(update)})',
         );
       }
     }
@@ -85,14 +91,17 @@ class WorkspaceChangelog {
     } else {
       for (final update in packagesWithOtherChanges) {
         body.writeln(
-          ' - [${_packageVersionTitle(update)}](${_packageVersionMarkdownAnchor(update)})',
+          // ignore: missing_whitespace_between_adjacent_strings
+          ' - [${_packageVersionTitle(update)}]'
+          '(${_packageVersionMarkdownAnchor(update)})',
         );
       }
     }
     if (graduatedPackages.isNotEmpty) {
       body.writeln();
       body.writeln(
-        'Packages graduated to a stable release (see pre-releases prior to the stable version for changelog entries):',
+        'Packages graduated to a stable release (see pre-releases prior to the '
+        'stable version for changelog entries):',
       );
       body.writeln();
       for (final update in graduatedPackages) {
@@ -106,7 +115,10 @@ class WorkspaceChangelog {
       body.writeln('Packages with dependency updates only:');
       body.writeln();
       body.writeln(
-        '> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.',
+        '> Packages listed below depend on other packages in this workspace '
+        'that have had changes. Their versions have been incremented to bump '
+        'the minimum dependency versions of the packages they depend upon in '
+        'this project.',
       );
       body.writeln();
       for (final update in dependencyOnlyPackages) {
@@ -161,7 +173,8 @@ class WorkspaceChangelog {
     var contents = await read();
     if (contents.contains(markdown)) {
       logger.trace(
-        'Identical changelog content for ${workspace.name} already exists, skipping.',
+        'Identical changelog content for ${workspace.name} already exists, '
+        'skipping.',
       );
       return;
     }

--- a/packages/melos/lib/src/global_options.dart
+++ b/packages/melos/lib/src/global_options.dart
@@ -15,7 +15,10 @@
  *
  */
 
+import 'package:meta/meta.dart';
+
 /// Global options that apply to all Melos commands.
+@immutable
 class GlobalOptions {
   const GlobalOptions({
     this.verbose = false,

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -191,10 +191,12 @@ class PackageFilter {
   /// Include only packages that do not depend on a specific package.
   final List<String> noDependsOn;
 
-  /// Filter package based on whether they received changed since a specific git commit/tag ID.
+  /// Filter package based on whether they received changed since a specific git
+  /// commit/tag ID.
   final String? updatedSince;
 
-  /// Filter package based on whether they are different between specific git commit/tag ID.
+  /// Filter package based on whether they are different between specific git
+  /// commit/tag ID.
   final String? diff;
 
   /// Include/Exclude packages with `publish_to: none`.
@@ -375,7 +377,7 @@ class PackageMap {
 
     final dartToolGlob =
         createGlob('**/.dart_tool', currentDirectoryPath: workspacePath);
-    // Flutter syminked plugins for iOS/macOS should not be included in the package list.
+    // Flutter symlinked plugins for iOS/macOS should not be included in the package list.
     final symlinksPluginsGlob = createGlob(
       '**/.symlinks/plugins',
       currentDirectoryPath: workspacePath,
@@ -385,7 +387,8 @@ class PackageMap {
       '**/.fvm',
       currentDirectoryPath: workspacePath,
     );
-    // Ephemeral plugin symlinked packages should not be included in the package list.
+    // Ephemeral plugin symlinked packages should not be included in the package
+    // list.
     final pluginSymlinksGlob = createGlob(
       '**/.plugin_symlinks',
       currentDirectoryPath: workspacePath,
@@ -476,8 +479,8 @@ The packages that caused the problem are:
     return _map[key];
   }
 
-  /// Detect packages in the workspace with the provided filters.
-  /// This is the default packages behaviour when a workspace is loaded.
+  /// Detect packages in the workspace with the provided filters. This is the
+  /// default packages behaviour when a workspace is loaded.
   Future<PackageMap> applyFilter(PackageFilter? filter) async {
     if (filter == null) return this;
 
@@ -542,8 +545,10 @@ extension on Iterable<Package> {
 
     return where((package) {
       final fileExistsMatched = filePaths.any((fileExistsPath) {
-        // TODO(rrousselGit): refactor the logic for applying environment variables
-        // TODO(rrousselGit): should support environment variables other than PACKAGE_NAME
+        // TODO(rrousselGit): refactor the logic for applying environment
+        // variables
+        // TODO(rrousselGit): should support environment variables other than
+        // PACKAGE_NAME
         final expandedFileExistsPath =
             fileExistsPath.replaceAll(r'$MELOS_PACKAGE_NAME', package.name);
 
@@ -555,9 +560,8 @@ extension on Iterable<Package> {
 
   /// Whether to include packages with `publish_to: none`.
   ///
-  /// If `include` is true, only include private packages.
-  /// If false, only include public packages.
-  /// If null, does nothing.
+  /// If `include` is true, only include private packages. If false, only
+  /// include public packages. If null, does nothing.
   Iterable<Package> filterPrivatePackages({bool? include}) {
     if (include == null) return this;
 
@@ -567,9 +571,8 @@ extension on Iterable<Package> {
   /// Whether to include/exclude packages with no changes since the latest
   /// version available on the registry.
   ///
-  /// If `include` is true, only include published packages.
-  /// If false, only include unpublished packages.
-  /// If null, does nothing.
+  /// If `include` is true, only include published packages. If false, only
+  /// include unpublished packages. If null, does nothing.
   Future<Iterable<Package>> filterPublishedPackages({
     required bool? published,
   }) async {
@@ -637,9 +640,8 @@ extension on Iterable<Package> {
 
   /// Whether to include/exclude packages that are null-safe.
   ///
-  /// If `include` is true, only null-safe packages.
-  /// If false, only include packages that are not null-safe.
-  /// If null, does nothing.
+  /// If `include` is true, only null-safe packages. If false, only include
+  /// packages that are not null-safe. If null, does nothing.
   Iterable<Package> filterNullSafe({required bool? nullSafe}) {
     if (nullSafe == null) return this;
 
@@ -812,8 +814,8 @@ class Package {
     return PackageType.dartPackage;
   }
 
-  /// Returns whether this package is for Flutter.
-  /// This is determined by whether the package depends on the Flutter SDK.
+  /// Returns whether this package is for Flutter. This is determined by whether
+  /// the package depends on the Flutter SDK.
   late final bool isFlutterPackage = dependencies.contains('flutter');
 
   /// Returns whether this package is private (publish_to set to 'none').
@@ -854,7 +856,8 @@ class Package {
     return versions.reversed.toList();
   }
 
-  /// Generates Pub/Flutter related temporary files such as .packages or pubspec.lock.
+  /// Generates Pub/Flutter related temporary files such as .packages or
+  /// pubspec.lock.
   Future<void> linkPackages(MelosWorkspace workspace) async {
     final pluginTemporaryPath =
         join(workspace.melosToolPath, pathRelativeToWorkspace);
@@ -879,8 +882,8 @@ class Package {
             const JsonEncoder.withIndent('  ').convert(packageConfig);
       }
 
-      final regexPathSeparator =
-          '${currentPlatform.isWindows ? r'\' : ''}${currentPlatform.pathSeparator}';
+      final regexPathSeparator = '${currentPlatform.isWindows ? r'\' : ''}'
+          '${currentPlatform.pathSeparator}';
       final melosToolPathRegExp = RegExp(
         '\\.dart_tool${regexPathSeparator}melos_tool$regexPathSeparator',
       );
@@ -900,10 +903,13 @@ class Package {
   }
 
   /// Returns whether this package is a Flutter app.
+  ///
   /// This is determined by ensuring all the following conditions are met:
-  ///  a) the package depends on the Flutter SDK.
-  ///  b) the package does not define itself as a Flutter plugin inside pubspec.yaml.
-  ///  c) a lib/main.dart file exists in the package.
+  ///
+  /// - a) the package depends on the Flutter SDK.
+  /// - b) the package does not define itself as a Flutter plugin inside
+  ///   pubspec.yaml.
+  /// - c) a lib/main.dart file exists in the package.
   bool get isFlutterApp {
     // Must directly depend on the Flutter SDK.
     if (!isFlutterPackage) return false;
@@ -958,7 +964,9 @@ class Package {
   }
 
   /// Returns whether this package is a Flutter plugin.
-  /// This is determined by whether the pubspec contains a flutter.plugin definition.
+  ///
+  /// This is determined by whether the pubspec contains a flutter.plugin
+  /// definition.
   bool get isFlutterPlugin => pubSpec.flutter?.plugin != null;
 
   String? get androidPackage {

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
@@ -123,6 +124,7 @@ RegExp dependencyTagReplaceRegex(String dependencyName) {
   );
 }
 
+@immutable
 class PackageFilter {
   PackageFilter({
     this.scope = const [],
@@ -542,10 +544,10 @@ extension on Iterable<Package> {
       final fileExistsMatched = filePaths.any((fileExistsPath) {
         // TODO(rrousselGit): refactor the logic for applying environment variables
         // TODO(rrousselGit): should support environment variables other than PACKAGE_NAME
-        final _fileExistsPath =
+        final expandedFileExistsPath =
             fileExistsPath.replaceAll(r'$MELOS_PACKAGE_NAME', package.name);
 
-        return fileExists(join(package.path, _fileExistsPath));
+        return fileExists(join(package.path, expandedFileExistsPath));
       });
       return fileExistsMatched;
     });

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -479,8 +479,9 @@ The packages that caused the problem are:
     return _map[key];
   }
 
-  /// Detect packages in the workspace with the provided filters. This is the
-  /// default packages behaviour when a workspace is loaded.
+  /// Detect packages in the workspace with the provided filters.
+  ///
+  /// This is the default packages behaviour when a workspace is loaded.
   Future<PackageMap> applyFilter(PackageFilter? filter) async {
     if (filter == null) return this;
 
@@ -814,8 +815,9 @@ class Package {
     return PackageType.dartPackage;
   }
 
-  /// Returns whether this package is for Flutter. This is determined by whether
-  /// the package depends on the Flutter SDK.
+  /// Returns whether this package is for Flutter.
+  ///
+  /// This is determined by whether the package depends on the Flutter SDK.
   late final bool isFlutterPackage = dependencies.contains('flutter');
 
   /// Returns whether this package is private (publish_to set to 'none').

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -384,8 +384,8 @@ class Script {
   /// Environment variables that will be passed to [run].
   final Map<String, String> env;
 
-  /// If the [run] command is a melos command, allows filtering packages
-  /// that will execute the command.
+  /// If the [run] command is a melos command, allows filtering packages that
+  /// will execute the command.
   final PackageFilter? filter;
 
   /// The options for `melos exec`, if [run] should be executed in multiple

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -125,6 +125,7 @@ ExecOptions(
 )''';
 }
 
+@immutable
 class Script {
   Script({
     required this.name,

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -133,8 +133,9 @@ class MelosWorkspace {
       utils.isPubspecOverridesSupported(sdkTool('dart'));
 
   /// Returns a string path to the 'melos_tool' directory in this workspace.
-  /// This directory should be git ignored and is used by Melos for temporary tasks
-  /// such as pub install.
+  ///
+  /// This directory should be git ignored and is used by Melos for temporary
+  /// tasks such as pub install.
   late final String melosToolPath = p.join(path, '.dart_tool', 'melos_tool');
 
   /// PATH environment variable for child processes launched in this workspace.
@@ -211,7 +212,8 @@ class MelosWorkspace {
     );
   }
 
-  /// Builds a dependency graph of dependencies and their dependents in this workspace.
+  /// Builds a dependency graph of dependencies and their dependents in this
+  /// workspace.
   Future<Map<String, Set<String>>> getDependencyGraph() async {
     final pubExecArgs = utils.pubCommandExecArgs(
       useFlutter: isFlutterWorkspace,

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -345,7 +345,8 @@ class VersionCommandConfigs {
   /// Whether to add links to commits in the generated CHANGELOG.md.
   final bool? linkToCommits;
 
-  /// Whether to also generate a CHANGELOG.md for the entire workspace at the root.
+  /// Whether to also generate a CHANGELOG.md for the entire workspace at the
+  /// root.
   final bool workspaceChangelog;
 
   /// Whether to also update pubspec with git referenced packages.
@@ -554,8 +555,8 @@ class MelosWorkspaceConfig {
         _searchForAncestorDirectoryWithMelosYaml(directory);
 
     if (melosWorkspaceDirectory == null) {
-      // Allow melos to use a project without a `melos.yaml` file if a `packages`
-      // directory exists.
+      // Allow melos to use a project without a `melos.yaml` file if a
+      // `packages` directory exists.
       final packagesDirectory = joinAll([directory.path, 'packages']);
 
       if (dirExists(packagesDirectory)) {
@@ -604,8 +605,8 @@ You must have one of the following to be a valid Melos workspace:
   /// packages.
   final List<Glob> ignore;
 
-  /// A list of scripts that can be executed with `melos run` or will be executed
-  /// before/after some specific melos commands.
+  /// A list of scripts that can be executed with `melos run` or will be
+  /// executed before/after some specific melos commands.
   final Scripts scripts;
 
   /// IDE-specific configurations.
@@ -616,7 +617,7 @@ You must have one of the following to be a valid Melos workspace:
 
   /// Command-specific configurations.
   ///
-  /// This allows customizing the default behavior of melos commands.
+  /// This allows customizing the default behaviour of melos commands.
   final CommandConfigs commands;
 
   /// Path to the Dart/Flutter SDK that should be used, unless overridden though

--- a/packages/melos/test/changelog_test.dart
+++ b/packages/melos/test/changelog_test.dart
@@ -90,8 +90,8 @@ void main() {
     });
 
     test(
-      'when enabled, and linkToCommits is also enabled adds link to commit'
-      ' behind each one',
+      'when enabled, and linkToCommits is also enabled adds link to commit '
+      'behind each one',
       () {
         final workspace = buildWorkspaceWithRepository(
           includeCommitId: true,

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -652,11 +652,12 @@ Future<void> runMelosBootstrap(Melos melos, TestLogger logger) async {
 ///
 /// In the example below **a** has no dependencies and **b** depends only on
 /// **a**:
-/// ```dart
-/// {
+///
+/// ```dart main
+/// final packages = {
 ///   'a': [],
 ///   'b': ['a']
-/// }
+/// };
 /// ```
 ///
 /// For each entry in [packages] a package with the key as the name will be

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -41,7 +41,7 @@ void main() {
         ['echo', 'hello', 'world'],
         concurrency: 1,
         filter: PackageFilter(
-          fileExists: ['log.txt'],
+          fileExists: const ['log.txt'],
         ),
       );
 

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -182,7 +182,8 @@ packages/c
       );
 
       test(
-        'full package path is printed by default if relativePaths is false or not set',
+        'full package path is printed by default if relativePaths is false or '
+        'not set',
         withMockFs(() async {
           final packages = [
             MockPackageFs(name: 'a'),

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -6,7 +6,7 @@ import 'package:pubspec/pubspec.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
-final throwsCyclicError = throwsA(isA<CycleException>());
+final throwsCyclicError = throwsA(isA<CycleException<String>>());
 
 void main() {
   group('publish', () {

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -12,51 +12,52 @@ import '../utils.dart';
 
 void main() {
   group('script', () {
-    test('supports passing package filter options to "melos exec" scripts',
-        () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
-        configBuilder: (path) => MelosWorkspaceConfig(
-          path: path,
-          name: 'test_package',
-          packages: [
-            createGlob('packages/**', currentDirectoryPath: path),
-          ],
-          scripts: Scripts({
-            'test_script': Script(
-              name: 'test_script',
-              run: 'melos exec -- "echo hello"',
-              filter: PackageFilter(
-                fileExists: ['log.txt'],
-              ),
-            )
-          }),
-        ),
-      );
+    test(
+      'supports passing package filter options to "melos exec" scripts',
+      () async {
+        final workspaceDir = createTemporaryWorkspaceDirectory(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_package',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            scripts: Scripts({
+              'test_script': Script(
+                name: 'test_script',
+                run: 'melos exec -- "echo hello"',
+                filter: PackageFilter(
+                  fileExists: const ['log.txt'],
+                ),
+              )
+            }),
+          ),
+        );
 
-      final aDir = await createProject(
-        workspaceDir,
-        const PubSpec(name: 'a'),
-      );
-      writeTextFile(join(aDir.path, 'log.txt'), '');
+        final aDir = await createProject(
+          workspaceDir,
+          const PubSpec(name: 'a'),
+        );
+        writeTextFile(join(aDir.path, 'log.txt'), '');
 
-      await createProject(
-        workspaceDir,
-        const PubSpec(name: 'b'),
-      );
+        await createProject(
+          workspaceDir,
+          const PubSpec(name: 'b'),
+        );
 
-      final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
-      final melos = Melos(
-        logger: logger,
-        config: config,
-      );
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+        final melos = Melos(
+          logger: logger,
+          config: config,
+        );
 
-      await melos.run(scriptName: 'test_script', noSelect: true);
+        await melos.run(scriptName: 'test_script', noSelect: true);
 
-      expect(
-        logger.output.normalizeNewLines(),
-        ignoringAnsii(
-          '''
+        expect(
+          logger.output.normalizeNewLines(),
+          ignoringAnsii(
+            '''
 melos run test_script
   └> melos exec -- "echo hello"
      └> RUNNING
@@ -79,9 +80,10 @@ melos run test_script
   └> melos exec -- "echo hello"
      └> SUCCESS
 ''',
-        ),
-      );
-    });
+          ),
+        );
+      },
+    );
 
     test('supports passing additional arguments to run scripts', () async {
       final workspaceDir = createTemporaryWorkspaceDirectory(

--- a/packages/melos/test/git_repository_test.dart
+++ b/packages/melos/test/git_repository_test.dart
@@ -51,7 +51,7 @@ void main() {
     });
 
     test('commitUrl returns correct URL', () {
-      final repo = GitHubRepository(owner: 'a', name: 'b');
+      const repo = GitHubRepository(owner: 'a', name: 'b');
       const commitId = 'b2841394a48cd7d84a4966a788842690e543b2ef';
 
       expect(
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('issueUrl returns correct URL', () {
-      final repo = GitHubRepository(owner: 'a', name: 'b');
+      const repo = GitHubRepository(owner: 'a', name: 'b');
       const issueId = '123';
 
       expect(

--- a/packages/melos/test/matchers.dart
+++ b/packages/melos/test/matchers.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: strict_raw_type
+
 /*
  * Copyright (c) 2016-present Invertase Limited & Contributors
  *

--- a/packages/melos/test/melos_test.dart
+++ b/packages/melos/test/melos_test.dart
@@ -39,7 +39,10 @@ class TestCase {
 
   @override
   String toString() {
-    return 'TestCase[$currentVersion => $expectedVersion ($requestedReleaseType)]\n  { '
+    return 'TestCase['
+        // ignore: missing_whitespace_between_adjacent_strings
+        '$currentVersion => $expectedVersion ($requestedReleaseType)'
+        ']\n  { '
         'shouldMakePrereleaseVersion:$shouldMakePrereleaseVersion, '
         'shouldMakeGraduateVersion:$shouldMakeGraduateVersion, '
         'requestedPreId:$requestedPreId '
@@ -88,9 +91,10 @@ const _versioningTestCases = [
     shouldMakePrereleaseVersion: true,
   ),
 
-  // Although semantic versioning doesn't promise any compatibility between versions prior to 1.0.0,
-  // the Dart community convention is to treat those versions semantically as well. The interpretation
-  // of each number is just shifted down one slot
+  // Although semantic versioning doesn't promise any compatibility between
+  // versions prior to 1.0.0, the Dart community convention is to treat those
+  // versions semantically as well. The interpretation of each number is just
+  // shifted down one slot
   TestCase('0.1.0', '0.2.0', SemverReleaseType.major),
   TestCase('0.1.0', '0.1.1', SemverReleaseType.minor),
   TestCase('0.1.0', '0.1.0+1', SemverReleaseType.patch),
@@ -128,7 +132,8 @@ const _versioningTestCases = [
   ),
 
   // Check that we preserve prerelease status, e.g. if already a prerelease
-  // then it should stay as a prerelease and not graduate to a non-prerelease version.
+  // then it should stay as a prerelease and not graduate to a non-prerelease
+  // version.
   TestCase('1.0.0-dev.1', '1.0.0-dev.2', SemverReleaseType.patch),
   // It should however graduate if it was specifically requested.
   TestCase(
@@ -144,8 +149,9 @@ const _versioningTestCases = [
     shouldMakeGraduateVersion: true,
   ),
 
-  // Check that we preserve any current prerelease preid if no preid option specified.
-  // So 1.0.0-beta.0 would become ...-beta.X rather than use the default preid "dev".
+  // Check that we preserve any current prerelease preid if no preid option
+  // specified. So 1.0.0-beta.0 would become ...-beta.X rather than use the
+  // default preid "dev".
   TestCase('1.0.0-beta.3', '1.0.0-beta.4', SemverReleaseType.patch),
 
   // Nullsafety
@@ -218,7 +224,8 @@ const _versioningTestCases = [
     SemverReleaseType.patch,
   ),
 
-  // Any nullsafety versions using the previous versioning style should get switched over.
+  // Any nullsafety versions using the previous versioning style should get
+  //switched over.
   NullSafetyTestCase(
     '0.8.0-nullsafety.1',
     '0.8.0-1.0.nullsafety.0',
@@ -247,23 +254,26 @@ void main() {
   group('Semantic Versioning', () {
     for (final testCase in _versioningTestCases) {
       test(
-          '#${_versioningTestCases.indexOf(testCase)}: the version ${testCase.currentVersion} should increment to ${testCase.expectedVersion}',
-          () {
-        final newVersion = nextVersion(
-          Version.parse(testCase.currentVersion),
-          testCase.requestedReleaseType,
-          graduate: testCase.shouldMakeGraduateVersion,
-          preid: testCase.requestedPreId,
-          prerelease: testCase.shouldMakePrereleaseVersion,
-        );
+        '#${_versioningTestCases.indexOf(testCase)}: the version '
+        '${testCase.currentVersion} should increment to '
+        '${testCase.expectedVersion}',
+        () {
+          final newVersion = nextVersion(
+            Version.parse(testCase.currentVersion),
+            testCase.requestedReleaseType,
+            graduate: testCase.shouldMakeGraduateVersion,
+            preid: testCase.requestedPreId,
+            prerelease: testCase.shouldMakePrereleaseVersion,
+          );
 
-        expect(
-          newVersion.toString(),
-          equals(testCase.expectedVersion),
-          reason:
-              'The version created did not match the version expected by this test case: $testCase.',
-        );
-      });
+          expect(
+            newVersion.toString(),
+            equals(testCase.expectedVersion),
+            reason: 'The version created did not match the version expected by '
+                'this test case: $testCase.',
+          );
+        },
+      );
     }
   });
 }

--- a/packages/melos/test/mock_fs.dart
+++ b/packages/melos/test/mock_fs.dart
@@ -22,8 +22,8 @@ import 'dart:io';
 import 'package:file/memory.dart';
 import 'package:melos/src/common/platform.dart';
 
-/// Overrides the body of a test so that I/O is run against an in-memory
-/// file system, not the host's disk.
+/// Overrides the body of a test so that I/O is run against an in-memory file
+/// system, not the host's disk.
 ///
 /// The I/O override is applied only to the code running within [testBody].
 FutureOr<void> Function() withMockFs(FutureOr<void> Function() testBody) {
@@ -36,7 +36,7 @@ FutureOr<void> Function() withMockFs(FutureOr<void> Function() testBody) {
 ///
 /// Usage:
 ///
-/// ```dart
+/// ```dart main
 /// test('My FS test', withMockFs(() {
 ///   File('foo').createSync(); // File created in memory
 /// }));

--- a/packages/melos/test/mock_workspace_fs.dart
+++ b/packages/melos/test/mock_workspace_fs.dart
@@ -22,8 +22,8 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'mock_fs.dart';
 
-/// Creates a mock workspace at [workspaceRoot], containing a `melos.yaml`
-/// and a set of package folders as described by [packages].
+/// Creates a mock workspace at [workspaceRoot], containing a `melos.yaml` and a
+/// set of package folders as described by [packages].
 ///
 /// The returned directory represents the workspace root.
 Directory createMockWorkspaceFs({
@@ -51,7 +51,7 @@ Directory createMockWorkspaceFs({
     intellij: intellij,
   );
 
-  // Sythesize a "package" (enough to satisfy our test requirements) for each
+  // Synthesize a "package" (enough to satisfy our test requirements) for each
   // entry in `packages`
   for (final package in packages) {
     _createPackage(package, workspaceRoot);
@@ -129,7 +129,8 @@ String _yamlMap(Map<String, String> map, {required int indent}) {
   return map.entries.map((e) => '$indentString${e.key}: ${e.value}').join('\n');
 }
 
-/// Used to generate a package's on-disk representation via [createMockWorkspaceFs].
+/// Used to generate a package's on-disk representation via
+/// [createMockWorkspaceFs].
 class MockPackageFs {
   MockPackageFs({
     required this.name,

--- a/packages/melos/test/package_filter_test.dart
+++ b/packages/melos/test/package_filter_test.dart
@@ -27,7 +27,7 @@ void main() {
         config,
         logger: TestLogger().toMelosLogger(),
         filter: PackageFilter(
-          dirExists: ['test'],
+          dirExists: const ['test'],
         ),
       );
 
@@ -63,7 +63,7 @@ void main() {
         config,
         logger: TestLogger().toMelosLogger(),
         filter: PackageFilter(
-          fileExists: ['log.txt'],
+          fileExists: const ['log.txt'],
         ),
       );
 

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -107,16 +107,16 @@ void main() {
 
       test('clone properties besides updatedSince', () {
         final filter = PackageFilter(
-          dependsOn: ['a'],
-          dirExists: ['a'],
-          fileExists: ['a'],
+          dependsOn: const ['a'],
+          dirExists: const ['a'],
+          fileExists: const ['a'],
           flutter: true,
           scope: [Glob('a')],
           ignore: [Glob('a')],
           includeDependencies: true,
           includeDependents: true,
           includePrivatePackages: false,
-          noDependsOn: ['a'],
+          noDependsOn: const ['a'],
           nullSafe: true,
           published: true,
           updatedSince: '123',

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -160,7 +160,7 @@ PackageConfig packageConfigForPackageAt(Directory dir) {
     ),
   );
 
-  return PackageConfig.fromJson(json.decode(source) as Map);
+  return PackageConfig.fromJson(json.decode(source) as Map<String, Object?>);
 }
 
 class PackageConfig {
@@ -170,17 +170,17 @@ class PackageConfig {
     required this.generator,
   });
 
-  PackageConfig.fromJson(Map<Object?, Object?> json)
+  PackageConfig.fromJson(Map<String, Object?> json)
       : this._(
           json,
           generator: json['generator']! as String,
           packages: (json['packages']! as List)
-              .cast<Map>()
+              .cast<Map<String, Object?>>()
               .map((e) => PackageDependencyConfig.fromJson(e))
               .toList(),
         );
 
-  final Map _map;
+  final Map<String, Object?> _map;
   final List<PackageDependencyConfig> packages;
   final String generator;
 
@@ -198,7 +198,7 @@ class PackageDependencyConfig {
     required this.packageUri,
   });
 
-  PackageDependencyConfig.fromJson(Map<Object?, Object?> json)
+  PackageDependencyConfig.fromJson(Map<String, Object?> json)
       : this._(
           json,
           name: json['name']! as String,
@@ -209,7 +209,7 @@ class PackageDependencyConfig {
   final String name;
   final String rootUri;
   final String packageUri;
-  final Map _map;
+  final Map<String, Object?> _map;
 
   @override
   String toString() {

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -19,11 +19,10 @@ class TestLogger extends StandardLogger {
 
   /// All the logs in order that were emitted so far.
   ///
-  /// This includes both [stdout], [stderr] and [trace].
-  /// Logs from [trace] and [stderr] are respectively prefixed by `t-` and `e-`
-  /// such that:
+  /// This includes both [stdout], [stderr] and [trace]. Logs from [trace] and
+  /// [stderr] are respectively prefixed by `t-` and `e-` such that:
   ///
-  /// ```dart
+  /// ```dart main
   /// logger.stdout('Hello');
   /// logger.stderr('Error');
   /// logger.stdout('world');
@@ -37,8 +36,8 @@ class TestLogger extends StandardLogger {
   /// world
   /// ```
   ///
-  /// This both ensures that tests to not forget to check errors and
-  /// allows testing what the logs would actually look like.
+  /// This both ensures that tests to not forget to check errors and allows
+  /// testing what the logs would actually look like.
   String get output => _buffer.toString();
 
   @override

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -393,7 +393,7 @@ void main() {
       expect(
         () => MelosWorkspaceConfig(
           name: '',
-          repository: GitHubRepository(owner: 'invertase', name: 'melos'),
+          repository: const GitHubRepository(owner: 'invertase', name: 'melos'),
           packages: const [],
           commands: const CommandConfigs(
             version: VersionCommandConfigs(linkToCommits: true),

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -277,7 +277,7 @@ void main() {
         expect(
           IDEConfigs.fromYaml(const {'intellij': true}),
           isA<IDEConfigs>()
-              .having((e) => e.intelliJ.enabled, 'intelliJ.eneabled', true),
+              .having((e) => e.intelliJ.enabled, 'intelliJ.enabled', true),
         );
       });
     });
@@ -373,20 +373,22 @@ void main() {
 
   group('MelosWorkspaceConfig', () {
     test(
-        'throws if commands.version.linkToCommits == true but repository is missing',
-        () {
-      expect(
-        () => MelosWorkspaceConfig(
-          name: '',
-          packages: const [],
-          commands: const CommandConfigs(
-            version: VersionCommandConfigs(linkToCommits: true),
+      'throws if commands.version.linkToCommits == true but repository is '
+      'missing',
+      () {
+        expect(
+          () => MelosWorkspaceConfig(
+            name: '',
+            packages: const [],
+            commands: const CommandConfigs(
+              version: VersionCommandConfigs(linkToCommits: true),
+            ),
+            path: testWorkspacePath,
           ),
-          path: testWorkspacePath,
-        ),
-        throwsMelosConfigException(),
-      );
-    });
+          throwsMelosConfigException(),
+        );
+      },
+    );
 
     test('accepts commands.version.linkToCommits == true if repository exists',
         () {


### PR DESCRIPTION
## Description

- Add rules to `all_lint_rules.yaml` that have been added since the file was created.
- Enable stricter static checks in `language` instead of `strong-mode`.
- Enable `no_default_cases`.
- Enable `lines_longer_than_80_chars`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
