### PR TITLE
chore: update `pub_updater` to 0.3.0

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   pool: ^1.4.0
   prompts: ^2.0.0
   pub_semver: ^2.0.0
-  pub_updater: ^0.2.2
+  pub_updater: ^0.3.0
   pubspec: ^2.1.0
   string_scanner: ^1.0.5
   yaml: ^3.1.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Currently melos is not compatible to packages like `dart_code_metrics ^5.7.4` because of a version conflict with `pub_updater`. Version `0.3.0` of pub_updater has been released that fixes bugs.

I have therefore set the version of `pub_updater` for melos to `^0.3.0`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
