### PR TITLE
chore: use `husky` and `commitlint` to lint commit message 

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+DEBUG=true dart run commitlint_cli --edit $1

--- a/commitlint.yaml
+++ b/commitlint.yaml
@@ -1,0 +1,1 @@
+include: package:commitlint_cli/commitlint.yaml

--- a/melos.yaml
+++ b/melos.yaml
@@ -7,6 +7,9 @@ ignore:
   - packages/melos_flutter_deps_check
 
 command:
+  bootstrap:
+    hooks:
+      post: dart run husky install
   version:
     # Generate commit links in package changelogs.
     linkToCommits: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,8 @@ executables:
   melos: melos_dev
 
 dev_dependencies:
+  commitlint_cli: ^0.3.0
+  husky: ^0.1.5
   melos:
     path: packages/melos
   path: ^1.7.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

use [`husky`](https://github.com/hyiso/husky) to manage `commit-msg` hook, and [`commitlint`](https://github.com/hyiso/commitlint) to lint commit messages to meet conventional commit。

After this PR is merged, contributors will have `commit-msg` hook installed after running `melos bootstrap`.

And when making a commit, the commit message will be checked by `commitlint` to ensure it is conventional commit.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
