### PR TITLE
chore: expand `cli_util` version constraint to include 0.4.0

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   ansi_styles: ^0.3.1
   args: ^2.0.0
   cli_launcher: ^0.3.0
-  cli_util: ^0.4.0
+  cli_util: '>=0.3.0 <0.5.0'
   collection: ^1.14.12
   conventional_commit: ^0.6.0+1
   file: ^6.1.0

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   ansi_styles: ^0.3.1
   args: ^2.0.0
   cli_launcher: ^0.3.0
-  cli_util: ^0.3.0
+  cli_util: ^0.4.0
   collection: ^1.14.12
   conventional_commit: ^0.6.0+1
   file: ^6.1.0


### PR DESCRIPTION


## Description

Updated the cli_util dependency from 0.3.0 to 0.4.0 some people were expressing it was creating conflicts with other packages, running test coverage showed the same result before and after the change.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
