### PR TITLE
feat: add path to `IOException` message

### DIFF
--- a/packages/melos/lib/src/common/io.dart
+++ b/packages/melos/lib/src/common/io.dart
@@ -195,7 +195,8 @@ void _attempt(
         throw IOException(
           'Melos failed to $description because $reason.\n'
           'This may be caused by a virus scanner or having a file\n'
-          'in the directory open in another application.',
+          'in the directory open in another application.\n'
+          'Path: ${error.path}\n',
         );
       }
     }


### PR DESCRIPTION
## Description

I'm regularly having an issue with melos not being able to delete some file or folder.
Turns out it was the `.dart_tool/melos_tool` folder.
Just in order to give the user a clue as to what is going wrong, I'd like to add the `path` of the `FileSystemException` to the `IOException being thrown`

## Type of Change
- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
