### PR TITLE
docs: fix a typo in getting started section

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -10,7 +10,7 @@ it.
 
 ## Installation
 
-Installe Melos as a
+Install Melos as a
 [global package](https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path)
 via [pub.dev](https://pub.dev/) so it can be used from anywhere on your system:
 


### PR DESCRIPTION
## Description

- Fixed a small typo. _Installe_ should be _Install_

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
