### PR TITLE
feat: add `--dependent-preid` option

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -90,7 +90,17 @@ melos version -a
 When run with this option, `melos version` will increment prerelease versions using the specified prerelease identifier, e.g. using a "beta" preid along with the --prerelease flag would result in a version in the format "1.0.0-1.0.beta.0". Applies only to Conventional Commits based versioning.
 
 ```bash
-melos version --preid=beta
+melos version --prerelease --preid=beta
+```
+
+## --dependent-preid
+
+This option is the same as --preid, but only applies to packages that are versioned due to a
+change in a dependency version. When this option is not provided but the --preid option is, the
+value of the --preid option will be used instead.
+
+```bash
+melos version --prerelease --dependent-preid=beta
 ```
 
 ## --message (-m)

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -120,6 +120,13 @@ class VersionCommand extends MelosCommand {
           'result in a version in the format "1.0.0-1.0.nullsafety.0". '
           'Applies only to Conventional Commits based versioning.',
     );
+    argParser.addOption(
+      'dependent-preid',
+      help: 'This option is the same as --preid, but only applies to packages '
+          'that are versioned due to a change in a dependency version. '
+          'When this option is not provided but the --preid option is, the '
+          'value of the --preid option will be used instead.',
+    );
     argParser.addMultiOption(
       'manual-version',
       abbr: 'V',
@@ -194,6 +201,7 @@ class VersionCommand extends MelosCommand {
       var updateDependentsVersions = argResults!['dependent-versions'] as bool;
       final versionPrivatePackages = argResults!['all'] as bool;
       final preid = argResults!['preid'] as String?;
+      final dependentPreid = argResults!['dependent-preid'] as String?;
       final manualVersionArgs = argResults!['manual-version'] as List<String>;
 
       final manualVersions = _parseManualVersions(manualVersionArgs);
@@ -227,6 +235,7 @@ class VersionCommand extends MelosCommand {
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
         preid: preid,
+        dependentPreid: dependentPreid,
         asPrerelease: asPrerelease,
         asStableRelease: asStableRelease,
         message: commitMessage,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -17,6 +17,7 @@ mixin _VersionMixin on _RunMixin {
     // all
     bool showPrivatePackages = false,
     String? preid,
+    String? dependentPreid,
     bool versionPrivatePackages = false,
     Map<String, versioning.ManualVersionChange> manualVersions = const {},
   }) async {
@@ -237,11 +238,7 @@ mixin _VersionMixin on _RunMixin {
             // specifically excluded.
             // graduate: false,
             prerelease: asPrerelease,
-            // TODO Should dependent packages also get the same preid, can we
-            // expose this as an option?
-            // TODO In the case of "nullsafety" it doesn't make sense for
-            // dependent packages to also become nullsafety preid versions.
-            // preid: preid,
+            preid: dependentPreid ?? preid,
             logger: logger,
           ),
         );


### PR DESCRIPTION
Previously, the preid of dependents was always `dev`.
Now `--preid` is used, if provided, unless `--dependent-preid` is provided.

Fixes #310

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
