### PR TITLE
fix: change used API endpoint for querying versions

### DIFF
--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -891,7 +891,7 @@ class Package {
 
     final pubHosted = publishTo ?? pubUrl;
 
-    final url = pubHosted.replace(path: '/packages/$name.json');
+    final url = pubHosted.replace(path: '/api/packages/$name');
     final response = await http.get(url);
 
     if (response.statusCode == 404) {
@@ -905,9 +905,11 @@ class Package {
     }
     final versions = <String>[];
     final versionsRaw =
-        (json.decode(response.body) as Map)['versions'] as List<Object?>;
+        (json.decode(response.body) as Map)['versions'] as List<dynamic>;
     for (final versionElement in versionsRaw) {
-      versions.add(versionElement! as String);
+      if (versionElement is Map<String, dynamic>) {
+        versions.add(versionElement['version'] as String);
+      }
     }
     versions.sort((String a, String b) {
       return Version.prioritize(Version.parse(a), Version.parse(b));

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -18,7 +18,9 @@ import 'utils.dart';
 const pubPackageJson = '''
   {
     "versions": [
-      "1.0.0"
+      {
+        "version": "1.0.0"
+      }
     ]
   }
 ''';
@@ -85,7 +87,7 @@ void main() {
     tearDownAll(() => testClient = null);
 
     test('requests published packages from pub.dev by default', () async {
-      final uri = Uri.parse('https://pub.dev/packages/melos.json');
+      final uri = Uri.parse('https://pub.dev/api/packages/melos');
       when(httpClientMock.get(uri))
           .thenAnswer((_) async => http.Response(pubPackageJson, 200));
 
@@ -99,7 +101,7 @@ void main() {
       'requests published packages from PUB_HOSTED_URL if present',
       withMockPlatform(
         () async {
-          final uri = Uri.parse('http://localhost:8080/packages/melos.json');
+          final uri = Uri.parse('http://localhost:8080/api/packages/melos');
           when(httpClientMock.get(uri))
               .thenAnswer((_) async => http.Response(pubPackageJson, 200));
 


### PR DESCRIPTION
## Description

Unpub doesn't support querying "/packages/[package-name].json" which is used for querying the published versions of a package.
This PR switches to the "/api/packages/[package-name]" endpoint that is supported by pub.dev and Unpub.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
