### PR TITLE
feat: add support for `melos_overrides.yaml` + `command/bootstrap/dependencyOverridePaths`

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -8,8 +8,9 @@ description: Configure Melos using the `melos.yaml` file.
 Every project requires a `melos.yaml` project in the root. The below outlines
 all the configurable fields and their purpose.
 
-Additionally, projects may include a `melos_overrides.yaml` file to override any `melos.yaml` field. This is useful for
-making untracked customizations to a project.
+Additionally, projects may include a `melos_overrides.yaml` file to override any
+`melos.yaml` field. This is useful for making untracked customizations to a
+project.
 
 ## `name`
 
@@ -112,22 +113,6 @@ ignore:
 > You can also expand the scope of ignored packages on a per-command basis via
 > the [`--scope` filter](/filters#scope) flag.
 
-## `dependencyOverrides`
-
-> optional
-
-A list of extra packages in the workspace directory that should be added to each workspace package's dependency
-overrides. Each entry can be a specific path or a [glob] pattern.
-
-Note that this option has a camelCase key, unlike the snake_case key used in `pubspec.yaml`.
-
-Tip: External local packages can be symlinked into the workspace directory.
-
-```yaml
-dependencyOverrides:
-  - 'external_dependencies/**'
-```
-
 ## `ide`
 
 > optional
@@ -173,6 +158,22 @@ Configuration relating to specific Melos commands such as versioning.
 ### `command/bootstrap`
 
 Configuration for the `bootstrap` command.
+
+### `command/bootstrap/dependencyOverridePaths`
+
+> optional
+
+A list of paths to local packages realtive to the workspace directory that
+should be added to each workspace package's dependency overrides. Each entry can
+be a specific path or a [glob] pattern.
+
+**Tip:** External local packages can be referenced using paths relative to the
+workspace root.
+
+```yaml
+dependencyOverridePaths:
+  - '../external_project/packages/**'
+```
 
 ### `command/bootstrap/runPubGetInParallel`
 

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -109,6 +109,20 @@ ignore:
 > You can also expand the scope of ignored packages on a per-command basis via
 > the [`--scope` filter](/filters#scope) flag.
 
+## `dependency_overrides`
+
+> optional
+
+A list of extra packages in the workspace directory that should be added to each workspace package's dependency
+overrides. Each entry can be a specific path or a [glob] pattern.
+
+Tip: External local packages can be symlinked into the workspace directory.
+
+```yaml
+dependency_overrides:
+  - 'external_dependencies/**'
+```
+
 ## `ide`
 
 > optional

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -8,6 +8,9 @@ description: Configure Melos using the `melos.yaml` file.
 Every project requires a `melos.yaml` project in the root. The below outlines
 all the configurable fields and their purpose.
 
+Additionally, projects may include a `melos_overrides.yaml` file to override any `melos.yaml` field. This is useful for
+making untracked customizations to a project.
+
 ## `name`
 
 > required

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -112,17 +112,19 @@ ignore:
 > You can also expand the scope of ignored packages on a per-command basis via
 > the [`--scope` filter](/filters#scope) flag.
 
-## `dependency_overrides`
+## `dependencyOverrides`
 
 > optional
 
 A list of extra packages in the workspace directory that should be added to each workspace package's dependency
 overrides. Each entry can be a specific path or a [glob] pattern.
 
+Note that this option has a camelCase key, unlike the snake_case key used in `pubspec.yaml`.
+
 Tip: External local packages can be symlinked into the workspace directory.
 
 ```yaml
-dependency_overrides:
+dependencyOverrides:
   - 'external_dependencies/**'
 ```
 

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -113,7 +113,8 @@ mixin _BootstrapMixin on _CleanMixin {
     }
 
     // Add custom workspace overrides.
-    for (final dependencyOverride in workspace.dependencyOverrides.values) {
+    for (final dependencyOverride
+        in workspace.dependencyOverridePackages.values) {
       melosDependencyOverrides[dependencyOverride.name] = PathReference(
         utils.relativePath(dependencyOverride.path, package.path),
       );

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -113,6 +113,13 @@ mixin _BootstrapMixin on _CleanMixin {
       }
     }
 
+    // Add custom dependency overrides.
+    for (final dependencyOverride in workspace.dependencyOverrides.values) {
+      melosDependencyOverrides[dependencyOverride.name] = PathReference(
+        utils.relativePath(dependencyOverride.path, package.path),
+      );
+    }
+
     // Load current pubspec_overrides.yaml.
     final pubspecOverridesFile =
         utils.pubspecOverridesPathForDirectory(package.path);

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -101,24 +101,28 @@ mixin _BootstrapMixin on _CleanMixin {
   ) async {
     final allTransitiveDependencies =
         package.allTransitiveDependenciesInWorkspace;
-    final melosDependencyOverrides = {...package.pubSpec.dependencyOverrides};
+    final melosDependencyOverrides = <String, DependencyReference>{};
 
     // Traversing all packages so that transitive dependencies for the
-    // bootstraped packages are setup properly.
+    // bootstrapped packages are setup properly.
     for (final otherPackage in workspace.allPackages.values) {
-      if (allTransitiveDependencies.containsKey(otherPackage.name) &&
-          !melosDependencyOverrides.containsKey(otherPackage.name)) {
+      if (allTransitiveDependencies.containsKey(otherPackage.name)) {
         melosDependencyOverrides[otherPackage.name] =
             PathReference(utils.relativePath(otherPackage.path, package.path));
       }
     }
 
-    // Add custom dependency overrides.
+    // Add custom workspace overrides.
     for (final dependencyOverride in workspace.dependencyOverrides.values) {
       melosDependencyOverrides[dependencyOverride.name] = PathReference(
         utils.relativePath(dependencyOverride.path, package.path),
       );
     }
+
+    // Add existing dependency overrides from pubspec.yaml last, overwriting
+    // overrides that would be made by Melos, to provide granular control at a
+    // package level.
+    melosDependencyOverrides.addAll(package.pubSpec.dependencyOverrides);
 
     // Load current pubspec_overrides.yaml.
     final pubspecOverridesFile =

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -352,7 +352,7 @@ String listAsPaddedTable(List<List<String>> table, {int paddingSize = 1}) {
 
 extension YamlUtils on YamlNode {
   /// Converts a YAML node to a regular mutable Dart object.
-  Object? unYaml() {
+  Object? toPlainObject() {
     final node = this;
     if (node is YamlScalar) {
       return node.value;
@@ -360,11 +360,11 @@ extension YamlUtils on YamlNode {
     if (node is YamlMap) {
       return {
         for (final entry in node.nodes.entries)
-          (entry.key as YamlNode).unYaml(): entry.value.unYaml(),
+          (entry.key as YamlNode).toPlainObject(): entry.value.toPlainObject(),
       };
     }
     if (node is YamlList) {
-      return node.nodes.map((node) => node.unYaml()).toList();
+      return node.nodes.map((node) => node.toPlainObject()).toList();
     }
     throw FormatException(
       'Unsupported YAML node type encountered: ${node.runtimeType}',

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -350,6 +350,30 @@ String listAsPaddedTable(List<List<String>> table, {int paddingSize = 1}) {
   return output.join('\n');
 }
 
+/// Merges two YAML maps together, overriding any values in [base] with those
+/// with the same key in [overlay].
+void mergeYaml(Map<Object?, Object?> base, Map<Object?, Object?> overlay) {
+  for (final entry in overlay.entries) {
+    final overlayValue = entry.value;
+    final baseValue = base[entry.key];
+    if (overlayValue is Map<Object?, Object?>) {
+      if (baseValue is Map<Object?, Object?>) {
+        mergeYaml(baseValue, overlayValue);
+      } else {
+        base[entry.key] = overlayValue;
+      }
+    } else if (overlayValue is List<Object?>) {
+      if (baseValue is List<Object?>) {
+        baseValue.addAll(overlayValue);
+      } else {
+        base[entry.key] = overlayValue;
+      }
+    } else {
+      base[entry.key] = overlayValue;
+    }
+  }
+}
+
 /// Generate a link for display in a terminal.
 ///
 /// Similar to `<a href="$url">$text</a>` in HTML.

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -297,6 +297,9 @@ String melosYamlPathForDirectory(String directory) =>
 String melosStatePathForDirectory(String directory) =>
     p.join(directory, '.melos');
 
+String melosOverridesYamlPathForDirectory(String directory) =>
+    p.join(directory, 'melos_overrides.yaml');
+
 String pubspecPathForDirectory(String directory) =>
     p.join(directory, 'pubspec.yaml');
 

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -615,6 +615,17 @@ The packages that caused the problem are:
       _logger,
     );
   }
+
+  /// Creates a new [PackageMap] containing the contents of the [overlay]
+  /// [PackageMap] combined with this [PackageMap]. Any entries in the original
+  /// with duplicate keys existing in the [overlay] will be overwritten.
+  ///
+  /// The [MelosLogger] from this [PackageMap] will be used in the resultant
+  /// [PackageMap].
+  PackageMap operator +(PackageMap overlay) => PackageMap(
+        {..._map, ...overlay._map},
+        _logger,
+      );
 }
 
 extension on Iterable<Package> {

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -615,17 +615,6 @@ The packages that caused the problem are:
       _logger,
     );
   }
-
-  /// Creates a new [PackageMap] containing the contents of the [overlay]
-  /// [PackageMap] combined with this [PackageMap]. Any entries in the original
-  /// with duplicate keys existing in the [overlay] will be overwritten.
-  ///
-  /// The [MelosLogger] from this [PackageMap] will be used in the resultant
-  /// [PackageMap].
-  PackageMap operator +(PackageMap overlay) => PackageMap(
-        {..._map, ...overlay._map},
-        _logger,
-      );
 }
 
 extension on Iterable<Package> {

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -48,7 +48,7 @@ class MelosWorkspace {
     required this.config,
     required this.allPackages,
     required this.filteredPackages,
-    required this.dependencyOverrides,
+    required this.dependencyOverridePackages,
     required this.sdkPath,
     required this.logger,
   });
@@ -66,9 +66,9 @@ class MelosWorkspace {
       ignore: workspaceConfig.ignore,
       logger: logger,
     );
-    final dependencyOverrides = await PackageMap.resolvePackages(
+    final dependencyOverridePackages = await PackageMap.resolvePackages(
       workspacePath: workspaceConfig.path,
-      packages: workspaceConfig.dependencyOverrides,
+      packages: workspaceConfig.commands.bootstrap.dependencyOverridePaths,
       ignore: const [],
       logger: logger,
     );
@@ -82,7 +82,7 @@ class MelosWorkspace {
       allPackages: allPackages,
       logger: logger,
       filteredPackages: filteredPackages,
-      dependencyOverrides: dependencyOverrides,
+      dependencyOverridePackages: dependencyOverridePackages,
       sdkPath: resolveSdkPath(
         configSdkPath: workspaceConfig.sdkPath,
         envSdkPath: currentPlatform.environment[utils.envKeyMelosSdkPath],
@@ -104,15 +104,20 @@ class MelosWorkspace {
   /// Configuration as defined in the "melos.yaml" file if it exists.
   final MelosWorkspaceConfig config;
 
-  /// All packages according to [MelosWorkspaceConfig].
+  /// All packages managed in this Melos workspace.
   ///
-  /// Packages filtered by [MelosWorkspaceConfig.ignore] are not included.
+  /// Packages specified in [MelosWorkspaceConfig.packages] are included,
+  /// except for those specified in [MelosWorkspaceConfig.ignore].
   final PackageMap allPackages;
 
+  /// The packages in this Melos workspace after applying filters.
+  ///
+  /// Filters are typically specified on the command line.
   final PackageMap filteredPackages;
 
-  /// Packages to use as dependency overrides.
-  final PackageMap dependencyOverrides;
+  /// The packages specified in
+  /// [BootstrapCommandConfigs.dependencyOverridePaths].
+  final PackageMap dependencyOverridePackages;
 
   late final IdeWorkspace ide = IdeWorkspace._(this);
 

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -48,6 +48,7 @@ class MelosWorkspace {
     required this.config,
     required this.allPackages,
     required this.filteredPackages,
+    required this.dependencyOverrides,
     required this.sdkPath,
     required this.logger,
   });
@@ -65,6 +66,12 @@ class MelosWorkspace {
       ignore: workspaceConfig.ignore,
       logger: logger,
     );
+    final dependencyOverrides = await PackageMap.resolvePackages(
+      workspacePath: workspaceConfig.path,
+      packages: workspaceConfig.dependencyOverrides,
+      ignore: const [],
+      logger: logger,
+    );
 
     final filteredPackages = await allPackages.applyFilter(filter);
 
@@ -75,6 +82,7 @@ class MelosWorkspace {
       allPackages: allPackages,
       logger: logger,
       filteredPackages: filteredPackages,
+      dependencyOverrides: dependencyOverrides,
       sdkPath: resolveSdkPath(
         configSdkPath: workspaceConfig.sdkPath,
         envSdkPath: currentPlatform.environment[utils.envKeyMelosSdkPath],
@@ -102,6 +110,9 @@ class MelosWorkspace {
   final PackageMap allPackages;
 
   final PackageMap filteredPackages;
+
+  /// Packages to use as dependency overrides.
+  final PackageMap dependencyOverrides;
 
   late final IdeWorkspace ide = IdeWorkspace._(this);
 

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -651,13 +651,13 @@ class MelosWorkspaceConfig {
       ),
     );
     final dependencyOverrides = assertListIsA<String>(
-      key: 'dependency_overrides',
+      key: 'dependencyOverrides',
       map: yaml,
       isRequired: false,
       assertItemIsA: (index, value) => assertIsA<String>(
         value: value,
         index: index,
-        path: 'dependency_overrides',
+        path: 'dependencyOverrides',
       ),
     );
 
@@ -889,7 +889,7 @@ You must have one of the following to be a valid Melos workspace:
       'packages': packages.map((p) => p.toString()).toList(),
       if (ignore.isNotEmpty) 'ignore': ignore.map((p) => p.toString()).toList(),
       if (dependencyOverrides.isNotEmpty)
-        'dependency_overrides':
+        'dependencyOverrides':
             dependencyOverrides.map((p) => p.toString()).toList(),
       if (scripts.isNotEmpty) 'scripts': scripts.toJson(),
       'ide': ide.toJson(),
@@ -906,7 +906,7 @@ MelosWorkspaceConfig(
   repository: $repository,
   packages: $packages,
   ignore: $ignore,
-  dependency_overrides: $dependencyOverrides,
+  dependencyOverrides: $dependencyOverrides,
   scripts: ${scripts.toString().indent('  ')},
   ide: ${ide.toString().indent('  ')},
   commands: ${commands.toString().indent('  ')},

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -778,9 +778,12 @@ You must have one of the following to be a valid Melos workspace:
     final melosOverridesYamlPath =
         melosOverridesYamlPathForDirectory(melosWorkspaceDirectory.path);
     final overridesYamlContents = await loadYamlFile(melosOverridesYamlPath);
+    if (overridesYamlContents != null) {
+      mergeYaml(yamlContents, overridesYamlContents);
+    }
 
     return MelosWorkspaceConfig.fromYaml(
-      {...yamlContents, ...?overridesYamlContents},
+      yamlContents,
       path: melosWorkspaceDirectory.path,
     )..validatePhysicalWorkspace();
   }

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -761,8 +761,12 @@ You must have one of the following to be a valid Melos workspace:
       throw MelosConfigException('Failed to parse the melos.yaml file');
     }
 
+    final melosOverridesYamlPath =
+        melosOverridesYamlPathForDirectory(melosWorkspaceDirectory.path);
+    final overridesYamlContents = await loadYamlFile(melosOverridesYamlPath);
+
     return MelosWorkspaceConfig.fromYaml(
-      yamlContents,
+      {...yamlContents, ...?overridesYamlContents},
       path: melosWorkspaceDirectory.path,
     )..validatePhysicalWorkspace();
   }

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -769,7 +769,8 @@ You must have one of the following to be a valid Melos workspace:
 
     final melosYamlPath =
         melosYamlPathForDirectory(melosWorkspaceDirectory.path);
-    final yamlContents = await loadYamlFile(melosYamlPath);
+    final yamlContents =
+        (await loadYamlFile(melosYamlPath))?.unYaml() as Map<Object?, Object?>?;
 
     if (yamlContents == null) {
       throw MelosConfigException('Failed to parse the melos.yaml file');
@@ -777,9 +778,10 @@ You must have one of the following to be a valid Melos workspace:
 
     final melosOverridesYamlPath =
         melosOverridesYamlPathForDirectory(melosWorkspaceDirectory.path);
-    final overridesYamlContents = await loadYamlFile(melosOverridesYamlPath);
+    final overridesYamlContents = (await loadYamlFile(melosOverridesYamlPath))
+        ?.unYaml() as Map<Object?, Object?>?;
     if (overridesYamlContents != null) {
-      mergeYaml(yamlContents, overridesYamlContents);
+      mergeMap(yamlContents, overridesYamlContents);
     }
 
     return MelosWorkspaceConfig.fromYaml(

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -769,8 +769,8 @@ You must have one of the following to be a valid Melos workspace:
 
     final melosYamlPath =
         melosYamlPathForDirectory(melosWorkspaceDirectory.path);
-    final yamlContents =
-        (await loadYamlFile(melosYamlPath))?.unYaml() as Map<Object?, Object?>?;
+    final yamlContents = (await loadYamlFile(melosYamlPath))?.toPlainObject()
+        as Map<Object?, Object?>?;
 
     if (yamlContents == null) {
       throw MelosConfigException('Failed to parse the melos.yaml file');
@@ -779,7 +779,7 @@ You must have one of the following to be a valid Melos workspace:
     final melosOverridesYamlPath =
         melosOverridesYamlPathForDirectory(melosWorkspaceDirectory.path);
     final overridesYamlContents = (await loadYamlFile(melosOverridesYamlPath))
-        ?.unYaml() as Map<Object?, Object?>?;
+        ?.toPlainObject() as Map<Object?, Object?>?;
     if (overridesYamlContents != null) {
       mergeMap(yamlContents, overridesYamlContents);
     }

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -556,6 +556,7 @@ class MelosWorkspaceConfig {
     this.repository,
     required this.packages,
     this.ignore = const [],
+    this.dependencyOverrides = const [],
     this.scripts = Scripts.empty,
     this.ide = IDEConfigs.empty,
     this.commands = CommandConfigs.empty,
@@ -649,6 +650,16 @@ class MelosWorkspaceConfig {
         path: 'ignore',
       ),
     );
+    final dependencyOverrides = assertListIsA<String>(
+      key: 'dependency_overrides',
+      map: yaml,
+      isRequired: false,
+      assertItemIsA: (index, value) => assertIsA<String>(
+        value: value,
+        index: index,
+        path: 'dependency_overrides',
+      ),
+    );
 
     final scriptsMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'scripts',
@@ -680,6 +691,9 @@ class MelosWorkspaceConfig {
           .toList(),
       ignore: ignore
           .map((ignore) => createGlob(ignore, currentDirectoryPath: path))
+          .toList(),
+      dependencyOverrides: dependencyOverrides
+          .map((override) => createGlob(override, currentDirectoryPath: path))
           .toList(),
       scripts: scriptsMap == null
           ? Scripts.empty
@@ -787,6 +801,10 @@ You must have one of the following to be a valid Melos workspace:
   /// packages.
   final List<Glob> ignore;
 
+  /// A list of [Glob]s for paths that contain packages to be used as dependency
+  /// overrides.
+  final List<Glob> dependencyOverrides;
+
   /// A list of scripts that can be executed with `melos run` or will be
   /// executed before/after some specific melos commands.
   final Scripts scripts;
@@ -839,6 +857,8 @@ You must have one of the following to be a valid Melos workspace:
       other.repository == repository &&
       const DeepCollectionEquality().equals(other.packages, packages) &&
       const DeepCollectionEquality().equals(other.ignore, ignore) &&
+      const DeepCollectionEquality()
+          .equals(other.dependencyOverrides, dependencyOverrides) &&
       other.scripts == scripts &&
       other.ide == ide &&
       other.commands == commands;
@@ -851,6 +871,7 @@ You must have one of the following to be a valid Melos workspace:
       repository.hashCode ^
       const DeepCollectionEquality().hash(packages) &
           const DeepCollectionEquality().hash(ignore) ^
+      const DeepCollectionEquality().hash(dependencyOverrides) ^
       scripts.hashCode ^
       ide.hashCode ^
       commands.hashCode;
@@ -862,6 +883,9 @@ You must have one of the following to be a valid Melos workspace:
       if (repository != null) 'repository': repository!,
       'packages': packages.map((p) => p.toString()).toList(),
       if (ignore.isNotEmpty) 'ignore': ignore.map((p) => p.toString()).toList(),
+      if (dependencyOverrides.isNotEmpty)
+        'dependency_overrides':
+            dependencyOverrides.map((p) => p.toString()).toList(),
       if (scripts.isNotEmpty) 'scripts': scripts.toJson(),
       'ide': ide.toJson(),
       'command': commands.toJson(),
@@ -877,6 +901,7 @@ MelosWorkspaceConfig(
   repository: $repository,
   packages: $packages,
   ignore: $ignore,
+  dependency_overrides: $dependencyOverrides,
   scripts: ${scripts.toString().indent('  ')},
   ide: ${ide.toString().indent('  ')},
   commands: ${commands.toString().indent('  ')},

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -294,7 +294,7 @@ class VirtualWorkspaceBuilder {
       config: config,
       allPackages: packageMap,
       filteredPackages: packageMap,
-      dependencyOverrides: _buildVirtualPackageMap(const [], logger),
+      dependencyOverridePackages: _buildVirtualPackageMap(const [], logger),
       logger: logger,
       sdkPath: sdkPath,
     );

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -294,6 +294,7 @@ class VirtualWorkspaceBuilder {
       config: config,
       allPackages: packageMap,
       filteredPackages: packageMap,
+      dependencyOverrides: _buildVirtualPackageMap(const [], logger),
       logger: logger,
       sdkPath: sdkPath,
     );

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -119,7 +119,7 @@ void main() {
         'stu': ['another', 'different', 'type'],
         'yza': false,
       };
-      mergeYaml(base, overlay);
+      mergeMap(base, overlay);
       expect(base, const {
         'abc': 098,
         'def': [4, 5, 6, 7],

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -100,4 +100,35 @@ void main() {
       );
     });
   });
+
+  group('mergeYaml', () {
+    test('correctly handles value overriding', () {
+      final base = {
+        'abc': 123,
+        'def': [4, 5, 6],
+        'ghi': {'j': 'k', 'l': 'm', 'n': 'o'},
+        'pqr': ['1', '2', '3'],
+        'stu': 'aStringValue',
+        'vwx': true,
+      };
+      const overlay = {
+        'abc': 098,
+        'def': [7],
+        'ghi': {'j': 'i', 'l': 'm', 'n': 'o', 'p': 'q'},
+        'pqr': 'differentType',
+        'stu': ['another', 'different', 'type'],
+        'yza': false,
+      };
+      mergeYaml(base, overlay);
+      expect(base, const {
+        'abc': 098,
+        'def': [4, 5, 6, 7],
+        'ghi': {'j': 'i', 'l': 'm', 'n': 'o', 'p': 'q'},
+        'pqr': 'differentType',
+        'stu': ['another', 'different', 'type'],
+        'vwx': true,
+        'yza': false,
+      });
+    });
+  });
 }

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -16,6 +16,7 @@
 
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/git_repository.dart';
+import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/platform.dart';
 import 'package:melos/src/scripts.dart';
 import 'package:melos/src/workspace_configs.dart';
@@ -35,16 +36,19 @@ void main() {
     group('fromYaml', () {
       test('accepts empty object', () {
         expect(
-          BootstrapCommandConfigs.fromYaml(const {}),
+          BootstrapCommandConfigs.fromYaml(const {}, workspacePath: '.'),
           BootstrapCommandConfigs.empty,
         );
       });
 
       test('throws if runPubGetInParallel is not a bool', () {
         expect(
-          () => BootstrapCommandConfigs.fromYaml(const {
-            'runPubGetInParallel': 42,
-          }),
+          () => BootstrapCommandConfigs.fromYaml(
+            const {
+              'runPubGetInParallel': 42,
+            },
+            workspacePath: '.',
+          ),
           throwsMelosConfigException(),
         );
       });
@@ -54,10 +58,17 @@ void main() {
           BootstrapCommandConfigs.fromYaml(
             const {
               'runPubGetInParallel': false,
+              'runPubGetOffline': true,
+              'dependencyOverridePaths': ['a'],
             },
+            workspacePath: '.',
           ),
-          const BootstrapCommandConfigs(
+          BootstrapCommandConfigs(
             runPubGetInParallel: false,
+            runPubGetOffline: true,
+            dependencyOverridePaths: [
+              createGlob('a', currentDirectoryPath: '.')
+            ],
           ),
         );
       });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This adds two related features related to the feature request #409.

1) Adds a `melos_overrides.yaml` file, that can be used to override any field in `melos.yaml` (for making local, untracked changes)

   Example use cases: local `dependency_overrides`, customized IDE project generation

2) Adds a `dependency_overrides` configuration option, to add non-workspace packages to each package's `dependency_overrides.yaml`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
