### PR TITLE
fix: commit scopes that contain "-" should be treated as valid scopes

### DIFF
--- a/packages/conventional_commit/lib/conventional_commit.dart
+++ b/packages/conventional_commit/lib/conventional_commit.dart
@@ -18,7 +18,7 @@
 final _mergeCommitPrefixRegex = RegExp('^Merged? (.*?:)?');
 
 final _conventionalCommitHeaderRegex = RegExp(
-  r'(?<type>[a-zA-Z0-9_]+)(\((?<scope>[a-zA-Z0-9_,\s\*]+)\))?(?<breaking>!)?: ?(?<description>.+)',
+  r'(?<type>[a-zA-Z0-9_]+)(\((?<scope>[a-zA-Z0-9\-_,\s\*]+)\))?(?<breaking>!)?: ?(?<description>.+)',
 );
 
 final _breakingChangeRegex =

--- a/packages/conventional_commit/test/conventional_commit_test.dart
+++ b/packages/conventional_commit/test/conventional_commit_test.dart
@@ -55,6 +55,12 @@ feat(*): a new something (#1234)
 This also fixes an issue something else.
 ''';
 
+const commitMessageHyphenScope = '''
+feat(remote-config)!: add support for onConfigUpdated (#10647)
+
+This PR is a breaking change for Remote Config since we're removing the ChangeNotifier mixin that came with FirebaseRemoteConfig. You should handle the state of the RemoteConfig using your own state provider.
+''';
+
 void main() {
   group('$ConventionalCommit', () {
     test('invalid commit messages', () {
@@ -119,6 +125,27 @@ void main() {
       expect(commit.body, equals('This also fixes an issue something else.'));
       expect(commit.type, equals('feat'));
       expect(commit.scopes, equals(['*']));
+    });
+
+    test('correctly handles messages with a scope that contains "-"', () {
+      final commit = ConventionalCommit.tryParse(commitMessageHyphenScope);
+      expect(commit, isNotNull);
+      expect(
+        commit!.description,
+        equals('add support for onConfigUpdated (#10647)'),
+      );
+      expect(
+        commit.body,
+        equals(
+          "This PR is a breaking change for Remote Config since we're removing "
+          'the ChangeNotifier mixin that came with FirebaseRemoteConfig. You '
+          'should handle the state of the RemoteConfig using your own state '
+          'provider.',
+        ),
+      );
+      expect(commit.type, equals('feat'));
+      expect(commit.isBreakingChange, equals(true));
+      expect(commit.scopes, equals(['remote-config']));
     });
 
     test('header', () {


### PR DESCRIPTION
## Description

Reproducible example: https://zapp.run/edit/dart-zt4q06ipt4r0?entry=lib/main.dart&file=lib/main.dart

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
