### PR TITLE
perf: use `Glob.list` to more efficiently find packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.runPubGetOnPubspecChanges": false
+  "dart.runPubGetOnPubspecChanges": "always"
 }

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -83,9 +83,9 @@ packages:
 > You can also reduce the scope of packages on a per-command basis via the
 > [`--scope` filter](/filters#scope) flag.
 
-Avoid recursive whildcard patterns like `**` as they require walking large parts
-of the file system and can be slow. If you have packages at multiple levels of
-depth, consider using multiple patterns instead:
+Avoid recursive whildcards (`**`) as they require walking large parts of the
+file system and can be slow. If you have packages at multiple levels of depth,
+consider using multiple patterns instead:
 
 ```yaml
 packages:

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -72,16 +72,26 @@ entry can be a specific path or a [glob] pattern.
 
 ```yaml
 packages:
-  # e.g. include all packages inside the `packages` directory at any level
-  - packages/**
-  # e.g. include all packages inside the `packages` directory that are direct children
-  - packages/*
-  # e.g. include the package in the workspace root
+  # Include the package in the workspace root.
   - .
+  # Include all packages inside the `packages` directory that are direct children.
+  - packages/*
+  # Include all packages inside the `packages` directory and all descendants.
+  - packages/**
 ```
 
 > You can also reduce the scope of packages on a per-command basis via the
 > [`--scope` filter](/filters#scope) flag.
+
+Avoid recursive whildcard patterns like `**` as they require walking large parts
+of the file system and can be slow. If you have packages at multiple levels of
+depth, consider using multiple patterns instead:
+
+```yaml
+packages:
+  - packages/*
+  - packages/*/example
+```
 
 ## `ignore`
 

--- a/packages/melos/lib/src/common/io.dart
+++ b/packages/melos/lib/src/common/io.dart
@@ -142,66 +142,6 @@ extension FileSystemEntityUtils on FileSystemEntity {
   }
 }
 
-extension DirectoryUtils on Directory {
-  /// Lists the sub-directories and files of this [Directory] similar to [list].
-  ///
-  /// However instead of just having a `recursive` parameter that decides
-  /// whether to recurse into all or no subdirectories, a function
-  /// [recurseCondition] can be given that can decide for a given directory
-  /// whether to recurse into it or not. The contents of this directory are
-  /// always listed and the function is not called with `this` as argument.
-  Stream<FileSystemEntity> listConditionallyRecursive({
-    required bool Function(Directory directory) recurseCondition,
-    bool followLinks = true,
-  }) {
-    Stream<FileSystemEntity> recurse(
-      Directory directory,
-      Set<String> visitedLinks,
-    ) async* {
-      await for (final entity in directory.list(followLinks: false)) {
-        if (entity is File) {
-          yield entity;
-        } else if (entity is Directory) {
-          yield entity;
-          if (recurseCondition(entity)) {
-            yield* recurse(entity, visitedLinks);
-          }
-        } else if (entity is Link) {
-          if (!followLinks ||
-              visitedLinks.contains(await entity.tryResolveSymbolicLinks())) {
-            yield entity;
-            break;
-          }
-
-          // We can ignore the link case here because
-          // [FileSystemEntity.typeSync] resolves links by default.
-          // ignore: exhaustive_cases
-          switch (FileSystemEntity.typeSync(entity.path)) {
-            case FileSystemEntityType.directory:
-              final directory = Directory(entity.path);
-              yield directory;
-              if (recurseCondition(directory)) {
-                yield* recurse(
-                  directory,
-                  {...visitedLinks, await entity.resolveSymbolicLinks()},
-                );
-              }
-              break;
-            case FileSystemEntityType.file:
-              yield File(entity.path);
-              break;
-            case FileSystemEntityType.notFound:
-              yield entity;
-              break;
-          }
-        }
-      }
-    }
-
-    return recurse(this, {});
-  }
-}
-
 /// Tries to resiliently perform [operation].
 ///
 /// Some file system operations can intermittently fail on Windows because other

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -364,9 +364,6 @@ String link(Uri url, String text) {
 bool isWorkspaceDirectory(String directory) =>
     fileExists(melosYamlPathForDirectory(directory));
 
-bool isPackageDirectory(String directory) =>
-    fileExists(pubspecPathForDirectory(directory));
-
 Future<Process> startCommandRaw(
   String command, {
   String? workingDirectory,

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -16,12 +16,12 @@
  */
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
@@ -460,6 +460,18 @@ class PackageMap {
   PackageMap(Map<String, Package> packages, this._logger)
       : _map = _packagesSortedByName(packages);
 
+  static const _commonIgnorePatterns = [
+    '**/.dart_tool/**',
+    // Flutter symlinked plugins for iOS/macOS should not be included in the
+    // package list.
+    '**/.symlinks/plugins/**',
+    // Flutter version manager should not be included in the package list.
+    '**/.fvm/**',
+    // Ephemeral plugin symlinked packages should not be included in the
+    // package list.
+    '**/.plugin_symlinks/**',
+  ];
+
   static Map<String, Package> _packagesSortedByName(
     Map<String, Package> packages,
   ) {
@@ -480,64 +492,16 @@ class PackageMap {
     required List<Glob> ignore,
     required MelosLogger logger,
   }) async {
+    final pubspecFiles = await _resolvePubspecFiles(
+      workspacePath: workspacePath,
+      packages: packages,
+      ignore: ignore,
+    );
+
     final packageMap = <String, Package>{};
 
-    final dartToolGlob =
-        createGlob('**/.dart_tool', currentDirectoryPath: workspacePath);
-    // Flutter symlinked plugins for iOS/macOS should not be included in the package list.
-    final symlinksPluginsGlob = createGlob(
-      '**/.symlinks/plugins',
-      currentDirectoryPath: workspacePath,
-    );
-    // Flutter version manager should not be included in the package list.
-    final fvmGlob = createGlob(
-      '**/.fvm',
-      currentDirectoryPath: workspacePath,
-    );
-    // Ephemeral plugin symlinked packages should not be included in the package
-    // list.
-    final pluginSymlinksGlob = createGlob(
-      '**/.plugin_symlinks',
-      currentDirectoryPath: workspacePath,
-    );
-
-    final pubspecsByResolvedPath =
-        HashMap<String, File>(equals: p.equals, hashCode: p.hash);
-
-    Stream<FileSystemEntity> allWorkspaceEntities() async* {
-      final workspaceDir = Directory(workspacePath);
-      yield workspaceDir;
-      yield* workspaceDir.listConditionallyRecursive(
-        recurseCondition: (dir) {
-          final path = dir.path;
-          return !dartToolGlob.matches(path) &&
-              !symlinksPluginsGlob.matches(path) &&
-              !fvmGlob.matches(path) &&
-              !pluginSymlinksGlob.matches(path);
-        },
-      );
-    }
-
-    await for (final entity in allWorkspaceEntities()) {
-      final path = entity.path;
-      late final isIncluded = packages.any((glob) => glob.matches(path)) &&
-          !ignore.any((glob) => glob.matches(path));
-
-      if (entity is File && p.basename(path) == 'pubspec.yaml' && isIncluded) {
-        final resolvedPath = await entity.resolveSymbolicLinks();
-        pubspecsByResolvedPath[resolvedPath] = entity;
-      } else if (entity is Directory &&
-          isPackageDirectory(entity.path) &&
-          isIncluded) {
-        final pubspecPath = p.join(path, 'pubspec.yaml');
-        pubspecsByResolvedPath[pubspecPath] = File(pubspecPath);
-      }
-    }
-
-    final allPubspecs = pubspecsByResolvedPath.values;
-
     await Future.wait<void>(
-      allPubspecs.map((pubspecFile) async {
+      pubspecFiles.map((pubspecFile) async {
         final pubspecDirPath = pubspecFile.parent.path;
         final pubSpec = await PubSpec.load(pubspecFile.parent);
 
@@ -572,6 +536,46 @@ The packages that caused the problem are:
     );
 
     return PackageMap(packageMap, logger);
+  }
+
+  static Future<List<File>> _resolvePubspecFiles({
+    required String workspacePath,
+    required List<Glob> packages,
+    required List<Glob> ignore,
+  }) async {
+    final pubspecEntities = await Stream.fromIterable(packages)
+        .map(_createPubspecGlob)
+        .asyncExpand((pubspecGlob) => pubspecGlob.list(root: workspacePath))
+        .toList();
+
+    final commonIgnoreGlobs = _commonIgnorePatterns
+        .map(
+          (pattern) => createGlob(pattern, currentDirectoryPath: workspacePath),
+        )
+        .map(_createPubspecGlob)
+        .toList();
+    final customIgnoreGlobs = ignore.map(_createPubspecGlob).toList();
+    final ignoredGlobs = [...commonIgnoreGlobs, ...customIgnoreGlobs];
+    bool isIgnored(File file) =>
+        ignoredGlobs.any((glob) => glob.matches(file.path));
+
+    final paths = pubspecEntities
+        .whereType<File>()
+        .whereNot(isIgnored)
+        .map((file) => p.canonicalize(file.absolute.path))
+        .toSet();
+
+    return paths.map((path) => File(path)).toList();
+  }
+
+  static Glob _createPubspecGlob(Glob event) {
+    return createGlob(
+      '${event.pattern}/pubspec.yaml',
+      caseSensitive: event.caseSensitive,
+      context: event.context,
+      recursive: event.recursive,
+      currentDirectoryPath: event.context.current,
+    );
   }
 
   final Map<String, Package> _map;

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -570,7 +570,7 @@ The packages that caused the problem are:
 
   static Glob _createPubspecGlob(Glob event) {
     return createGlob(
-      '${event.pattern}/pubspec.yaml',
+      p.posix.normalize('${event.pattern}/pubspec.yaml'),
       caseSensitive: event.caseSensitive,
       context: event.context,
       recursive: event.recursive,

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -495,7 +495,11 @@ class PackageMap {
     final pubspecFiles = await _resolvePubspecFiles(
       workspacePath: workspacePath,
       packages: packages,
-      ignore: ignore,
+      ignore: [
+        ...ignore,
+        for (final pattern in _commonIgnorePatterns)
+          createGlob(pattern, currentDirectoryPath: workspacePath)
+      ],
     );
 
     final packageMap = <String, Package>{};
@@ -548,16 +552,9 @@ The packages that caused the problem are:
         .asyncExpand((pubspecGlob) => pubspecGlob.list(root: workspacePath))
         .toList();
 
-    final commonIgnoreGlobs = _commonIgnorePatterns
-        .map(
-          (pattern) => createGlob(pattern, currentDirectoryPath: workspacePath),
-        )
-        .map(_createPubspecGlob)
-        .toList();
-    final customIgnoreGlobs = ignore.map(_createPubspecGlob).toList();
-    final ignoredGlobs = [...commonIgnoreGlobs, ...customIgnoreGlobs];
+    final pubspecIgnoreGlobs = ignore.map(_createPubspecGlob).toList();
     bool isIgnored(File file) =>
-        ignoredGlobs.any((glob) => glob.matches(file.path));
+        pubspecIgnoreGlobs.any((glob) => glob.matches(file.path));
 
     final paths = pubspecEntities
         .whereType<File>()

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -565,7 +565,7 @@ The packages that caused the problem are:
         .map((file) => p.canonicalize(file.absolute.path))
         .toSet();
 
-    return paths.map((path) => File(path)).toList();
+    return paths.map(File.new).toList();
   }
 
   static Glob _createPubspecGlob(Glob event) {

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   collection: ^1.14.12
   conventional_commit: ^0.5.0+1
   file: ^6.1.0
-  glob: ^2.0.1
+  glob: ^2.1.0
   graphs: ^2.1.0
   http: ^0.13.1
   meta: ^1.1.8

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -194,7 +194,8 @@ packages/c
             packages: packages,
           );
           final packagePaths = packages
-              .map((package) => p.join(workspaceDir.path, package.path));
+              .map((package) => p.join(workspaceDir.path, package.path))
+              .map(p.canonicalize);
 
           final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
           final melos = Melos(logger: logger, config: config);

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -152,100 +152,50 @@ The packages that caused the problem are:
     });
 
     group('locate packages', () {
-      group('in workspace root', () {
-        test('by matching pubspec.yaml', () async {
-          final workspaceDir = createTemporaryWorkspaceDirectory(
-            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
-              const {
-                'name': 'test',
-                'packages': ['*']
-              },
-              path: path,
-            ),
-          );
+      test('in workspace root', () async {
+        final workspaceDir = createTemporaryWorkspaceDirectory(
+          configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+            const {
+              'name': 'test',
+              'packages': ['.']
+            },
+            path: path,
+          ),
+        );
 
-          await createProject(
-            workspaceDir,
-            const PubSpec(name: 'a'),
-            path: '.',
-          );
+        await createProject(
+          workspaceDir,
+          const PubSpec(name: 'a'),
+          path: '.',
+        );
 
-          final workspace = await MelosWorkspace.fromConfig(
-            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
-            logger: TestLogger().toMelosLogger(),
-          );
+        final workspace = await MelosWorkspace.fromConfig(
+          await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+          logger: TestLogger().toMelosLogger(),
+        );
 
-          expect(workspace.allPackages['a'], isNotNull);
-        });
-
-        test('by matching package directory', () async {
-          final workspaceDir = createTemporaryWorkspaceDirectory(
-            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
-              const {
-                'name': 'test',
-                'packages': ['.']
-              },
-              path: path,
-            ),
-          );
-
-          await createProject(
-            workspaceDir,
-            const PubSpec(name: 'a'),
-            path: '.',
-          );
-
-          final workspace = await MelosWorkspace.fromConfig(
-            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
-            logger: TestLogger().toMelosLogger(),
-          );
-
-          expect(workspace.allPackages['a'], isNotNull);
-        });
+        expect(workspace.allPackages['a'], isNotNull);
       });
 
-      group('in child directory', () {
-        test('by matching pubspec.yaml', () async {
-          final workspaceDir = createTemporaryWorkspaceDirectory(
-            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
-              const {
-                'name': 'test',
-                'packages': ['packages/a/*']
-              },
-              path: path,
-            ),
-          );
+      test('in child directory', () async {
+        final workspaceDir = createTemporaryWorkspaceDirectory(
+          configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+            const {
+              'name': 'test',
+              'packages': ['packages/a']
+            },
+            path: path,
+          ),
+        );
 
-          await createProject(workspaceDir, const PubSpec(name: 'a'));
+        await createProject(workspaceDir, const PubSpec(name: 'a'));
 
-          final workspace = await MelosWorkspace.fromConfig(
-            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
-            logger: TestLogger().toMelosLogger(),
-          );
+        final workspace = await MelosWorkspace.fromConfig(
+          await MelosWorkspaceConfig.fromDirectory(workspaceDir),
+          logger: TestLogger().toMelosLogger(),
+        );
 
-          expect(workspace.allPackages['a'], isNotNull);
-        });
-
-        test('by matching package directory', () async {
-          final workspaceDir = createTemporaryWorkspaceDirectory(
-            configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
-              const {
-                'name': 'test',
-                'packages': ['packages/a']
-              },
-              path: path,
-            ),
-          );
-
-          await createProject(workspaceDir, const PubSpec(name: 'a'));
-
-          final workspace = await MelosWorkspace.fromConfig(
-            await MelosWorkspaceConfig.fromDirectory(workspaceDir),
-            logger: TestLogger().toMelosLogger(),
-          );
-
-          expect(workspace.allPackages['a'], isNotNull);
-        });
+        expect(workspace.allPackages['a'], isNotNull);
       });
     });
 


### PR DESCRIPTION
## Description

Before this change all files in a workspace were iterated over to find packages.

`Glob.list` can potentially skip searching through many directories based on the pattern. In larger workspaces this can save upwards of 300ms during each invocation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
