### PR TITLE
feat: support self-hosted git repositories

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -31,6 +31,16 @@ Supported hosts:
 repository: https://github.com/invertase/melos
 ```
 
+When using a self-hosted GitHub or GitLab instance, you can specify the repository location like this:
+
+```yaml
+repository:
+  type: gitlab
+  base: https://gitlab.example.dev
+  owner: invertase
+  name: melos
+```
+
 ## `sdkPath`
 
 > optional

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -36,7 +36,7 @@ When using a self-hosted GitHub or GitLab instance, you can specify the reposito
 ```yaml
 repository:
   type: gitlab
-  base: https://gitlab.example.dev
+  origin: https://gitlab.example.dev
   owner: invertase
   name: melos
 ```

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -71,7 +71,7 @@ mixin SupportsManualRelease on HostedGitRepository {
 @immutable
 class GitHubRepository extends HostedGitRepository with SupportsManualRelease {
   const GitHubRepository({
-    this.base = kDefaultBase,
+    this.base = defaultBase,
     required this.owner,
     required this.name,
   });
@@ -90,7 +90,7 @@ class GitHubRepository extends HostedGitRepository with SupportsManualRelease {
     throw FormatException('The URL $uri is not a valid GitHub repository URL.');
   }
 
-  static const kDefaultBase = 'https://github.com';
+  static const defaultBase = 'https://github.com';
 
   /// The base of the GitHub server, defaults to `https://github.com`.
   final String base;
@@ -152,7 +152,7 @@ GitHubRepository(
 @immutable
 class GitLabRepository extends HostedGitRepository {
   GitLabRepository({
-    String base = kDefaultBase,
+    String base = defaultBase,
     required this.owner,
     required this.name,
   }) : base = base.endsWith('/') ? base.substring(0, base.length - 1) : base;
@@ -171,7 +171,7 @@ class GitLabRepository extends HostedGitRepository {
     throw FormatException('The URL $uri is not a valid GitLab repository URL.');
   }
 
-  static const kDefaultBase = 'https://gitlab.com';
+  static const defaultBase = 'https://gitlab.com';
 
   /// The base of the GitLab server, defaults to `https://gitlab.com`.
   final String base;

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -631,3 +631,7 @@ String prettyEncodeJson(Object? value) =>
 extension OptionalArgResults on ArgResults {
   dynamic optional(String name) => wasParsed(name) ? this[name] : null;
 }
+
+String removeTrailingSlash(String url) {
+  return url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+}

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -473,22 +473,55 @@ class MelosWorkspaceConfig {
     }
 
     HostedGitRepository? repository;
-    final repositoryUrlString =
-        assertKeyIsA<String?>(key: 'repository', map: yaml);
-    if (repositoryUrlString != null) {
-      Uri repositoryUrl;
-      try {
-        repositoryUrl = Uri.parse(repositoryUrlString);
-      } on FormatException catch (e) {
-        throw MelosConfigException(
-          'The repository URL $repositoryUrlString is not a valid URL:\n $e',
-        );
-      }
+    if (yaml.containsKey('repository')) {
+      final repositoryYaml = yaml['repository'];
 
-      try {
-        repository = parseHostedGitRepositoryUrl(repositoryUrl);
-      } on FormatException catch (e) {
-        throw MelosConfigException(e.toString());
+      if (repositoryYaml is Map<Object?, Object?>) {
+        final type = assertKeyIsA<String>(
+          key: 'type',
+          map: repositoryYaml,
+          path: 'repository',
+        );
+        final base = assertKeyIsA<String>(
+          key: 'base',
+          map: repositoryYaml,
+          path: 'repository',
+        );
+        final owner = assertKeyIsA<String>(
+          key: 'owner',
+          map: repositoryYaml,
+          path: 'repository',
+        );
+        final name = assertKeyIsA<String>(
+          key: 'name',
+          map: repositoryYaml,
+          path: 'repository',
+        );
+
+        try {
+          repository = parseHostedGitRepositorySpec(type, base, owner, name);
+        } on FormatException catch (e) {
+          throw MelosConfigException(e.toString());
+        }
+      } else if (repositoryYaml is String) {
+        Uri repositoryUrl;
+        try {
+          repositoryUrl = Uri.parse(repositoryYaml);
+        } on FormatException catch (e) {
+          throw MelosConfigException(
+            'The repository URL $repositoryYaml is not a valid URL:\n $e',
+          );
+        }
+
+        try {
+          repository = parseHostedGitRepositoryUrl(repositoryUrl);
+        } on FormatException catch (e) {
+          throw MelosConfigException(e.toString());
+        }
+      } else if (repositoryYaml != null) {
+        throw MelosConfigException(
+          'The repository value must be a string or repository spec',
+        );
       }
     }
 

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -482,8 +482,8 @@ class MelosWorkspaceConfig {
           map: repositoryYaml,
           path: 'repository',
         );
-        final base = assertKeyIsA<String>(
-          key: 'base',
+        final origin = assertKeyIsA<String>(
+          key: 'origin',
           map: repositoryYaml,
           path: 'repository',
         );
@@ -499,7 +499,7 @@ class MelosWorkspaceConfig {
         );
 
         try {
-          repository = parseHostedGitRepositorySpec(type, base, owner, name);
+          repository = parseHostedGitRepositorySpec(type, origin, owner, name);
         } on FormatException catch (e) {
           throw MelosConfigException(e.toString());
         }

--- a/packages/melos/test/git_repository_test.dart
+++ b/packages/melos/test/git_repository_test.dart
@@ -24,6 +24,8 @@ void main() {
       test('parse GitHub repository URL correctly', () {
         final url = Uri.parse('https://github.com/a/b');
         final repo = GitHubRepository.fromUrl(url);
+
+        expect(repo.base, 'https://github.com');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://github.com/a/b/'));
@@ -47,6 +49,34 @@ void main() {
           'https://github.com/',
           'https://github.com',
         ].forEach(expectBadUrl);
+      });
+    });
+
+    group('fromSpec', () {
+      test('parse GitHub repository spec correctly', () {
+        const repo = GitHubRepository(
+          base: 'https://github.invertase.dev',
+          owner: 'a',
+          name: 'b',
+        );
+
+        expect(repo.base, 'https://github.invertase.dev');
+        expect(repo.owner, 'a');
+        expect(repo.name, 'b');
+        expect(repo.url, Uri.parse('https://github.invertase.dev/a/b/'));
+      });
+
+      test('parse GitHub repository spec with sub-path correctly', () {
+        const repo = GitHubRepository(
+          base: 'https://invertase.dev/github',
+          owner: 'a',
+          name: 'b',
+        );
+
+        expect(repo.base, 'https://invertase.dev/github');
+        expect(repo.owner, 'a');
+        expect(repo.name, 'b');
+        expect(repo.url, Uri.parse('https://invertase.dev/github/a/b/'));
       });
     });
 
@@ -78,6 +108,8 @@ void main() {
       test('parse GitLab repository URL correctly', () {
         final url = Uri.parse('https://gitlab.com/a/b');
         final repo = GitLabRepository.fromUrl(url);
+
+        expect(repo.base, 'https://gitlab.com');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://gitlab.com/a/b/'));
@@ -86,6 +118,8 @@ void main() {
       test('parse GitLab repository URL with nested groups correctly', () {
         final url = Uri.parse('https://gitlab.com/a/b/c');
         final repo = GitLabRepository.fromUrl(url);
+
+        expect(repo.base, 'https://gitlab.com');
         expect(repo.owner, 'a/b');
         expect(repo.name, 'c');
         expect(repo.url, Uri.parse('https://gitlab.com/a/b/c/'));
@@ -109,6 +143,62 @@ void main() {
           'https://gitlab.com/',
           'https://gitlab.com',
         ].forEach(expectBadUrl);
+      });
+    });
+
+    group('fromSpec', () {
+      test('parse GitLab repository spec correctly', () {
+        final repo = GitLabRepository(
+          base: 'https://gitlab.invertase.dev',
+          owner: 'a',
+          name: 'b',
+        );
+
+        expect(repo.base, 'https://gitlab.invertase.dev');
+        expect(repo.owner, 'a');
+        expect(repo.name, 'b');
+        expect(repo.url, Uri.parse('https://gitlab.invertase.dev/a/b/'));
+      });
+
+      test('parse GitLab repository spec with sub-path correctly', () {
+        final repo = GitLabRepository(
+          base: 'https://invertase.dev/gitlab',
+          owner: 'a',
+          name: 'b',
+        );
+
+        expect(repo.base, 'https://invertase.dev/gitlab');
+        expect(repo.owner, 'a');
+        expect(repo.name, 'b');
+        expect(repo.url, Uri.parse('https://invertase.dev/gitlab/a/b/'));
+      });
+
+      test('parse GitLab repository spec with nested groups correctly', () {
+        final repo = GitLabRepository(
+          base: 'https://gitlab.invertase.dev',
+          owner: 'a/b',
+          name: 'c',
+        );
+
+        expect(repo.base, 'https://gitlab.invertase.dev');
+        expect(repo.owner, 'a/b');
+        expect(repo.name, 'c');
+        expect(repo.url, Uri.parse('https://gitlab.invertase.dev/a/b/c/'));
+      });
+
+      test(
+          'parse GitLab repository spec with sub-path and nested groups '
+          'correctly', () {
+        final repo = GitLabRepository(
+          base: 'https://invertase.dev/gitlab',
+          owner: 'a/b',
+          name: 'c',
+        );
+
+        expect(repo.base, 'https://invertase.dev/gitlab');
+        expect(repo.owner, 'a/b');
+        expect(repo.name, 'c');
+        expect(repo.url, Uri.parse('https://invertase.dev/gitlab/a/b/c/'));
       });
     });
 
@@ -151,6 +241,42 @@ void main() {
     test('throws if URL cannot be parsed as URL to one of known hosts', () {
       expect(
         () => parseHostedGitRepositoryUrl(Uri.parse('https://example.com')),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('parseHostedGitRepositorySpec', () {
+    test('parses GitHub repository spec', () {
+      final repo = parseHostedGitRepositorySpec(
+        'github',
+        'https://github.invertase.com',
+        'a',
+        'b',
+      );
+
+      expect(repo, isA<GitHubRepository>());
+    });
+
+    test('parses GitLab repository spec', () {
+      final repo = parseHostedGitRepositorySpec(
+        'gitlab',
+        'https://gitlab.invertase.com',
+        'a',
+        'b',
+      );
+
+      expect(repo, isA<GitLabRepository>());
+    });
+
+    test('throws if URL cannot be parsed as URL to one of known hosts', () {
+      expect(
+        () => parseHostedGitRepositorySpec(
+          'example',
+          'https://example.com',
+          'a',
+          'b',
+        ),
         throwsFormatException,
       );
     });

--- a/packages/melos/test/git_repository_test.dart
+++ b/packages/melos/test/git_repository_test.dart
@@ -25,7 +25,7 @@ void main() {
         final url = Uri.parse('https://github.com/a/b');
         final repo = GitHubRepository.fromUrl(url);
 
-        expect(repo.base, 'https://github.com');
+        expect(repo.origin, 'https://github.com');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://github.com/a/b/'));
@@ -54,26 +54,26 @@ void main() {
 
     group('fromSpec', () {
       test('parse GitHub repository spec correctly', () {
-        const repo = GitHubRepository(
-          base: 'https://github.invertase.dev',
+        final repo = GitHubRepository(
+          origin: 'https://github.invertase.dev',
           owner: 'a',
           name: 'b',
         );
 
-        expect(repo.base, 'https://github.invertase.dev');
+        expect(repo.origin, 'https://github.invertase.dev');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://github.invertase.dev/a/b/'));
       });
 
       test('parse GitHub repository spec with sub-path correctly', () {
-        const repo = GitHubRepository(
-          base: 'https://invertase.dev/github',
+        final repo = GitHubRepository(
+          origin: 'https://invertase.dev/github',
           owner: 'a',
           name: 'b',
         );
 
-        expect(repo.base, 'https://invertase.dev/github');
+        expect(repo.origin, 'https://invertase.dev/github');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://invertase.dev/github/a/b/'));
@@ -81,7 +81,7 @@ void main() {
     });
 
     test('commitUrl returns correct URL', () {
-      const repo = GitHubRepository(owner: 'a', name: 'b');
+      final repo = GitHubRepository(owner: 'a', name: 'b');
       const commitId = 'b2841394a48cd7d84a4966a788842690e543b2ef';
 
       expect(
@@ -93,7 +93,7 @@ void main() {
     });
 
     test('issueUrl returns correct URL', () {
-      const repo = GitHubRepository(owner: 'a', name: 'b');
+      final repo = GitHubRepository(owner: 'a', name: 'b');
       const issueId = '123';
 
       expect(
@@ -109,7 +109,7 @@ void main() {
         final url = Uri.parse('https://gitlab.com/a/b');
         final repo = GitLabRepository.fromUrl(url);
 
-        expect(repo.base, 'https://gitlab.com');
+        expect(repo.origin, 'https://gitlab.com');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://gitlab.com/a/b/'));
@@ -119,7 +119,7 @@ void main() {
         final url = Uri.parse('https://gitlab.com/a/b/c');
         final repo = GitLabRepository.fromUrl(url);
 
-        expect(repo.base, 'https://gitlab.com');
+        expect(repo.origin, 'https://gitlab.com');
         expect(repo.owner, 'a/b');
         expect(repo.name, 'c');
         expect(repo.url, Uri.parse('https://gitlab.com/a/b/c/'));
@@ -149,12 +149,12 @@ void main() {
     group('fromSpec', () {
       test('parse GitLab repository spec correctly', () {
         final repo = GitLabRepository(
-          base: 'https://gitlab.invertase.dev',
+          origin: 'https://gitlab.invertase.dev',
           owner: 'a',
           name: 'b',
         );
 
-        expect(repo.base, 'https://gitlab.invertase.dev');
+        expect(repo.origin, 'https://gitlab.invertase.dev');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://gitlab.invertase.dev/a/b/'));
@@ -162,12 +162,12 @@ void main() {
 
       test('parse GitLab repository spec with sub-path correctly', () {
         final repo = GitLabRepository(
-          base: 'https://invertase.dev/gitlab',
+          origin: 'https://invertase.dev/gitlab',
           owner: 'a',
           name: 'b',
         );
 
-        expect(repo.base, 'https://invertase.dev/gitlab');
+        expect(repo.origin, 'https://invertase.dev/gitlab');
         expect(repo.owner, 'a');
         expect(repo.name, 'b');
         expect(repo.url, Uri.parse('https://invertase.dev/gitlab/a/b/'));
@@ -175,12 +175,12 @@ void main() {
 
       test('parse GitLab repository spec with nested groups correctly', () {
         final repo = GitLabRepository(
-          base: 'https://gitlab.invertase.dev',
+          origin: 'https://gitlab.invertase.dev',
           owner: 'a/b',
           name: 'c',
         );
 
-        expect(repo.base, 'https://gitlab.invertase.dev');
+        expect(repo.origin, 'https://gitlab.invertase.dev');
         expect(repo.owner, 'a/b');
         expect(repo.name, 'c');
         expect(repo.url, Uri.parse('https://gitlab.invertase.dev/a/b/c/'));
@@ -190,12 +190,12 @@ void main() {
           'parse GitLab repository spec with sub-path and nested groups '
           'correctly', () {
         final repo = GitLabRepository(
-          base: 'https://invertase.dev/gitlab',
+          origin: 'https://invertase.dev/gitlab',
           owner: 'a/b',
           name: 'c',
         );
 
-        expect(repo.base, 'https://invertase.dev/gitlab');
+        expect(repo.origin, 'https://invertase.dev/gitlab');
         expect(repo.owner, 'a/b');
         expect(repo.name, 'c');
         expect(repo.url, Uri.parse('https://invertase.dev/gitlab/a/b/c/'));

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -438,7 +438,7 @@ void main() {
       expect(
         () => MelosWorkspaceConfig(
           name: '',
-          repository: const GitHubRepository(owner: 'invertase', name: 'melos'),
+          repository: GitHubRepository(owner: 'invertase', name: 'melos'),
           packages: const [],
           commands: const CommandConfigs(
             version: VersionCommandConfigs(linkToCommits: true),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
   path: ^1.7.0
   yaml: ^3.1.0
 
-# These allows us to use melos on itself during development.
+# These allow us to use melos on itself during development.
 # If you make a new local package in this repo that the melos package
 # will depend on, then make sure to add it here otherwise you'll face
 # "'pubspec.yaml' has been modified since".. issues.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR implements support for self-hosted git repositories. This configuration syntax for this is as follows:
```yaml
repository:
  type: gitlab
  base: https://gitlab.example.dev
  owner: invertase
  name: melos
```

I initially tried to use RegEx to extract this information from only the URL, but GitLab supports both subgroups and hosting not on the root of a domain. This means that `https://example.com/gitlab/invertase/melos` could be both a GitLab instance on `https://example.com/gitlab` with a group named `invertase` or an instance on `https://example.com/` with a group/subgroup of `gitlab/invertase`. I was also tempted to validate the owner/name fields using RegEx, but at least for GitLab the [patterns](https://gitlab.com/gitlab-org/gitlab/-/blob/0890bda6ba241539914cd95fcc83bbcc7960c953/lib/gitlab/regex.rb#L11) are unnecessary complicated and use features that aren't available in Dart.

I've also gone ahead and mirrored the syntax for GitHub, but since I lack knowledge of GitHub Enterprise as much as access to an instance of it this is currently untested. I'd appreciate if anyone here has the resources to help out with this.

Closes #392 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
