### PR TITLE
feat: support running scripts in topological order with `melos exec`

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -91,10 +91,12 @@ Whether `exec` should fail fast and not execute the script in further packages i
 in an individual package.
 Defaults to `false`.
 
-## `scripts/*/exec/requireDependencies`
+## `scripts/*/exec/orderDependents`
 
-Whether `exec` should require the dependencies of this package to be completed first. Only applies
-to dependencies that would normally be part of this command.
+Whether `exec` should order the execution of the script in multiple packages based on the
+dependency graph of the packages. The script will be executed in leaf packages first and then
+in packages that depend on them and so on. This is useful for example, for a script that generates
+code in multiple packages, which depend on each other.
 Defaults to `false`.
 
 ## `scripts/*/env`

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -91,6 +91,12 @@ Whether `exec` should fail fast and not execute the script in further packages i
 in an individual package.
 Defaults to `false`.
 
+## `scripts/*/exec/requireDependencies`
+
+Whether `exec` should require the dependencies of this package to be completed first. Only applies
+to dependencies that would normally be part of this command.
+Defaults to `false`.
+
 ## `scripts/*/env`
 
 A map of environment variables that will be passed to the executed command.

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -31,6 +31,13 @@ class ExecCommand extends MelosCommand {
           'Whether exec should fail fast and not execute the script in further '
           'packages if the script fails in a individual package.',
     );
+    argParser.addFlag(
+      'require-dependencies',
+      abbr: 'd',
+      help: 'Whether `exec` should require the dependencies of this package to '
+          'be completed first. Only applies to dependencies that would '
+          'normally be part of this command.',
+    );
   }
 
   @override
@@ -59,11 +66,14 @@ class ExecCommand extends MelosCommand {
     final packageFilter = parsePackageFilter(config.path);
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final failFast = argResults!['fail-fast'] as bool;
+    final requireDependencies =
+        argResults?['require-dependencies'] as bool? ?? false;
 
     return melos.exec(
       execArgs,
       concurrency: concurrency,
       failFast: failFast,
+      requireDependencies: requireDependencies,
       global: global,
       filter: packageFilter,
     );

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -32,11 +32,14 @@ class ExecCommand extends MelosCommand {
           'packages if the script fails in a individual package.',
     );
     argParser.addFlag(
-      'require-dependencies',
-      abbr: 'd',
-      help: 'Whether `exec` should require the dependencies of this package to '
-          'be completed first. Only applies to dependencies that would '
-          'normally be part of this command.',
+      'order-dependents',
+      abbr: 'o',
+      help: 'Whether exec should order the execution of the script in multiple '
+          'packages based on the dependency graph of the packages. The script '
+          'will be executed in leaf packages first and then in packages that '
+          'depend on them and so on. This is useful for example, for a script '
+          'that generates code in multiple packages, which depend on each '
+          'other.',
     );
   }
 
@@ -66,14 +69,13 @@ class ExecCommand extends MelosCommand {
     final packageFilter = parsePackageFilter(config.path);
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final failFast = argResults!['fail-fast'] as bool;
-    final requireDependencies =
-        argResults?['require-dependencies'] as bool? ?? false;
+    final orderDependents = argResults!['order-dependents'] as bool;
 
     return melos.exec(
       execArgs,
       concurrency: concurrency,
       failFast: failFast,
-      requireDependencies: requireDependencies,
+      orderDependents: orderDependents,
       global: global,
       filter: packageFilter,
     );

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -157,6 +157,7 @@ mixin _PublishMixin on _ExecMixin {
       execArgs,
       concurrency: 1,
       failFast: true,
+      requireDependencies: false,
     );
 
     if (exitCode != 1) {

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -157,7 +157,7 @@ mixin _PublishMixin on _ExecMixin {
       execArgs,
       concurrency: 1,
       failFast: true,
-      requireDependencies: false,
+      orderDependents: false,
     );
 
     if (exitCode != 1) {

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -95,18 +95,17 @@ class ExecOptions {
   ExecOptions({
     this.concurrency,
     this.failFast,
-    this.requireDependencies,
+    this.orderDependents,
   });
 
   final int? concurrency;
   final bool? failFast;
-  final bool? requireDependencies;
+  final bool? orderDependents;
 
   Map<String, Object?> toJson() => {
         if (concurrency != null) 'concurrency': concurrency,
         if (failFast != null) 'failFast': failFast,
-        if (requireDependencies != null)
-          'requireDependencies': requireDependencies,
+        if (orderDependents != null) 'orderDependents': orderDependents,
       };
 
   @override
@@ -115,21 +114,21 @@ class ExecOptions {
       runtimeType == other.runtimeType &&
       concurrency == other.concurrency &&
       failFast == other.failFast &&
-      requireDependencies == other.requireDependencies;
+      orderDependents == other.orderDependents;
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       concurrency.hashCode ^
       failFast.hashCode ^
-      requireDependencies.hashCode;
+      orderDependents.hashCode;
 
   @override
   String toString() => '''
 ExecOptions(
   concurrency: $concurrency,
   failFast: $failFast,
-  requireDependencies: $requireDependencies,
+  orderDependents: $orderDependents,
 )''';
 }
 
@@ -257,8 +256,8 @@ class Script {
       path: execPath,
     );
 
-    final requireDependencies = assertKeyIsA<bool?>(
-      key: 'requireDependencies',
+    final orderDependents = assertKeyIsA<bool?>(
+      key: 'orderDependents',
       map: yaml,
       path: execPath,
     );
@@ -266,7 +265,7 @@ class Script {
     return ExecOptions(
       concurrency: concurrency,
       failFast: failFast,
-      requireDependencies: requireDependencies,
+      orderDependents: orderDependents,
     );
   }
 
@@ -304,13 +303,12 @@ class Script {
         parts.addAll(['--concurrency', '${exec.concurrency}']);
       }
 
-      // --fail-fast is a flag and as such does not accept any value
       if (exec.failFast ?? false) {
         parts.add('--fail-fast');
       }
 
-      if (exec.requireDependencies ?? false) {
-        parts.add('--require-dependencies');
+      if (exec.orderDependents ?? false) {
+        parts.add('--order-dependents');
       }
 
       parts.addAll(['--', quoteScript(run)]);

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -95,14 +95,18 @@ class ExecOptions {
   ExecOptions({
     this.concurrency,
     this.failFast,
+    this.requireDependencies,
   });
 
   final int? concurrency;
   final bool? failFast;
+  final bool? requireDependencies;
 
   Map<String, Object?> toJson() => {
         if (concurrency != null) 'concurrency': concurrency,
         if (failFast != null) 'failFast': failFast,
+        if (requireDependencies != null)
+          'requireDependencies': requireDependencies,
       };
 
   @override
@@ -110,17 +114,22 @@ class ExecOptions {
       other is ExecOptions &&
       runtimeType == other.runtimeType &&
       concurrency == other.concurrency &&
-      failFast == other.failFast;
+      failFast == other.failFast &&
+      requireDependencies == other.requireDependencies;
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^ concurrency.hashCode ^ failFast.hashCode;
+      runtimeType.hashCode ^
+      concurrency.hashCode ^
+      failFast.hashCode ^
+      requireDependencies.hashCode;
 
   @override
   String toString() => '''
 ExecOptions(
   concurrency: $concurrency,
   failFast: $failFast,
+  requireDependencies: $requireDependencies,
 )''';
 }
 
@@ -248,9 +257,16 @@ class Script {
       path: execPath,
     );
 
+    final requireDependencies = assertKeyIsA<bool?>(
+      key: 'requireDependencies',
+      map: yaml,
+      path: execPath,
+    );
+
     return ExecOptions(
       concurrency: concurrency,
       failFast: failFast,
+      requireDependencies: requireDependencies,
     );
   }
 
@@ -291,6 +307,10 @@ class Script {
       // --fail-fast is a flag and as such does not accept any value
       if (exec.failFast ?? false) {
         parts.add('--fail-fast');
+      }
+
+      if (exec.requireDependencies ?? false) {
+        parts.add('--require-dependencies');
       }
 
       parts.addAll(['--', quoteScript(run)]);

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
@@ -168,6 +170,20 @@ ${'-' * terminalWidth}
           requireDependencies: true,
         );
 
+        late final String platformExitString;
+
+        if (Platform.isWindows) {
+          platformExitString = '''
+e-[b]: 'unrecognised' is not recognized as an internal or external command,
+e-[b]: operable program or batch file.''';
+        } else if (Platform.isMacOS) {
+          platformExitString = '''
+e-[b]: /bin/sh: unrecognised: command not found''';
+        } else {
+          platformExitString = '''
+e-[b]: /bin/sh: 1: eval: unrecognised: not found''';
+        }
+
         expect(
           logger.output.normalizeNewLines(),
           ignoringAnsii(
@@ -177,14 +193,14 @@ ${'-' * terminalWidth}
      └> RUNNING (in 3 packages)
 
 ${'-' * terminalWidth}
-e-[b]: /bin/sh: unrecognised: command not found
+$platformExitString
 e-
 ${'-' * terminalWidth}
 
 \$ melos exec
   └> unrecognised
      └> FAILED (in 3 packages)
-        └> b (with exit code 127)
+        └> b (with exit code ${Platform.isWindows ? 1 : 127})
         └> c (dependency failed)
         └> a (dependency failed)
 ''',

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -430,7 +430,7 @@ void main() {
               'exec': {
                 'concurrency': 1,
                 'failFast': true,
-                'requireDependencies': true
+                'orderDependents': true
               },
             },
           }),
@@ -442,7 +442,7 @@ void main() {
           ExecOptions(
             concurrency: 1,
             failFast: true,
-            requireDependencies: true,
+            orderDependents: true,
           ),
         );
       });

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -430,13 +430,21 @@ void main() {
               'exec': {
                 'concurrency': 1,
                 'failFast': true,
+                'requireDependencies': true
               },
             },
           }),
           workspacePath: testWorkspacePath,
         );
         expect(scripts['a']!.run, 'b');
-        expect(scripts['a']!.exec, ExecOptions(concurrency: 1, failFast: true));
+        expect(
+          scripts['a']!.exec,
+          ExecOptions(
+            concurrency: 1,
+            failFast: true,
+            requireDependencies: true,
+          ),
+        );
       });
 
       test('throws when specifying command in "run" and "exec"', () {


### PR DESCRIPTION
## Description

Add `--require-dependencies` flag to exec to require the dependencies of a package be exec'd before the package itself.
As part of this, reorder the exec's to be topological like publish.

I believe this should close #433 

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
