### PR TITLE
fix: run commands in single shell

### DIFF
--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -74,7 +74,7 @@ mixin _ExecMixin on _Melos {
       environment.remove(envKeyMelosTerminalWidth);
     }
 
-    return startProcess(
+    return startCommand(
       execArgs,
       logger: logger,
       environment: environment,

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -158,7 +158,7 @@ mixin _RunMixin on _Melos {
         .child(runningLabel)
         .newLine();
 
-    return startProcess(
+    return startCommand(
       scriptParts..addAll(extraArgs),
       logger: logger,
       environment: environment,

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -183,7 +183,7 @@ class MelosWorkspace {
       if (childProcessPath != null) 'PATH': childProcessPath!,
     };
 
-    return utils.startProcess(
+    return utils.startCommand(
       execArgs,
       logger: logger,
       environment: environment,
@@ -203,7 +203,7 @@ class MelosWorkspace {
       if (childProcessPath != null) 'PATH': childProcessPath!,
     };
 
-    return utils.startProcess(
+    return utils.startCommand(
       execArgs,
       logger: logger,
       environment: environment,

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -1,11 +1,14 @@
 import 'dart:io';
 
+import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
+import 'package:melos/src/logging.dart';
 import 'package:path/path.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+import 'matchers.dart';
 import 'utils.dart';
 
 void main() {
@@ -69,6 +72,32 @@ void main() {
           useFlutter: false,
         ),
         [join(sdkPath, 'bin', 'dart'), 'pub'],
+      );
+    });
+  });
+
+  group('startProcess', () {
+    test('runs command chain in single shell', () async {
+      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final testDir = p.join(workspaceDir.path, 'test');
+
+      ensureDir(testDir);
+
+      final logger = TestLogger();
+      await startCommand(
+        [
+          'cd',
+          'test',
+          '&&',
+          if (Platform.isWindows) 'cd' else 'pwd',
+        ],
+        logger: logger.toMelosLogger(),
+        workingDirectory: workspaceDir.path,
+      );
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii('$testDir\n'),
       );
     });
   });


### PR DESCRIPTION
This change removes `runInShell: true` from `Process.start` when
executing commands. This option is unnecessary since Melos is spawning
a shell itself to execute the command. Using `runInShell: true`
becomes a problem for command chains (e.g. '&&' or '||').
In this case only the first command is executed in the shell that Melos
is spawning and the rest of the commands are executed in the shell
spawned by `Process.start`.

The change also cleans up a few other related bits of code.

Fixes #367

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
