### PR TITLE
fix: Merge commits should be versioned

### DIFF
--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -93,13 +93,24 @@ void main() {
       'correctly parses commit with prefix before conventional commit type',
       () {
         const commitMessage = 'Merged PR 404: feat(scope): new feature';
-        final conventionalCommit = ConventionalCommit.tryParse(commitMessage);
-        expect(conventionalCommit?.type, 'feat');
-        expect(conventionalCommit?.scopes, ['scope']);
-        expect(conventionalCommit?.description, 'new feature');
-        expect(conventionalCommit?.isMergeCommit, true);
+        final conventionalCommit = ConventionalCommit.tryParse(commitMessage)!;
+        expect(conventionalCommit.type, 'feat');
+        expect(conventionalCommit.scopes, ['scope']);
+        expect(conventionalCommit.description, 'new feature');
+        expect(conventionalCommit.isMergeCommit, true);
       },
     );
+
+    test('parses merge commits which are not conventional commits', () {
+      const commitMessage = 'Merged foo into bar';
+      final conventionalCommit = ConventionalCommit.tryParse(commitMessage)!;
+      expect(conventionalCommit.type, isNull);
+      expect(conventionalCommit.scopes, isEmpty);
+      expect(conventionalCommit.description, isNull);
+      expect(conventionalCommit.body, isNull);
+      expect(conventionalCommit.header, commitMessage);
+      expect(conventionalCommit.isMergeCommit, true);
+    });
 
     test('correctly handles messages with a `*` scope', () {
       final commit = ConventionalCommit.tryParse(commitMessageStarScope);
@@ -326,6 +337,10 @@ void main() {
       expect(
         ConventionalCommit.tryParse("Merge branch 'main' of invertase/melos")!
             .isMergeCommit,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse('Merged PR #0: fix: foo')!.isMergeCommit,
         isTrue,
       );
       expect(

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -170,20 +170,16 @@ extension ChangelogStringBufferExtension on StringBuffer {
           write(' ');
         }
 
-        if (parsedMessage.isMergeCommit) {
-          writePunctuated(processCommitHeader(parsedMessage.header));
-        } else {
-          writeBold(parsedMessage.type!.toUpperCase());
-          if (config.commands.version.includeScopes) {
-            if (parsedMessage.scopes.isNotEmpty) {
-              write('(');
-              write(parsedMessage.scopes.join(','));
-              write(')');
-            }
+        writeBold(parsedMessage.type!.toUpperCase());
+        if (config.commands.version.includeScopes) {
+          if (parsedMessage.scopes.isNotEmpty) {
+            write('(');
+            write(parsedMessage.scopes.join(','));
+            write(')');
           }
-          write(': ');
-          writePunctuated(processCommitHeader(parsedMessage.description!));
         }
+        write(': ');
+        writePunctuated(processCommitHeader(parsedMessage.description!));
 
         if (linkToCommits || includeCommitId) {
           final shortCommitId = commit.id.substring(0, 8);
@@ -208,11 +204,7 @@ List<RichGitCommit> _filteredAndSortedCommits(
   MelosPendingPackageUpdate update,
 ) {
   final commits = update.commits
-      .where(
-        (commit) =>
-            !commit.parsedMessage.isMergeCommit &&
-            commit.parsedMessage.isVersionableCommit,
-      )
+      .where((commit) => commit.parsedMessage.isVersionableCommit)
       .toList();
 
   // Sort so that Breaking Changes appear at the top.

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -34,7 +34,6 @@ extension ConventionalCommitVersioningExtension on ConventionalCommit {
   /// Whether this commit should trigger a version bump in it's residing
   /// package.
   bool get isVersionableCommit {
-    if (isMergeCommit) return false;
     return isBreakingChange ||
         [
           'docs',

--- a/packages/melos/test/changelog_test.dart
+++ b/packages/melos/test/changelog_test.dart
@@ -59,6 +59,34 @@ void main() {
         contains('**FEAT**(a,b): c.'),
       );
     });
+
+    test('merge commit without conventional commit', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      expect(
+        renderCommitPackageUpdate(
+          workspace,
+          package,
+          testCommit(message: 'Merge foo into bar'),
+        ),
+        '## 0.0.0+1\n\n',
+      );
+    });
+
+    test('merge commit with conventional commit', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      expect(
+        renderCommitPackageUpdate(
+          workspace,
+          package,
+          testCommit(message: 'Merge PR #1: feat: a'),
+        ),
+        contains('**FEAT**: a.'),
+      );
+    });
   });
 
   group('linkToCommits', () {

--- a/packages/melos/test/common/versioning_test.dart
+++ b/packages/melos/test/common/versioning_test.dart
@@ -31,6 +31,18 @@ void main() {
           .isVersionableCommit,
       isFalse,
     );
+    expect(
+      ConventionalCommit.tryParse('Merged PR 1337: bar foo')!.isVersionableCommit,
+      isFalse,
+    );
+    expect(
+      ConventionalCommit.tryParse('Merged PR 1337: fix(1338): bar foo')!.isVersionableCommit,
+      isTrue,
+    );
+    expect(
+      ConventionalCommit.tryParse('Merged PR: fix(*): bar foo')!.isVersionableCommit,
+      isTrue,
+    );
   });
 
   test('semverReleaseType', () {

--- a/packages/melos/test/common/versioning_test.dart
+++ b/packages/melos/test/common/versioning_test.dart
@@ -32,16 +32,23 @@ void main() {
       isFalse,
     );
     expect(
-      ConventionalCommit.tryParse('Merged PR 1337: bar foo')!.isVersionableCommit,
+      ConventionalCommit.tryParse('Merged PR 1337: bar foo')!
+          .isVersionableCommit,
       isFalse,
     );
     expect(
-      ConventionalCommit.tryParse('Merged PR 1337: fix(1338): bar foo')!.isVersionableCommit,
+      ConventionalCommit.tryParse('Merged PR 1337: fix(1338): bar foo')!
+          .isVersionableCommit,
       isTrue,
     );
     expect(
-      ConventionalCommit.tryParse('Merged PR: fix(*): bar foo')!.isVersionableCommit,
+      ConventionalCommit.tryParse('Merged PR: fix(*): bar foo')!
+          .isVersionableCommit,
       isTrue,
+    );
+    expect(
+      ConventionalCommit.tryParse('Merged foo into bar')!.isVersionableCommit,
+      isFalse,
     );
   });
 


### PR DESCRIPTION
## Description

Merge commits were not versioned. Example:

```Merged PR 123: fix(3305): change url launcher to open externally```

Fixes a regression of #258.

Me and @spydon fixed this together :)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
