### PR TITLE
fix: false positive for non-unique packages

### DIFF
--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -16,6 +16,7 @@
  */
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -394,7 +395,8 @@ class PackageMap {
       currentDirectoryPath: workspacePath,
     );
 
-    final pubspecsByResolvedPath = <String, File>{};
+    final pubspecsByResolvedPath =
+        HashMap<String, File>(equals: p.equals, hashCode: p.hash);
 
     Stream<FileSystemEntity> allWorkspaceEntities() async* {
       final workspaceDir = Directory(workspacePath);


### PR DESCRIPTION
It is possible that `resolvePackages` finds the same package twice, under paths that point to the same location but are represented by `String`s that are not equal.

This change ensures a package is only found once by using functions from  `package:path` for using paths as keys in a `Map`.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
