### PR TITLE
refactor: Remove unnecessary parenthesis to get analyzer green

### DIFF
--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -35,7 +35,7 @@ mixin _ExecMixin on _Melos {
     final environment = {
       ...currentPlatform.environment,
       'MELOS_PACKAGE_NAME': package.name,
-      'MELOS_PACKAGE_VERSION': (package.version).toString(),
+      'MELOS_PACKAGE_VERSION': package.version.toString(),
       'MELOS_PACKAGE_PATH': package.path,
       'MELOS_ROOT_PATH': workspace.path,
       if (workspace.sdkPath != null) envKeyMelosSdkPath: workspace.sdkPath!,

--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -74,7 +74,7 @@ mixin _ListMixin on _Melos {
             .map(
               (package) => [
                 package.name,
-                AnsiStyles.green((package.version).toString()),
+                AnsiStyles.green(package.version.toString()),
                 AnsiStyles.gray(printablePath(package.pathRelativeToWorkspace)),
                 if (package.isPrivate) AnsiStyles.red('PRIVATE'),
               ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The analyzer is currently failing with the newest dart version, this fix simply removes the unnecessary parenthesis so that `analyze` becomes green again.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
