### PR TITLE
feat!: local installation of melos in workspace

### DIFF
--- a/.github/workflows/scripts/install-tools.bat
+++ b/.github/workflows/scripts/install-tools.bat
@@ -1,2 +1,4 @@
 CMD /C dart pub global activate --source=path . --executable=melos --overwrite
+REM Workaround an issue when running global executables on Windows for the first time.
+CMD /C melos > NUL
 melos bootstrap

--- a/.github/workflows/scripts/install-tools.bat
+++ b/.github/workflows/scripts/install-tools.bat
@@ -1,4 +1,2 @@
-CMD /C dart pub global activate --source=path . --executable=melos
-REM Workaround an issue when running global executables on Windows for the first time.
-CMD /C melos > NUL
+CMD /C dart pub global activate --source=path . --executable=melos --overwrite
 melos bootstrap

--- a/.github/workflows/scripts/install-tools.sh
+++ b/.github/workflows/scripts/install-tools.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-dart pub global activate --source="path" . --executable="melos"
+dart pub global activate --source="path" . --executable="melos" --overwrite
 melos bootstrap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ To setup and use this melos mono repo locally for the purposes of contributing, 
 ```bash
 # Install melos if it's not already installed:
 dart pub global activate melos
+# Bootstrap the workspace.
+melos bootstrap
 # Activate 'melos' from path:
 melos activate
 # Confirm you now using a local development version:
@@ -90,7 +92,7 @@ To send us a pull request:
 Please make sure all your check-ins have detailed commit messages explaining the patch.
 
 When naming the title of your pull request, please follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-guide. 
+guide.
 
 Please also enable **“Allow edits by maintainers”**, this will help to speed-up the review
 process as well.

--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -19,11 +19,11 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
     - always_specify_types
     - always_use_package_imports
     - annotate_overrides
     - avoid_annotating_with_dynamic
+    # - avoid_as
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -48,8 +48,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_returning_this
     - avoid_setters_without_getters
@@ -95,6 +93,7 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
+    - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
@@ -128,6 +127,7 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message
+    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -137,6 +137,7 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
+    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each
@@ -176,6 +177,7 @@ linter:
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
+    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - tighten_type_of_initializing_formals
@@ -184,6 +186,7 @@ linter:
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     - unnecessary_final

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -87,3 +87,6 @@ linter:
     # Not a common style and would add a lot of verbosity to function signature.
     # 'parameter_assignments' already enforces this to an extent.
     prefer_final_parameters: false
+
+    # Useful to allow for `multiLine` utility function.
+    no_adjacent_strings_in_list: false

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -5,34 +5,72 @@ description: Learn how to start using Melos in your project
 
 # Getting Started
 
-Melos requires a few one-off steps to be completed before you can start using it.
+Melos requires a few one-off steps to be completed before you can start using
+it.
 
 ## Installation
 
-Melos can be installed as a global package via [pub.dev](https://pub.dev/):
+Installe Melos as a
+[global package](https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path)
+via [pub.dev](https://pub.dev/) so it can be used from anywhere on your system:
 
 ```bash
 dart pub global activate melos
 ```
 
-### Setup
+## Setup a workspace
 
-To set up your project to use Melos, create a `melos.yaml` file in the root of the project.
+Melos is designed to work with a workspace. A workspace is a directory which
+contains all the packages that are going to be developed together. Its root
+directory must contain a `melos.yaml` file.
 
-Within the `melos.yaml` file, add `name` and `packages` fields:
+### Install Melos in the workspace
+
+Different Melos workspaces might use different versions of Melos. To ensure
+everyone working in the workspace (as well as CI jobs) is using the same version
+of Melos, a dependency on the `melos` package has to be added to the
+`pubspec.yaml` file at the workspace root directory. The globally installed
+version of Melos will switch to the version specified in the `pubspec.yaml`
+file, if both versions are not the same.
+
+If you don't have a `pubspec.yaml` file at the workspace root yet, create one
+now:
 
 ```yaml
-name: my_project
+name: <project>_workspace
 
-packages:
-  - packages/**
+environment:
+  sdk: '>=2.18.0 <3.0.0'
 ```
 
-The `packages` list should contain paths to the individual packages within your project. Each path
-can be defined using the [glob](https://docs.python.org/3/library/glob.html) pattern expansion format.
+The corresponding `pubspec.lock` file should also be committed. Make sure to
+exclude it from the `.gitignore` file.
 
-Melos generates `pubspec_overrides.yaml` files to link local packages for development. Typically these files
-should be ignored by git. To ignore these files, add the following to your `.gitignore` file:
+Add Melos as a development dependency by running the following command:
+
+```bash
+dart pub add melos --dev
+```
+
+### Configure the workspace
+
+Next create a `melos.yaml` file at the repository root. Within the `melos.yaml`
+file, add the `name` and `packages` fields:
+
+```yaml
+name: <project>
+
+packages:
+  - packages/*
+```
+
+The `packages` list should contain paths to the individual packages within your
+project. Each path can be defined using the
+[glob](https://docs.python.org/3/library/glob.html) pattern expansion format.
+
+Melos generates `pubspec_overrides.yaml` files to link local packages for
+development. Typically these files should be ignored by git. To ignore these
+files, add the following to your `.gitignore` file:
 
 ```
 pubspec_overrides.yaml
@@ -40,29 +78,37 @@ pubspec_overrides.yaml
 
 ## Bootstrapping
 
-Once installed & setup, Melos needs to be bootstrapped. Bootstrapping has 2 primary roles:
+Once installed & setup, Melos needs to be bootstrapped. Bootstrapping has 2
+primary roles:
 
 1. Installing all package dependencies (internally using `pub get`).
 2. Locally linking any packages together.
 
 ### Why do I need to bootstrap?
 
-In normal projects, packages can be linked by providing a `path` within the `pubspec.yaml`. This works for small
-projects however presents a problem at scale. Packages cannot be published with a locally defined path, meaning
-once you're ready to publish your packages you'll need to manually update all the packages `pubspec.yaml` files
-with the versions. If your packages are also tightly coupled (dependencies of each other), you'll also have to manually
-check which versions should be updated. Even with a few packages this can become a long and error-prone task.
+In normal projects, packages can be linked by providing a `path` within the
+`pubspec.yaml`. This works for small projects however presents a problem at
+scale. Packages cannot be published with a locally defined path, meaning once
+you're ready to publish your packages you'll need to manually update all the
+packages `pubspec.yaml` files with the versions. If your packages are also
+tightly coupled (dependencies of each other), you'll also have to manually check
+which versions should be updated. Even with a few packages this can become a
+long and error-prone task.
 
-Melos solves this problem by overriding local files which the Dart analyzer uses to read packages from. If a local package
-exists (defined in the `melos.yaml` file) and a different local package has it listed as a dependency, it will be linked
-regardless of whether a version has been specified.
+Melos solves this problem by overriding local files which the Dart analyzer uses
+to read packages from. If a local package exists (defined in the `melos.yaml`
+file) and a different local package has it listed as a dependency, it will be
+linked regardless of whether a version has been specified.
 
 ## Next steps
 
-Once successfully bootstrapped, you can develop your packages side-by-side with changes to a single package immediately reflecting
-across other dependent packages.
+Once successfully bootstrapped, you can develop your packages side-by-side with
+changes to a single package immediately reflecting across other dependent
+packages.
 
-Melos also provides other helpful features such as running scripts across all packages. For example, to run dart analyzer in each package, add a new `script` item in your `melos.yaml`:
+Melos also provides other helpful features such as running scripts across all
+packages. For example, to run dart analyzer in each package, add a new `script`
+item in your `melos.yaml`:
 
 ```yaml
 name: my_project
@@ -77,7 +123,9 @@ scripts:
 
 Then execute the command by running `melos run analyze`.
 
-If you're looking for some inspiration as to what scripts can help with, check out the
+If you're looking for some inspiration as to what scripts can help with, check
+out the
 [FlutterFire repository](https://github.com/firebase/flutterfire/blob/master/melos.yaml).
 
-If you are using VS Code, there is an [extension](/ide-support#vs-code) available, to integrate Melos with VS Code.
+If you are using VS Code, there is an [extension](/ide-support#vs-code)
+available, to integrate Melos with VS Code.

--- a/docs/guides/migrations.mdx
+++ b/docs/guides/migrations.mdx
@@ -7,6 +7,38 @@ description: How to migrate between major versions of Melos.
 
 ## 2.0.0 to 3.0.0
 
+### Versioning of Melos in workspaces
+
+From Melos 3.0.0, the version of Melos to use in any given workspace must be
+specified in a `pubspec.yaml` file next to the `melos.yaml` file, in the
+workspace root directory.
+
+Different Melos workspaces might use different versions of Melos. To ensure
+everyone working in the workspace (as well as CI jobs) is using the same version
+of Melos, a dependency on the `melos` package has to be added to the
+`pubspec.yaml` file at the workspace root directory. The globally installed
+version of Melos will switch to the version specified in the `pubspec.yaml`
+file, if both versions are not the same.
+
+If you don't have a `pubspec.yaml` file at the workspace root yet, create one
+now:
+
+```yaml
+name: <project>_workspace
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+```
+
+The corresponding `pubspec.lock` file should also be committed. Make sure to
+exclude it from the `.gitignore` file.
+
+Add Melos as a development dependency by running the following command:
+
+```bash
+dart pub add melos --dev
+```
+
 ### Local package linking with `pubspec_overrides.yaml`
 
 The initial mechanism used by Melos to link local packages for development had

--- a/melos.yaml
+++ b/melos.yaml
@@ -36,7 +36,7 @@ scripts:
       concurrency: 1
     packageFilters:
       dirExists:
-        - 'test/'
+        - test
     # This tells Melos tests to ignore env variables passed to tests from `melos run test`
     # as they could change the behaviour of how tests filter packages.
     env:

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -131,15 +131,8 @@ The following projects are using Melos:
 
 ## Getting Started
 
-Install the latest Melos version as a global package via
-[Pub](https://pub.dev/).
-
-```bash
-dart pub global activate melos
-
-# Or alternatively to specify a specific version:
-# pub global activate melos 0.4.1
-```
+Go to the [Getting Started](https://melos.invertase.dev/getting-started) page of
+the [documentation](https://docs.page/invertase/melos) to start using Melos.
 
 ---
 

--- a/packages/melos/bin/melos.dart
+++ b/packages/melos/bin/melos.dart
@@ -1,64 +1,11 @@
-// ignore_for_file: avoid_print
-
-import 'dart:io';
-
-import 'package:args/command_runner.dart';
+import 'package:cli_launcher/cli_launcher.dart';
 import 'package:melos/src/command_runner.dart';
-import 'package:melos/src/common/exception.dart';
-import 'package:melos/src/common/utils.dart' as utils;
-import 'package:melos/src/workspace_configs.dart';
-import 'package:melos/version.g.dart';
-import 'package:pub_updater/pub_updater.dart';
 
-Future<void> main(List<String> arguments) async {
-  if (arguments.contains('--version') || arguments.contains('-v')) {
-    print(melosVersion);
-    // No version checks on CIs.
-    if (utils.isCI) return;
-
-    // Check for updates.
-    final pubUpdater = PubUpdater();
-    const packageName = 'melos';
-    final isUpToDate = await pubUpdater.isUpToDate(
-      packageName: packageName,
-      currentVersion: melosVersion,
+Future<void> main(List<String> arguments) async => launchExecutable(
+      arguments,
+      LaunchConfig(
+        name: ExecutableName('melos'),
+        launchFromSelf: false,
+        entrypoint: melosEntryPoint,
+      ),
     );
-    if (!isUpToDate) {
-      final latestVersion = await pubUpdater.getLatestVersion(packageName);
-      final shouldUpdate = utils.promptBool(
-        message: 'There is a new version of $packageName available '
-            '($latestVersion). Would you like to update?',
-        defaultsTo: true,
-        defaultsToWithoutPrompt: false,
-      );
-      if (shouldUpdate) {
-        await pubUpdater.update(packageName: packageName);
-        print('$packageName has been updated to version $latestVersion.');
-      }
-    }
-
-    return;
-  }
-  try {
-    final config = shouldUseEmptyConfig(arguments)
-        ? MelosWorkspaceConfig.empty()
-        : await MelosWorkspaceConfig.fromDirectory(Directory.current);
-    await MelosCommandRunner(config).run(arguments);
-  } on MelosException catch (err) {
-    stderr.writeln(err.toString());
-    exitCode = 1;
-  } on UsageException catch (err) {
-    stderr.writeln(err.toString());
-    exitCode = 1;
-  } catch (err) {
-    exitCode = 1;
-    rethrow;
-  }
-}
-
-bool shouldUseEmptyConfig(List<String> arguments) {
-  final willShowHelp = arguments.isEmpty ||
-      arguments.contains('--help') ||
-      arguments.contains('-h');
-  return willShowHelp;
-}

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -15,9 +15,16 @@
  *
  */
 
+import 'dart:async';
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:cli_launcher/cli_launcher.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:pub_updater/pub_updater.dart';
 
+import '../version.g.dart';
 import 'command_runner/bootstrap.dart';
 import 'command_runner/clean.dart';
 import 'command_runner/exec.dart';
@@ -26,14 +33,17 @@ import 'command_runner/publish.dart';
 import 'command_runner/run.dart';
 import 'command_runner/script.dart';
 import 'command_runner/version.dart';
+import 'common/exception.dart';
 import 'common/utils.dart';
+import 'common/utils.dart' as utils;
+import 'logging.dart';
 import 'workspace_configs.dart';
 
 /// A class that can run Melos commands.
 ///
 /// To run a command, do:
 ///
-/// ```dart main
+/// ```dart
 /// final melos = MelosCommandRunner();
 ///
 /// await melos.run(['bootstrap']);
@@ -79,4 +89,86 @@ class MelosCommandRunner extends CommandRunner<void> {
   Future<void> runCommand(ArgResults topLevelResults) async {
     await super.runCommand(topLevelResults);
   }
+}
+
+@override
+FutureOr<void> melosEntryPoint(
+  List<String> arguments,
+  LaunchContext context,
+) async {
+  if (arguments.contains('--version') || arguments.contains('-v')) {
+    final logger = MelosLogger(Logger.standard());
+
+    logger.log(melosVersion);
+
+    // No version checks on CIs.
+    if (utils.isCI) return;
+
+    // Check for updates.
+    final pubUpdater = PubUpdater();
+    const packageName = 'melos';
+    final isUpToDate = await pubUpdater.isUpToDate(
+      packageName: packageName,
+      currentVersion: melosVersion,
+    );
+    if (!isUpToDate) {
+      final latestVersion = await pubUpdater.getLatestVersion(packageName);
+      final isGlobal = context.localInstallation == null;
+
+      if (isGlobal) {
+        final shouldUpdate = utils.promptBool(
+          message: 'There is a new version of $packageName available '
+              '($latestVersion). Would you like to update?',
+          defaultsTo: true,
+          defaultsToWithoutPrompt: false,
+        );
+        if (shouldUpdate) {
+          await pubUpdater.update(packageName: packageName);
+          logger.log(
+            '$packageName has been updated to version $latestVersion.',
+          );
+        }
+      } else {
+        logger.log(
+          'There is a new version of $packageName available '
+          '($latestVersion).',
+        );
+      }
+    }
+    return;
+  }
+  try {
+    final config =
+        await _resolveConfig(arguments, context.localInstallation?.packageRoot);
+    await MelosCommandRunner(config).run(arguments);
+  } on MelosException catch (err) {
+    stderr.writeln(err.toString());
+    exitCode = 1;
+  } on UsageException catch (err) {
+    stderr.writeln(err.toString());
+    exitCode = 1;
+  } catch (err) {
+    exitCode = 1;
+    rethrow;
+  }
+}
+
+Future<MelosWorkspaceConfig> _resolveConfig(
+  List<String> arguments,
+  Directory? workspaceRoot,
+) async {
+  if (_shouldUseEmptyConfig(arguments)) {
+    return MelosWorkspaceConfig.empty();
+  }
+  if (workspaceRoot == null) {
+    return MelosWorkspaceConfig.handleWorkspaceNotFound(Directory.current);
+  }
+  return MelosWorkspaceConfig.fromWorkspaceRoot(workspaceRoot);
+}
+
+bool _shouldUseEmptyConfig(List<String> arguments) {
+  final willShowHelp = arguments.isEmpty ||
+      arguments.contains('--help') ||
+      arguments.contains('-h');
+  return willShowHelp;
 }

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -65,6 +65,18 @@ extension Let<T> on T? {
 
 String describeEnum(Object value) => value.toString().split('.').last;
 
+/// Utility function to write inline multi-line strings with indentation and
+/// without trailing a new line.
+///
+/// ```dart
+/// print(multiLine([
+///  'The quick brown fox jumps over the lazy dog.',
+///  '', // Empty line
+///  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod.',
+/// ]));
+/// ```
+String multiLine(List<String> lines) => lines.join('\n');
+
 // MELOS_PACKAGES environment variable is a comma delimited list of
 // package names - used instead of filters if it is present.
 // This can be user defined or can come from package selection in `melos run`.
@@ -296,21 +308,6 @@ Future<String> getMelosRoot() async {
 
   // Get from lib/melos.dart to the package root
   return p.normalize('${melosPackageFileUri!.toFilePath()}/../..');
-}
-
-YamlMap? loadYamlFileSync(String path) {
-  if (!fileExists(path)) return null;
-
-  return loadYaml(readTextFile(path)) as YamlMap;
-}
-
-Future<YamlMap?> loadYamlFile(String path) async {
-  if (!fileExists(path)) return null;
-
-  return loadYaml(
-    await readTextFileAsync(path),
-    sourceUrl: Uri.parse(path),
-  ) as YamlMap;
 }
 
 String melosYamlPathForDirectory(String directory) =>

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -17,16 +17,16 @@
 
 import 'dart:io';
 
+import 'package:ansi_styles/ansi_styles.dart';
 import 'package:collection/collection.dart';
 import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 
 import '../melos.dart';
 import 'common/git_repository.dart';
 import 'common/glob.dart';
 import 'common/io.dart';
-import 'common/platform.dart';
 import 'common/utils.dart';
 import 'common/validation.dart';
 import 'scripts.dart';
@@ -752,18 +752,6 @@ class MelosWorkspaceConfig {
     );
   }
 
-  MelosWorkspaceConfig.fallback({required String path})
-      : this(
-          name: 'Melos',
-          packages: [
-            createGlob('packages/**', currentDirectoryPath: path),
-          ],
-          path: currentPlatform.isWindows
-              ? p.windows.normalize(path).replaceAll(r'\', r'\\')
-              : path,
-          commands: CommandConfigs.empty,
-        );
-
   MelosWorkspaceConfig.empty()
       : this(
           name: 'Melos',
@@ -772,69 +760,109 @@ class MelosWorkspaceConfig {
           commands: CommandConfigs.empty,
         );
 
-  static Directory? _searchForAncestorDirectoryWithMelosYaml(Directory from) {
-    for (var testedDirectory = from;
-        testedDirectory.path != testedDirectory.parent.path;
-        testedDirectory = testedDirectory.parent) {
-      if (isWorkspaceDirectory(testedDirectory.path)) {
-        return testedDirectory;
-      }
-    }
-    return null;
-  }
-
-  /// Creates a new configuration from a [Directory].
-  ///
-  /// If no `melos.yaml` is found, but [Directory] contains a `packages/`
-  /// sub-directory, a configuration for those packages will be created.
-  static Future<MelosWorkspaceConfig> fromDirectory(
-    Directory directory,
+  /// Loads the [MelosWorkspaceConfig] for the workspace at [workspaceRoot].
+  static Future<MelosWorkspaceConfig> fromWorkspaceRoot(
+    Directory workspaceRoot,
   ) async {
-    final melosWorkspaceDirectory =
-        _searchForAncestorDirectoryWithMelosYaml(directory);
+    final melosYamlFile = File(melosYamlPathForDirectory(workspaceRoot.path));
 
-    if (melosWorkspaceDirectory == null) {
-      // Allow melos to use a project without a `melos.yaml` file if a
-      // `packages` directory exists.
-      final packagesDirectory = p.joinAll([directory.path, 'packages']);
-
-      if (dirExists(packagesDirectory)) {
-        return MelosWorkspaceConfig.fallback(path: directory.path)
-          ..validatePhysicalWorkspace();
-      }
-
-      throw MelosConfigException(
-        '''
-Your current directory does not appear to be a valid Melos workspace.
-
-You must have one of the following to be a valid Melos workspace:
-  - a "melos.yaml" file in the root with a "packages" option defined
-  - a "packages" directory
-''',
+    if (!melosYamlFile.existsSync()) {
+      throw UnresolvedWorkspace(
+        multiLine([
+          'Found no melos.yaml file in "${workspaceRoot.path}".',
+          '',
+          'You must have a ${AnsiStyles.bold('melos.yaml')} file in the root '
+              'of your workspace.',
+          '',
+          'For more information, see: '
+              'https://melos.invertase.dev/configuration/overview',
+        ]),
       );
     }
 
-    final melosYamlPath =
-        melosYamlPathForDirectory(melosWorkspaceDirectory.path);
-    final yamlContents = (await loadYamlFile(melosYamlPath))?.toPlainObject()
-        as Map<Object?, Object?>?;
-
-    if (yamlContents == null) {
-      throw MelosConfigException('Failed to parse the melos.yaml file');
+    Object? melosYamlContents;
+    try {
+      melosYamlContents = loadYamlNode(
+        await melosYamlFile.readAsString(),
+        sourceUrl: melosYamlFile.uri,
+      ).toPlainObject();
+    } on YamlException catch (error) {
+      throw MelosConfigException('Failed to parse melos.yaml:\n$error');
     }
 
-    final melosOverridesYamlPath =
-        melosOverridesYamlPathForDirectory(melosWorkspaceDirectory.path);
-    final overridesYamlContents = (await loadYamlFile(melosOverridesYamlPath))
-        ?.toPlainObject() as Map<Object?, Object?>?;
-    if (overridesYamlContents != null) {
-      mergeMap(yamlContents, overridesYamlContents);
+    if (melosYamlContents is! Map<Object?, Object?>) {
+      throw MelosConfigException('melos.yaml must contain a YAML map.');
+    }
+
+    final melosOverridesYamlFile =
+        File(melosOverridesYamlPathForDirectory(workspaceRoot.path));
+    if (melosOverridesYamlFile.existsSync()) {
+      Object? melosOverridesYamlContents;
+      try {
+        melosOverridesYamlContents = loadYamlNode(
+          await melosOverridesYamlFile.readAsString(),
+          sourceUrl: melosOverridesYamlFile.uri,
+        ).toPlainObject();
+      } on YamlException catch (error) {
+        throw MelosConfigException(
+          'Failed to parse melos_overrides.yaml:\n$error',
+        );
+      }
+
+      if (melosOverridesYamlContents is! Map<Object?, Object?>) {
+        throw MelosConfigException(
+          'melos_overrides.yaml must contain a YAML map.',
+        );
+      }
+
+      mergeMap(melosYamlContents, melosOverridesYamlContents);
     }
 
     return MelosWorkspaceConfig.fromYaml(
-      yamlContents,
-      path: melosWorkspaceDirectory.path,
+      melosYamlContents,
+      path: workspaceRoot.path,
     )..validatePhysicalWorkspace();
+  }
+
+  /// Handles the case where a workspace could not be found in the [current]
+  /// or a parent directory by throwing an error with a helpful message.
+  static Future<Never> handleWorkspaceNotFound(Directory current) async {
+    final legacyWorkspace = await _findMelosYaml(current);
+    if (legacyWorkspace != null) {
+      throw UnresolvedWorkspace(
+        multiLine([
+          'Found a melos.yaml file in "${legacyWorkspace.path}" but no local '
+              'installation of Melos.',
+          '',
+          'From version 3.0.0, the ${AnsiStyles.bold('melos')} package must be '
+              'installed in a ${AnsiStyles.bold('pubspec.yaml')} file next to '
+              'the melos.yaml file.',
+          '',
+          'For more information, see: '
+              'https://melos.invertase.dev/guides/migrations#200-to-300'
+        ]),
+      );
+    }
+
+    throw UnresolvedWorkspace(
+      multiLine([
+        'Your current directory does not appear to be within a Melos '
+            'workspace.',
+        '',
+        'For setting up a workspace, see: '
+            'https://melos.invertase.dev/getting-started#setup',
+      ]),
+    );
+  }
+
+  static Future<Directory?> _findMelosYaml(Directory start) async {
+    final melosYamlFile = File(melosYamlPathForDirectory(start.path));
+    if (melosYamlFile.existsSync()) {
+      return start;
+    }
+
+    final parent = start.parent;
+    return parent.path == start.path ? null : _findMelosYaml(parent);
   }
 
   /// The absolute path to the workspace folder.
@@ -966,4 +994,14 @@ class _GlobEquality implements Equality<Glob> {
 
   @override
   bool isValidKey(Object? o) => true;
+}
+
+/// An exception thrown when a Melos workspace could not be resolved.
+class UnresolvedWorkspace implements MelosException {
+  UnresolvedWorkspace(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
 }

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -17,6 +17,7 @@ executables:
 dependencies:
   ansi_styles: ^0.3.1
   args: ^2.0.0
+  cli_launcher: ^0.3.0
   cli_util: ^0.3.0
   collection: ^1.14.12
   conventional_commit: ^0.5.0+1

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 void main() {
   group('CommandRunner', () {
     test('adds hidden script commands', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -23,7 +23,7 @@ void main() {
         ),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final runner = MelosCommandRunner(config);
 
       expect(
@@ -37,7 +37,7 @@ void main() {
     });
 
     test('excludes conflicting script commands', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -50,7 +50,7 @@ void main() {
         ),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final runner = MelosCommandRunner(config);
 
       final command = runner.commands['run'];

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -50,7 +50,7 @@ void main() {
         path: '',
       );
 
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       final aPath = p.join(workspaceDir.path, 'packages', 'a');
 
@@ -78,7 +78,7 @@ void main() {
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final workspace = await MelosWorkspace.fromConfig(
         config,
         logger: logger.toMelosLogger(),
@@ -152,7 +152,7 @@ Generating IntelliJ IDE files...
     });
 
     test('resolves workspace packages with path dependency', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       final aDir = await createProject(
         workspaceDir,
@@ -177,7 +177,7 @@ Generating IntelliJ IDE files...
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,
@@ -254,9 +254,7 @@ Generating IntelliJ IDE files...
     );
 
     test('respects user dependency_overrides', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
-        configBuilder: (path) => MelosWorkspaceConfig.fallback(path: path),
-      );
+      final workspaceDir = await createTemporaryWorkspace();
 
       final pkgA = await createProject(
         workspaceDir,
@@ -275,7 +273,7 @@ Generating IntelliJ IDE files...
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,
@@ -293,9 +291,7 @@ Generating IntelliJ IDE files...
     });
 
     test('bootstrap flutter example packages', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
-        configBuilder: (path) => MelosWorkspaceConfig.fallback(path: path),
-      );
+      final workspaceDir = await createTemporaryWorkspace();
 
       await createProject(
         workspaceDir,
@@ -320,7 +316,7 @@ Generating IntelliJ IDE files...
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,
@@ -493,7 +489,7 @@ dependency_overrides:
     });
 
     test('handles errors in pub get', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       await createProject(
         workspaceDir,
@@ -508,7 +504,7 @@ dependency_overrides:
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final workspace = await MelosWorkspace.fromConfig(
         config,
         logger: logger.toMelosLogger(),
@@ -550,7 +546,7 @@ e-Because a depends on package_that_does_not_exists any which doesn't exist (cou
     });
 
     test('can run pub get offline', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
           createYamlMap(
             {
@@ -567,7 +563,7 @@ e-Because a depends on package_that_does_not_exists any which doesn't exist (cou
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final workspace = await MelosWorkspace.fromConfig(
         config,
         logger: logger.toMelosLogger(),
@@ -635,9 +631,7 @@ Future<void> runMelosBootstrap(Melos melos, TestLogger logger) async {
 Future<void> dependencyResolutionTest(
   Map<String, List<String>> packages,
 ) async {
-  final workspaceDir = createTemporaryWorkspaceDirectory(
-    configBuilder: (path) => MelosWorkspaceConfig.fallback(path: path),
-  );
+  final workspaceDir = await createTemporaryWorkspace();
 
   Future<MapEntry<String, io.Directory>> createPackage(
     MapEntry<String, List<String>> entry,
@@ -694,7 +688,7 @@ Future<void> dependencyResolutionTest(
   }
 
   final logger = TestLogger();
-  final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+  final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
   final melos = Melos(
     logger: logger,
     config: config,

--- a/packages/melos/test/commands/clean_test.dart
+++ b/packages/melos/test/commands/clean_test.dart
@@ -12,7 +12,7 @@ import '../utils.dart';
 void main() {
   group('clean', () {
     test('removes dependency overrides from pubspec_overrides.yaml', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_workspace',
@@ -32,7 +32,7 @@ void main() {
       final pubspecOverrides =
           p.join(packageBDir.path, 'pubspec_overrides.yaml');
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final logger = TestLogger();
       final melos = Melos(config: config, logger: logger);
       await melos.bootstrap();

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -12,7 +12,7 @@ import '../utils.dart';
 void main() {
   group('exec', () {
     test('supports package filters', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       final aDir = await createProject(
         workspaceDir,
@@ -32,7 +32,7 @@ void main() {
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,
@@ -74,7 +74,7 @@ ${'-' * terminalWidth}
 
     group('order dependents', () {
       test('sorts execution order topologically', () async {
-        final workspaceDir = createTemporaryWorkspaceDirectory();
+        final workspaceDir = await createTemporaryWorkspace();
 
         await createProject(
           workspaceDir,
@@ -98,7 +98,8 @@ ${'-' * terminalWidth}
         );
 
         final logger = TestLogger();
-        final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+        final config =
+            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
         final melos = Melos(
           logger: logger,
           config: config,
@@ -133,7 +134,7 @@ ${'-' * terminalWidth}
       });
 
       test('fails fast if dependencies fail', () async {
-        final workspaceDir = createTemporaryWorkspaceDirectory();
+        final workspaceDir = await createTemporaryWorkspace();
 
         await createProject(
           workspaceDir,
@@ -157,7 +158,8 @@ ${'-' * terminalWidth}
         );
 
         final logger = TestLogger();
-        final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+        final config =
+            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
         final melos = Melos(
           logger: logger,
           config: config,
@@ -192,7 +194,7 @@ ${'-' * terminalWidth}
       });
 
       test('does not fail fast if dependencies is not run', () async {
-        final workspaceDir = createTemporaryWorkspaceDirectory();
+        final workspaceDir = await createTemporaryWorkspace();
 
         final aDir = await createProject(
           workspaceDir,
@@ -218,7 +220,8 @@ ${'-' * terminalWidth}
         writeTextFile(p.join(cDir.path, 'log.txt'), '');
 
         final logger = TestLogger();
-        final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+        final config =
+            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
         final melos = Melos(
           logger: logger,
           config: config,
@@ -254,7 +257,5 @@ ${'-' * terminalWidth}
         );
       });
     });
-
-    // TODO test that environment variables are injected
   });
 }

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -30,7 +30,8 @@ void main() {
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
 
           await melos.list();
@@ -64,7 +65,8 @@ b
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
 
           await melos.list();
@@ -93,7 +95,8 @@ c
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
 
           await melos.list(
@@ -128,7 +131,8 @@ c
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
 
           await melos.list(
@@ -161,7 +165,8 @@ long_name 0.0.0 packages/long_name PRIVATE
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
           await melos.list(
             kind: ListOutputKind.parsable,
@@ -197,7 +202,8 @@ packages/c
               .map((package) => p.join(workspaceDir.path, package.path))
               .map(p.canonicalize);
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
           await melos.list(
             kind: ListOutputKind.parsable,
@@ -233,7 +239,8 @@ ${packagePaths.join('\n')}
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
           await melos.list(
             kind: ListOutputKind.graph,
@@ -276,7 +283,8 @@ ${packagePaths.join('\n')}
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
           await melos.list(
             kind: ListOutputKind.json,
@@ -338,7 +346,8 @@ ${packagePaths.join('\n')}
             ],
           );
 
-          final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+          final config =
+              await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
           final melos = Melos(logger: logger, config: config);
           await melos.list(
             kind: ListOutputKind.gviz,

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -16,7 +16,8 @@ void main() {
     test(
       'supports passing package filter options to "melos exec" scripts',
       () async {
-        final workspaceDir = createTemporaryWorkspaceDirectory(
+        final workspaceDir = await createTemporaryWorkspace(
+          runPubGet: true,
           configBuilder: (path) => MelosWorkspaceConfig(
             path: path,
             name: 'test_package',
@@ -47,7 +48,8 @@ void main() {
         );
 
         final logger = TestLogger();
-        final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+        final config =
+            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
         final melos = Melos(
           logger: logger,
           config: config,
@@ -87,7 +89,7 @@ melos run test_script
     );
 
     test('supports passing additional arguments to run scripts', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -104,7 +106,7 @@ melos run test_script
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,
@@ -139,7 +141,8 @@ melos run test_script
     });
 
     test('supports running "melos exec" script with "exec" options', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -164,7 +167,7 @@ melos run test_script
       );
 
       final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
         logger: logger,
         config: config,

--- a/packages/melos/test/commands/script_test.dart
+++ b/packages/melos/test/commands/script_test.dart
@@ -9,7 +9,7 @@ import '../utils.dart';
 void main() {
   group('Script', () {
     test('fromConfig creates aliases for all scripts', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -24,7 +24,7 @@ void main() {
         ),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final command = ScriptCommand.fromConfig(config);
       expect(command, isNotNull);
       expect(
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('fromConfig excludes given commands', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -50,14 +50,14 @@ void main() {
         ),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final command = ScriptCommand.fromConfig(config, exclude: ['run']);
       expect(command, isNotNull);
       expect([command!.name, ...command.aliases], isNot(contains('run')));
     });
 
     test('fromConfig does not create an empty command', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory(
+      final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
           name: 'test_package',
@@ -70,7 +70,7 @@ void main() {
         ),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final command = ScriptCommand.fromConfig(config, exclude: ['clean']);
       expect(command, isNull);
     });

--- a/packages/melos/test/package_filter_test.dart
+++ b/packages/melos/test/package_filter_test.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 void main() {
   group('PackageFilters', () {
     test('dirExists', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       final aDir = await createProject(
         workspaceDir,
@@ -22,7 +22,7 @@ void main() {
         const PubSpec(name: 'b'),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final workspace = await MelosWorkspace.fromConfig(
         config,
         logger: TestLogger().toMelosLogger(),
@@ -45,7 +45,7 @@ void main() {
     });
 
     test('fileExists', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
 
       final aDir = await createProject(
         workspaceDir,
@@ -58,7 +58,7 @@ void main() {
         const PubSpec(name: 'b'),
       );
 
-      final config = await MelosWorkspaceConfig.fromDirectory(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final workspace = await MelosWorkspace.fromConfig(
         config,
         logger: TestLogger().toMelosLogger(),

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -64,7 +64,7 @@ void main() {
       reset(httpClientMock);
       IOOverrides.global = MockFs();
 
-      final config = await MelosWorkspaceConfig.fromDirectory(
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
         createMockWorkspaceFs(
           packages: [
             MockPackageFs(

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -77,7 +77,7 @@ void main() {
 
   group('startProcess', () {
     test('runs command chain in single shell', () async {
-      final workspaceDir = createTemporaryWorkspaceDirectory();
+      final workspaceDir = await createTemporaryWorkspace();
       final testDir = p.join(workspaceDir.path, 'test');
 
       ensureDir(testDir);

--- a/packages/melos/test/workspace_test.dart
+++ b/packages/melos/test/workspace_test.dart
@@ -139,18 +139,20 @@ The packages that caused the problem are:
       }),
     );
 
-    test('load workspace config when workspace contains broken symlink',
-        () async {
-      final workspaceDir = await createTemporaryWorkspace();
+    test(
+      'load workspace config when workspace contains broken symlink',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace();
 
-      final link = Link(p.join(workspaceDir.path, 'link'));
-      await link.create(p.join(workspaceDir.path, 'does-not-exist'));
+        final link = Link(p.join(workspaceDir.path, 'link'));
+        await link.create(p.join(workspaceDir.path, 'does-not-exist'));
 
-      await MelosWorkspace.fromConfig(
-        await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir),
-        logger: TestLogger().toMelosLogger(),
-      );
-    });
+        await MelosWorkspace.fromConfig(
+          await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir),
+          logger: TestLogger().toMelosLogger(),
+        );
+      },
+    );
 
     group('locate packages', () {
       test('in workspace root', () async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,4 @@
-name: 'melos_monorepo'
-publish_to: none
+name: melos_workspace
 
 environment:
   sdk: '>=2.18.0 <3.0.0'
@@ -10,16 +9,6 @@ executables:
 
 dev_dependencies:
   melos:
-    path: ./packages/melos
+    path: packages/melos
   path: ^1.7.0
   yaml: ^3.1.0
-
-# These allow us to use melos on itself during development.
-# If you make a new local package in this repo that the melos package
-# will depend on, then make sure to add it here otherwise you'll face
-# "'pubspec.yaml' has been modified since".. issues.
-dependency_overrides:
-  conventional_commit:
-    path: ./packages/conventional_commit
-  melos:
-    path: ./packages/melos


### PR DESCRIPTION
Before this change, versioning of Melos by users was not enforced. Most users installed Melos globally, and without specify a version, on development as well as CI machines. That means potentially breaking versions of Melos were adopted without the users' knowledge.

With this change, users are required to add a dependency on `melos` to a `pubspec.yaml` file, next to the `melos.yaml` file. The globally installed `melos` executable will hand over to the locally installed version if their versions are different. This ensures that the version of Melos used is always the correct one for the workspace the user is currently working in.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
