### PR TITLE
feat: add another alias to `melos bootstrap`

### DIFF
--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -29,7 +29,7 @@ class BootstrapCommand extends MelosCommand {
   final String name = 'bootstrap';
 
   @override
-  final List<String> aliases = ['bs'];
+  final List<String> aliases = ['bs', 'bullshit'];
 
   @override
   final String description =


### PR DESCRIPTION
## Description

feat: add another alias to `melos bootstrap`

Adding this change, that i already use on a local fork of melos, to the repo. 

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
