### PR TITLE
feat: add "--no-example" arg to "pub get " command for melos bootstrap

### DIFF
--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -19,6 +19,13 @@ melos bs
 Bootstrapping has two primary functions:
 
 1. Installing all package dependencies (internally using `pub get`).
+   Optionally, you can use the `--no-example`` flag to exclude flutter package's example's dependencies (https://github.com/dart-lang/pub/pull/3856):
+   ```bash
+   melos bootstrap --no-example
+   # or
+   melos bs --no-example
+   ```
+   this will run `pub get --no-example` instead of `pub get`
 2. Locally linking any packages together via path dependency overrides _without
    having to edit your pubspec.yaml_.
 

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -23,6 +23,11 @@ import 'base.dart';
 class BootstrapCommand extends MelosCommand {
   BootstrapCommand(super.config) {
     setupPackageFilterParser();
+    argParser.addFlag(
+      'no-example',
+      negatable: false,
+      help: 'Run pub get with/without example pub get',
+    );
   }
 
   @override
@@ -39,10 +44,10 @@ class BootstrapCommand extends MelosCommand {
   @override
   FutureOr<void>? run() {
     final melos = Melos(logger: logger, config: config);
-
     return melos.bootstrap(
       global: global,
       packageFilters: parsePackageFilters(config.path),
+      noExample: argResults?['no-example'] as bool,
     );
   }
 }

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -4,6 +4,7 @@ mixin _BootstrapMixin on _CleanMixin {
   Future<void> bootstrap({
     GlobalOptions? global,
     PackageFilters? packageFilters,
+    required bool noExample,
   }) async {
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
@@ -19,6 +20,7 @@ mixin _BootstrapMixin on _CleanMixin {
             workspace: workspace,
           ),
           'get',
+          if (noExample == true) '--no-example',
           if (bootstrapCommandConfig.runPubGetOffline) '--offline',
         ].join(' ');
 
@@ -50,7 +52,10 @@ mixin _BootstrapMixin on _CleanMixin {
             }).drain<void>();
           }
 
-          await _linkPackagesWithPubspecOverrides(workspace);
+          await _linkPackagesWithPubspecOverrides(
+            workspace,
+            noExample: noExample,
+          );
         } on BootstrapException catch (exception) {
           _logBootstrapException(exception, workspace);
           rethrow;
@@ -77,8 +82,9 @@ mixin _BootstrapMixin on _CleanMixin {
   }
 
   Future<void> _linkPackagesWithPubspecOverrides(
-    MelosWorkspace workspace,
-  ) async {
+    MelosWorkspace workspace, {
+    required bool noExample,
+  }) async {
     final filteredPackages = workspace.filteredPackages.values;
 
     await Stream.fromIterable(filteredPackages).parallel(
@@ -105,7 +111,11 @@ mixin _BootstrapMixin on _CleanMixin {
             bootstrappedPackages.add(example);
           }
         }
-        await _runPubGetForPackage(workspace, package);
+        await _runPubGetForPackage(
+          workspace,
+          package,
+          noExample: noExample,
+        );
 
         bootstrappedPackages.forEach(_logBootstrapSuccess);
       },
@@ -170,14 +180,16 @@ mixin _BootstrapMixin on _CleanMixin {
 
   Future<void> _runPubGetForPackage(
     MelosWorkspace workspace,
-    Package package,
-  ) async {
+    Package package, {
+    required bool noExample,
+  }) async {
     final command = [
       ...pubCommandExecArgs(
         useFlutter: package.isFlutterPackage,
         workspace: workspace,
       ),
       'get',
+      if (noExample) '--no-example',
       if (workspace.config.commands.bootstrap.runPubGetOffline) '--offline',
     ];
 

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -4,7 +4,7 @@ mixin _BootstrapMixin on _CleanMixin {
   Future<void> bootstrap({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    required bool noExample,
+    bool noExample = false,
   }) async {
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);


### PR DESCRIPTION
## Description

- add ``` --no-example ``` arg for ```dart/flutter pub get``` of bootstrap command [https://github.com/dart-lang/pub/pull/3856](url)

## Usage
```
melos bs --no-example
```

## Type of Change

- [ x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
