### PR TITLE
docs: fix description of git-tag-version option

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -47,7 +47,7 @@ Use `--no-changelog` to disable.
 
 ## --[no-]git-tag-version (-t)
 
-Update CHANGELOG.md files (based on conventional commit messages). Defaults to `true`.
+Create a git tag. Defaults to `true`.
 
 ```bash
 melos version --git-tag-version


### PR DESCRIPTION
## Description

Fixed a wrong description in the documentation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
