### PR TITLE
fix: typo in version.mdx

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -179,5 +179,5 @@ Each value must be in the format
 ```bash
 melos version --manual-version=foo:patch
 melos version --manual-version=foo:1.0.0
-melos version -Vfoo:1.0.0
+melos version -V foo:1.0.0
 ```


### PR DESCRIPTION
## Description

Typo fix in `version` command documentation page.

P.S. Not for Hacktoberfest sake :) Found this typo while trying to find out how to do manual versioning for multiple packages #586

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
