### PR TITLE
fix: `scripts.*.exec.failFast` option in `melos.yaml`

### DIFF
--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -402,8 +402,10 @@ class Script {
       if (exec.concurrency != null) {
         parts.addAll(['--concurrency', '${exec.concurrency}']);
       }
-      if (exec.failFast != null) {
-        parts.addAll(['--fail-fast', '${exec.failFast}']);
+
+      // --fail-fast is a flag and as such does not accept any value
+      if (exec.failFast ?? false) {
+        parts.add('--fail-fast');
       }
 
       parts.addAll(['--', _quoteScript(run)]);


### PR DESCRIPTION
## Description

`--fail-fast` is a flag and not an option and as such does not accept any value.

### Example

This config is currently broken as in the generated command `--fail-fast true` is not valid syntax.

```yaml
scripts:
  lint:
    run: flutter analyze
    exec:
      failFast: true
      concurrency: 1
```

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
