### PR TITLE
fix: unicode characters in commit titles

### DIFF
--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -15,6 +15,7 @@
  *
  */
 
+import 'dart:convert';
 import 'dart:io';
 
 import '../logging.dart';
@@ -76,6 +77,8 @@ Future<ProcessResult> gitExecuteCommand({
     executable,
     arguments,
     workingDirectory: workingDirectory,
+    stdoutEncoding: utf8,
+    stderrEncoding: utf8,
   );
 
   if (throwOnExitCodeError && processResult.exitCode != 0) {

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -16,6 +16,7 @@
  */
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:meta/meta.dart';
@@ -230,6 +231,8 @@ class MelosWorkspace {
       ],
       runInShell: true,
       workingDirectory: melosToolPath,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
     );
 
     final pubDepList =


### PR DESCRIPTION
`Process.run()` uses the default [system encoding ](https://api.dart.dev/stable/2.18.3/dart-io/systemEncoding-constant.html) for stderr/stdout. Only on Windows this default to the active code page while on other systems this is always UTF-8. This commit forces `Process.run()` to use UTF-8 in all places and thus handle e.g. Chinese characters correctly.

Fixes #411.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
