### PR TITLE
Fix instructions on how to disable intellij

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -103,8 +103,7 @@ The default is `true`.
 
 ```yaml
 ide:
-  intellij:
-    enabled: false # set to false to override default and disable
+  intellij: false # set to false to override default and disable
 ```
 
 ## `ide/intellij/moduleNamePrefix`


### PR DESCRIPTION
## Description
Fix instructions on how to disable intellij

The instructions as given result in an error in the yaml syntax check: Incorrect type. Expected "boolean".

But when fixed as above, the error goes away and intellij seems disabled.  It's also possible the yaml schema is wrong and both variants work.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ X] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
