### PR TITLE
chore: widen constraints to allow `http` 1.0.0

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   file: ^6.1.0
   glob: ^2.1.0
   graphs: ^2.1.0
-  http: ^0.13.1
+  http: ">=0.13.1 <2.0.0"
   meta: ^1.1.8
   mustache_template: ^2.0.0
   path: ^1.7.0


### PR DESCRIPTION
## Description

The `http` package was updated to `1.0.0`. There are no change that affect usage (it just adds new class restrictions), so this extends all dependencies to include both `0.13.x` and `1.x.x`.

fixes: #532

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
