### PR TITLE
fix: `.idea/modules.xml` should always uses `/` instead of `\`

### DIFF
--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -149,11 +149,11 @@ class IntellijProject {
   }
 
   String ideaModuleStringForName(String moduleName, {String? relativePath}) {
-    String imlPath = relativePath != null
+    var imlPath = relativePath != null
         ? p.normalize('$relativePath/$moduleName.iml')
         : '$moduleName.iml';
     // Use `/` instead of `\` no matter what platform is.
-    imlPath = imlPath.replaceAll(r'\', r'/');
+    imlPath = imlPath.replaceAll(r'\', '/');
     final module = '<module '
         'fileurl="file://\$PROJECT_DIR\$/$imlPath" '
         'filepath="\$PROJECT_DIR\$/$imlPath" '

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -149,9 +149,11 @@ class IntellijProject {
   }
 
   String ideaModuleStringForName(String moduleName, {String? relativePath}) {
-    final imlPath = relativePath != null
+    String imlPath = relativePath != null
         ? p.normalize('$relativePath/$moduleName.iml')
         : '$moduleName.iml';
+    // Use `/` instead of `\` no matter what platform is.
+    imlPath = imlPath.replaceAll(r'\', r'/');
     final module = '<module '
         'fileurl="file://\$PROJECT_DIR\$/$imlPath" '
         'filepath="\$PROJECT_DIR\$/$imlPath" '

--- a/packages/melos/test/common/intellij_project_test.dart
+++ b/packages/melos/test/common/intellij_project_test.dart
@@ -29,4 +29,29 @@ void main() {
       expect(modulesXml, contains(r'file://$PROJECT_DIR$/melos_root.iml'));
     },
   );
+
+  // https://github.com/invertase/melos/issues/582
+  test(
+    'always generates iml paths with `/`',
+    () async {
+      final tempDir = createTestTempDir();
+      final workspaceBuilder = VirtualWorkspaceBuilder(
+        path: tempDir.path,
+        '''
+        packages:
+          - .
+        ''',
+      )..addPackage(
+          '''
+          name: test
+          ''',
+          path: 'test',
+        );
+      final workspace = workspaceBuilder.build();
+      final project = IntellijProject.fromWorkspace(workspace);
+      await project.generate();
+      final modulesXml = readTextFile(project.pathModulesXml);
+      expect(modulesXml, contains(r'file://$PROJECT_DIR$/test/melos_test.iml'));
+    },
+  );
 }


### PR DESCRIPTION
Resolves #581.

## Description

Replace all `\` with `/` regardless of platforms.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
