### PR TITLE
feat: Sync common dependency versions between packages

### DIFF
--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -89,37 +89,35 @@ melos bootstrap --diff="main"
 Melos bootstrap command supports a few different flags that can be defined in
 your `melos.yaml`.
 
+
 ### Shared dependencies
 
 If you want to share dependency versions between your packages in your Melos
-project, add the flag `runPubGetInParallel` to your bootstrap config and add a
-file `common_packages.yaml` to your project.
+project, just add the dependencies you wish to share between the packages to
+your bootstrap config in your `melos.yaml` file.
+
+If a dependency from `environment`, `dependencies` or `dev_dependencies` in
+your `common_packages.yaml` exists in a package, the dependency version in this
+package will be updated to match the version defined in your
+bootstrap config every time `melos bootstrap` is run.
 
 ```yaml
 # melos.yaml
 # ...
 command:
+  environment:
+    sdk: ">=3.0.0 <4.0.0"
+    flutter: ">=3.0.0 <4.0.0"  
   bootstrap:
-    shareDependencies: true
-# ...
-```
-
-If a dependency from `dependencies` or `dev_dependencies` in your
-`common_packages.yaml` exists in a package, the dependency version in this
-package will be updated to match the version defined in your
-`common_packages.yaml` file every time `melos bootstrap` is run.
-
-```yaml
-# common_packages.yaml
-# ...
-dependencies:
-  collection: ^1.17.0
-  uni_links2:
-  uni_links_macos:
-    git: https://github.com/SamJakob/uni_links_macos.git
-
-dev_dependencies:
-  build_runner: ^2.3.3
+    dependencies:
+      collection: ^1.18.0
+      integral_isolates: any
+      uni_links2:
+      uni_links_macos:
+        git: https://github.com/SamJakob/uni_links_macos.git
+    
+    dev_dependencies:
+      build_runner: ^2.3.3
 # ...
 ```
 

--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -84,6 +84,45 @@ example:
 melos bootstrap --diff="main"
 ```
 
+## Bootstrap flags
+
+Melos bootstrap command supports a few different flags that can be defined in
+your `melos.yaml`.
+
+### Shared dependencies
+
+If you want to share dependency versions between your packages in your Melos
+project, add the flag `runPubGetInParallel` to your bootstrap config and add a
+file `common_packages.yaml` to your project.
+
+```yaml
+# melos.yaml
+# ...
+command:
+  bootstrap:
+    shareDependencies: true
+# ...
+```
+
+If a dependency from `dependencies` or `dev_dependencies` in your
+`common_packages.yaml` exists in a package, the dependency version in this
+package will be updated to match the version defined in your
+`common_packages.yaml` file every time `melos bootstrap` is run.
+
+```yaml
+# common_packages.yaml
+# ...
+dependencies:
+  collection: ^1.17.0
+  uni_links2:
+  uni_links_macos:
+    git: https://github.com/SamJakob/uni_links_macos.git
+
+dev_dependencies:
+  build_runner: ^2.3.3
+# ...
+```
+
 ## Adding a post bootstrap lifecycle script
 
 Melos supports various command [lifecycle hooks](/configuration/scripts#hooks)

--- a/melos.yaml
+++ b/melos.yaml
@@ -7,6 +7,38 @@ ignore:
   - packages/melos_flutter_deps_check
 
 command:
+  bootstrap:
+    environment:
+      sdk: '>=2.18.0 <3.0.0'
+    dependencies:
+      ansi_styles: ^0.3.1
+      args: ^2.0.0
+      cli_launcher: ^0.3.0
+      cli_util: '>=0.3.0 <0.5.0'
+      collection: ^1.14.12
+      conventional_commit: ^0.6.0+1
+      file: ^6.1.0
+      glob: ^2.1.0
+      graphs: ^2.1.0
+      http: ">=0.13.1 <2.0.0"
+      meta: ^1.1.8
+      mustache_template: ^2.0.0
+      path: ^1.7.0
+      platform: ^3.1.0
+      pool: ^1.4.0
+      prompts: ^2.0.0
+      pub_semver: ^2.0.0
+      pub_updater: ^0.3.0
+      pubspec: ^2.1.0
+      string_scanner: ^1.0.5
+      yaml: ^3.1.0
+      yaml_edit: ^2.0.2
+    dev_dependencies:
+      collection: ^1.15.0
+      mockito: ^5.1.0
+      test: ^1.17.5
+      path: ^1.7.0
+      yaml: ^3.1.0
   version:
     # Generate commit links in package changelogs.
     linkToCommits: true

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -300,8 +300,8 @@ mixin _BootstrapMixin on _CleanMixin {
             collectionStyle: CollectionStyle.BLOCK,
           ),
         );
+        didUpdate = true;
       }
-      didUpdate = true;
     }
 
     return didUpdate;

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -223,14 +223,14 @@ mixin _BootstrapMixin on _CleanMixin {
 
     final pubspecEditor = YamlEditor(packagePubspecContents);
 
-    final dependenciesUpdated = _updatePackages(
+    final updatedDependenciesCount = _updateDependencies(
       pubspecEditor: pubspecEditor,
       workspaceDependencies: workspacePubspec.dependencies,
       packageDependencies: package.pubSpec.dependencies,
       pubspecKey: 'dependencies',
     );
 
-    final devDependenciesUpdated = _updatePackages(
+    final updatedDevDependenciesCount = _updateDependencies(
       pubspecEditor: pubspecEditor,
       workspaceDependencies: workspacePubspec.devDependencies,
       packageDependencies: package.pubSpec.devDependencies,
@@ -242,11 +242,11 @@ mixin _BootstrapMixin on _CleanMixin {
       pubspecEditor.toString(),
     );
 
-    final totalUpdated = dependenciesUpdated + devDependenciesUpdated;
+    final totalUpdated = updatedDependenciesCount + updatedDevDependenciesCount;
     logger.log('Updated $totalUpdated packages in ${package.name}');
   }
 
-  int _updatePackages({
+  int _updateDependencies({
     required YamlEditor pubspecEditor,
     required Map<String, DependencyReference> workspaceDependencies,
     required Map<String, DependencyReference> packageDependencies,
@@ -254,13 +254,13 @@ mixin _BootstrapMixin on _CleanMixin {
   }) {
     // Filter out the packages that does not exist in package and only the
     // dependencies that has a different version specified in the workspace.
-    final packagesToUpgrade = workspaceDependencies.entries.where((element) {
+    final dependenciesToUpgrade = workspaceDependencies.entries.where((element) {
       if (!packageDependencies.containsKey(element.key)) return false;
       if (packageDependencies[element.key] == element.value) return false;
       return true;
     });
 
-    for (final entry in packagesToUpgrade) {
+    for (final entry in dependenciesToUpgrade) {
       pubspecEditor.update(
         [pubspecKey, entry.key],
         wrapAsYamlNode(
@@ -270,7 +270,7 @@ mixin _BootstrapMixin on _CleanMixin {
       );
     }
 
-    return packagesToUpgrade.length;
+    return dependenciesToUpgrade.length;
   }
 
   void _logBootstrapSuccess(Package package) {

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -289,7 +289,7 @@ mixin _BootstrapMixin on _CleanMixin {
     final workspaceUnParsedYaml = workspaceEnvironment.unParsedYaml;
     final packageUnParsedYaml = packageEnvironment.unParsedYaml;
     if (workspaceUnParsedYaml != null && packageUnParsedYaml != null) {
-      for(final entry in workspaceUnParsedYaml.entries){
+      for (final entry in workspaceUnParsedYaml.entries) {
         if (!packageUnParsedYaml.containsKey(entry.key)) continue;
         if (packageUnParsedYaml[entry.key] == entry.value) continue;
 

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -317,7 +317,7 @@ mixin _BootstrapMixin on _CleanMixin {
   }) {
     if (workspaceDependencies == null) return 0;
     // Filter out the packages that do not exist in package and only the
-    // dependencies that has a different version specified in the workspace.
+    // dependencies that have a different version specified in the workspace.
     final dependenciesToUpdate = workspaceDependencies.entries.where((entry) {
       if (!packageDependencies.containsKey(entry.key)) return false;
       if (packageDependencies[entry.key] == entry.value) return false;

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -321,6 +321,9 @@ String melosOverridesYamlPathForDirectory(String directory) =>
 String pubspecPathForDirectory(String directory) =>
     p.join(directory, 'pubspec.yaml');
 
+String pubspecCommonPathForDirectory(String directory) =>
+    p.join(directory, 'common_packages.yaml');
+
 String pubspecOverridesPathForDirectory(String directory) =>
     p.join(directory, 'pubspec_overrides.yaml');
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -321,9 +321,6 @@ String melosOverridesYamlPathForDirectory(String directory) =>
 String pubspecPathForDirectory(String directory) =>
     p.join(directory, 'pubspec.yaml');
 
-String pubspecCommonPathForDirectory(String directory) =>
-    p.join(directory, 'common_packages.yaml');
-
 String pubspecOverridesPathForDirectory(String directory) =>
     p.join(directory, 'pubspec_overrides.yaml');
 

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -457,13 +457,13 @@ class BootstrapCommandConfigs {
   /// The default is `false`.
   final bool runPubGetOffline;
 
-  // TODO(lohnn): Document
+  /// Environment configuration to be synced between all packages.
   final Environment? environment;
 
-  // TODO(lohnn): Document
+  /// Dependencies to be synced between all packages.
   final Map<String, DependencyReference>? dependencies;
 
-  // TODO(lohnn): Document
+  /// Dev dependencies to be synced between all packages.
   final Map<String, DependencyReference>? devDependencies;
 
   /// A list of [Glob]s for paths that contain packages to be used as dependency

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -483,7 +483,7 @@ class BootstrapCommandConfigs {
           (key, value) => MapEntry(key, value.toJson()),
         ),
       if (devDependencies != null)
-        'devDependencies': devDependencies!.map(
+        'dev_dependencies': devDependencies!.map(
           (key, value) => MapEntry(key, value.toJson()),
         ),
       if (dependencyOverridePaths.isNotEmpty)

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -357,6 +357,7 @@ class BootstrapCommandConfigs {
   const BootstrapCommandConfigs({
     this.runPubGetInParallel = true,
     this.runPubGetOffline = false,
+    this.shareDependencies = false,
     this.dependencyOverridePaths = const [],
     this.hooks = LifecycleHooks.empty,
   });
@@ -374,6 +375,13 @@ class BootstrapCommandConfigs {
 
     final runPubGetOffline = assertKeyIsA<bool?>(
           key: 'runPubGetOffline',
+          map: yaml,
+          path: 'command/bootstrap',
+        ) ??
+        false;
+
+    final shareDependencies = assertKeyIsA<bool?>(
+          key: 'shareDependencies',
           map: yaml,
           path: 'command/bootstrap',
         ) ??
@@ -402,6 +410,7 @@ class BootstrapCommandConfigs {
     return BootstrapCommandConfigs(
       runPubGetInParallel: runPubGetInParallel,
       runPubGetOffline: runPubGetOffline,
+      shareDependencies: shareDependencies,
       dependencyOverridePaths: dependencyOverridePaths
           .map(
             (override) =>
@@ -425,6 +434,12 @@ class BootstrapCommandConfigs {
   /// The default is `false`.
   final bool runPubGetOffline;
 
+  /// Whether to sync package dependencies with dependencies specified in
+  /// common_packages.yaml.
+  ///
+  /// The default is `false`.
+  final bool shareDependencies;
+
   /// A list of [Glob]s for paths that contain packages to be used as dependency
   /// overrides for all packages managed in the Melos workspace.
   final List<Glob> dependencyOverridePaths;
@@ -436,6 +451,7 @@ class BootstrapCommandConfigs {
     return {
       'runPubGetInParallel': runPubGetInParallel,
       'runPubGetOffline': runPubGetOffline,
+      'shareDependencies': shareDependencies,
       if (dependencyOverridePaths.isNotEmpty)
         'dependencyOverridePaths':
             dependencyOverridePaths.map((path) => path.toString()).toList(),
@@ -449,6 +465,7 @@ class BootstrapCommandConfigs {
       runtimeType == other.runtimeType &&
       other.runPubGetInParallel == runPubGetInParallel &&
       other.runPubGetOffline == runPubGetOffline &&
+      other.shareDependencies == shareDependencies &&
       const DeepCollectionEquality(_GlobEquality())
           .equals(other.dependencyOverridePaths, dependencyOverridePaths) &&
       other.hooks == hooks;
@@ -458,6 +475,7 @@ class BootstrapCommandConfigs {
       runtimeType.hashCode ^
       runPubGetInParallel.hashCode ^
       runPubGetOffline.hashCode ^
+      shareDependencies.hashCode ^
       const DeepCollectionEquality(_GlobEquality())
           .hash(dependencyOverridePaths) ^
       hooks.hashCode;
@@ -468,6 +486,7 @@ class BootstrapCommandConfigs {
 BootstrapCommandConfigs(
   runPubGetInParallel: $runPubGetInParallel,
   runPubGetOffline: $runPubGetOffline,
+  shareDependencies: $shareDependencies,
   dependencyOverridePaths: $dependencyOverridePaths,
   hooks: $hooks,
 )''';

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -477,7 +477,7 @@ class BootstrapCommandConfigs {
     return {
       'runPubGetInParallel': runPubGetInParallel,
       'runPubGetOffline': runPubGetOffline,
-      if (environment != null) 'environment': environment,
+      if (environment != null) 'environment': environment!.toJson(),
       if (dependencies != null)
         'dependencies': dependencies!.map(
           (key, value) => MapEntry(key, value.toJson()),
@@ -499,8 +499,12 @@ class BootstrapCommandConfigs {
       runtimeType == other.runtimeType &&
       other.runPubGetInParallel == runPubGetInParallel &&
       other.runPubGetOffline == runPubGetOffline &&
-      // TODO(lohnn): Equality implementation for environment
-      other.environment == environment &&
+      // Extracting equality from environment here as it does not implement ==
+      other.environment?.sdkConstraint == environment?.sdkConstraint &&
+      const DeepCollectionEquality().equals(
+        other.environment?.unParsedYaml,
+        environment?.unParsedYaml,
+      ) &&
       const DeepCollectionEquality().equals(other.dependencies, dependencies) &&
       const DeepCollectionEquality()
           .equals(other.devDependencies, devDependencies) &&
@@ -513,8 +517,12 @@ class BootstrapCommandConfigs {
       runtimeType.hashCode ^
       runPubGetInParallel.hashCode ^
       runPubGetOffline.hashCode ^
-      // TODO(lohnn): Hashcode for environment?
-      environment.hashCode ^
+      // Extracting hashCode from environment here as it does not implement
+      // hashCode
+      (environment?.sdkConstraint).hashCode ^
+      const DeepCollectionEquality().hash(
+        environment?.unParsedYaml,
+      ) ^
       const DeepCollectionEquality().hash(dependencies) ^
       const DeepCollectionEquality().hash(devDependencies) ^
       const DeepCollectionEquality(_GlobEquality())

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -600,6 +600,10 @@ Generating IntelliJ IDE files...
             ],
             commands: CommandConfigs(
               bootstrap: BootstrapCommandConfigs(
+                environment: Environment(
+                  VersionConstraint.parse('>=2.18.0 <3.0.0'),
+                  {'flutter': '>=2.18.0 <3.0.0'},
+                ),
                 dependencies: {
                   'intl': HostedReference(
                     VersionConstraint.compatibleWith(Version.parse('0.18.1')),
@@ -626,6 +630,10 @@ Generating IntelliJ IDE files...
           workspaceDir,
           PubSpec(
             name: 'a',
+            environment: Environment(
+              VersionConstraint.any,
+              {},
+            ),
             dependencies: {
               'intl': HostedReference(
                 VersionConstraint.compatibleWith(Version.parse('0.18.1')),
@@ -646,6 +654,16 @@ Generating IntelliJ IDE files...
           workspaceDir,
           PubSpec(
             name: 'b',
+            environment: Environment(
+              VersionRange(
+                min: Version.parse('2.12.0'),
+                max: Version.parse('3.0.0'),
+                includeMin: true,
+              ),
+              {
+                'flutter': '>=2.12.0 <3.0.0',
+              },
+            ),
             dependencies: {
               'integral_isolates': HostedReference(
                 VersionConstraint.compatibleWith(Version.parse('0.4.1')),
@@ -672,6 +690,14 @@ Generating IntelliJ IDE files...
         final pubspecB = pubSpecFromYamlFile(directory: pkgB.path);
 
         expect(
+          pubspecA.environment?.sdkConstraint,
+          equals(VersionConstraint.parse('>=2.18.0 <3.0.0')),
+        );
+        expect(
+          pubspecA.environment?.unParsedYaml,
+          equals({}),
+        );
+        expect(
           pubspecA.dependencies,
           equals({
             'intl': HostedReference(
@@ -691,6 +717,14 @@ Generating IntelliJ IDE files...
           }),
         );
 
+        expect(
+          pubspecB.environment?.sdkConstraint,
+          equals(VersionConstraint.parse('>=2.18.0 <3.0.0')),
+        );
+        expect(
+          pubspecB.environment?.unParsedYaml,
+          equals({'flutter': '>=2.18.0 <3.0.0'}),
+        );
         expect(
           pubspecB.dependencies,
           equals({

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -284,6 +284,13 @@ PubSpec pubSpecFromJsonFile({
   return PubSpec.fromJson(json.decode(jsonAsString) as Map);
 }
 
+PubSpec pubSpecFromYamlFile({
+  required String directory,
+}) {
+  final filePath = pubspecPathForDirectory(directory);
+  return PubSpec.fromYamlString(readTextFile(filePath));
+}
+
 /// Builder to build a [MelosWorkspace] that is entirely virtual and only exists
 /// in memory.
 class VirtualWorkspaceBuilder {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

**NOTE:** I'm adding this as a draft PR as docs and tests are not yet added and I haven't yet added feedback if the user turned on the flag but didn't provide the `common_packages.yaml`-file. But I wish for feedback on my solution anyways.

## Description

Added support for setting versions for common/shared dependencies that will be applied to all packages in a Melos monorepo project. Implements #94.

A new bootstrap config flag (`shareDependencies`) is added to start using this new feature, and then the dependency versions for `dependencies` and `dev_dependencies` in `common_packages.yaml` will be applied to all packages that contains said dependency.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
