### PR TITLE
docs: add yak_packages reference to docs/index

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -36,6 +36,7 @@ The following projects are using Melos:
 - [kmartins/groveman](https://github.com/kmartins/groveman)
 - [ApptiveGrid/apptive_grid_flutter](https://github.com/ApptiveGrid/apptive_grid_flutter)
 - [flutternetwork/WiFiFlutter](https://github.com/flutternetwork/WiFiFlutter)
+- [iapicca/yak_packages](https://github.com/iapicca/yak_packages)
 
 > Submit a PR if you'd like to add your project to the list.
 > Update the 

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -103,6 +103,7 @@ The following projects are using Melos:
 - [danvick/flutter_form_builder](https://github.com/danvick/flutter_form_builder)
 - [kmartins/groveman](https://github.com/kmartins/groveman)
 - [flutternetwork/WiFiFlutter](https://github.com/flutternetwork/WiFiFlutter)
+- [iapicca/yak_packages](https://github.com/iapicca/yak_packages)
 
 > Submit a PR if you'd like to add your project to the list.
 > Update the [README.md](https://github.com/invertase/melos/edit/main/packages/melos/README.md) and the


### PR DESCRIPTION
## Description

add [yak_packages](https://github.com/iapicca/yak_packages) to [docs/index]([docs](https://github.com/invertase/melos/edit/main/docs/index.mdx))

it's a mono repo for the following packages:

| Package | Link |
|--------|-----|
| [byte_token](https://github.com/iapicca/yak_packages/tree/master/packages/byte_token) | [pub](https://pub.dev/packages/byte_token) |
| [stub](https://github.com/iapicca/yak_packages/tree/master/packages/stub) | [pub](https://pub.dev/packages/stub) |
| [yak_flutter](https://github.com/iapicca/yak_packages/tree/master/packages/yak_flutter) | [pub](https://pub.dev/packages/yak_flutter) |
| [yak_result](https://github.com/iapicca/yak_packages/tree/master/packages/yak_result) | [pub](https://pub.dev/packages/yak_result) |
| [yak_runner](https://github.com/iapicca/yak_packages/tree/master/packages/yak_runner) | [pub](https://pub.dev/packages/yak_runner) |
| [yak_test](https://github.com/iapicca/yak_packages/tree/master/packages/yak_test) | [pub](https://pub.dev/packages/yak_test) |
| [yak_tween](https://github.com/iapicca/yak_packages/tree/master/packages/yak_tween) | [pub](https://pub.dev/packages/yak_tween) |
| [yak_utils](https://github.com/iapicca/yak_packages/tree/master/packages/yak_utils) | [pub](https://pub.dev/packages/yak_utils) |



## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore

fixes https://github.com/invertase/melos/issues/382