### PR TITLE
fix: use `git pull --tags` instead of `git fetch --tags`

### DIFF
--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -229,7 +229,7 @@ Future<void> gitFetchTags({
   required MelosLogger logger,
 }) async {
   await gitExecuteCommand(
-    arguments: ['fetch', '--tags'],
+    arguments: ['pull', '--tags'],
     workingDirectory: workingDirectory,
     logger: logger,
   );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Use `git pull --tags` instead of `git fetch --tags`. The problem with using `fetch` - the tag needs to be associated with a branch that is on remote. If it isn't (i.e. usually squashed and merge) it will not be retrieved and will remain orphaned on remote.

Using `git pull --tags` will pull all tags no matter the status of the branch.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [X] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
