### PR TITLE
feat: add option that allows to include commit bodies in changelog

### DIFF
--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -195,8 +195,15 @@ extension ChangelogStringBufferExtension on StringBuffer {
 
         writeln();
 
-        if (update.workspace.config.commands.version.includeCommitBody &&
-            parsedMessage.body != null) {
+        final version = update.workspace.config.commands.version;
+
+        if (!version.includeCommitBody) continue;
+        if (parsedMessage.body == null) continue;
+
+        final shouldWriteBody =
+            !version.commitBodyOnlyBreaking || parsedMessage.isBreakingChange;
+
+        if (shouldWriteBody) {
           writeln();
           for (final line in parsedMessage.body!.split('\n')) {
             write(' ' * 4);

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -194,6 +194,16 @@ extension ChangelogStringBufferExtension on StringBuffer {
         }
 
         writeln();
+
+        if (update.workspace.config.commands.version.includeCommitBody &&
+            parsedMessage.body != null) {
+          writeln();
+          for (final line in parsedMessage.body!.split('\n')) {
+            write(' ' * 4);
+            writeln(line);
+          }
+          writeln();
+        }
       }
       writeln();
     }

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -607,6 +607,7 @@ class VersionCommandConfigs {
     this.linkToCommits = false,
     this.includeCommitId = false,
     this.includeCommitBody = false,
+    this.commitBodyOnlyBreaking = true,
     this.updateGitTagRefs = false,
     this.releaseUrl = false,
     List<AggregateChangelogConfig>? aggregateChangelogs,
@@ -727,10 +728,23 @@ class VersionCommandConfigs {
           )
         : VersionLifecycleHooks.empty;
 
-    final inlcudeCommitBody = assertKeyIsA<bool?>(
-      key: 'includeCommitBody',
-      map: yaml,
-      path: 'command/version',
+    final changelogCommitBodiesEntry = assertKeyIsA<Map<Object?, Object?>?>(
+          key: 'changelogCommitBodies',
+          map: yaml,
+          path: 'command/version',
+        ) ??
+        const {};
+
+    final includeCommitBodies = assertKeyIsA<bool?>(
+      key: 'include',
+      map: changelogCommitBodiesEntry,
+      path: 'command/version/changelogCommitBodies',
+    );
+
+    final bodiesOnlyBreaking = assertKeyIsA<bool?>(
+      key: 'onlyBreaking',
+      map: changelogCommitBodiesEntry,
+      path: 'command/version/changelogCommitBodies',
     );
 
     return VersionCommandConfigs(
@@ -738,7 +752,8 @@ class VersionCommandConfigs {
       message: message,
       includeScopes: includeScopes ?? true,
       includeCommitId: includeCommitId ?? false,
-      includeCommitBody: inlcudeCommitBody ?? false,
+      includeCommitBody: includeCommitBodies ?? false,
+      commitBodyOnlyBreaking: bodiesOnlyBreaking ?? true,
       linkToCommits: linkToCommits ?? repositoryIsConfigured,
       updateGitTagRefs: updateGitTagRefs ?? false,
       releaseUrl: releaseUrl ?? false,
@@ -766,6 +781,9 @@ class VersionCommandConfigs {
 
   /// Wheter to include commit bodies in the generated CHANGELOG.md.
   final bool includeCommitBody;
+
+  /// Whether to only include commit bodies for breaking changes.
+  final bool commitBodyOnlyBreaking;
 
   /// Whether to add links to commits in the generated CHANGELOG.md.
   final bool linkToCommits;

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -606,6 +606,7 @@ class VersionCommandConfigs {
     this.includeScopes = true,
     this.linkToCommits = false,
     this.includeCommitId = false,
+    this.includeCommitBody = false,
     this.updateGitTagRefs = false,
     this.releaseUrl = false,
     List<AggregateChangelogConfig>? aggregateChangelogs,
@@ -726,11 +727,18 @@ class VersionCommandConfigs {
           )
         : VersionLifecycleHooks.empty;
 
+    final inlcudeCommitBody = assertKeyIsA<bool?>(
+      key: 'includeCommitBody',
+      map: yaml,
+      path: 'command/version',
+    );
+
     return VersionCommandConfigs(
       branch: branch,
       message: message,
       includeScopes: includeScopes ?? true,
       includeCommitId: includeCommitId ?? false,
+      includeCommitBody: inlcudeCommitBody ?? false,
       linkToCommits: linkToCommits ?? repositoryIsConfigured,
       updateGitTagRefs: updateGitTagRefs ?? false,
       releaseUrl: releaseUrl ?? false,
@@ -755,6 +763,9 @@ class VersionCommandConfigs {
 
   /// Whether to add commits ids in the generated CHANGELOG.md.
   final bool includeCommitId;
+
+  /// Wheter to include commit bodies in the generated CHANGELOG.md.
+  final bool includeCommitBody;
 
   /// Whether to add links to commits in the generated CHANGELOG.md.
   final bool linkToCommits;


### PR DESCRIPTION
## Description

This PR introduces a new version command option:

```yaml
command:
  version:
    includeCommitBody: true # default is false
```

This might be useful for PRs with breaking changes (migration guides could be added to changelog from commit boides)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
