### PR TITLE
docs: added missing execution of `melos bootstrap` in getting started file

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -84,6 +84,12 @@ primary roles:
 1. Installing all package dependencies (internally using `pub get`).
 2. Locally linking any packages together.
 
+Bootstrap your project by running the following command: 
+
+```bash
+melos bootstrap
+```
+
 ### Why do I need to bootstrap?
 
 In normal projects, packages can be linked by providing a `path` within the


### PR DESCRIPTION
## Description

While the _Getting Started_ document tells the user about the importance of bootstrapping, the actual `melos bootstrap` command is neither shown nor executed. This is not a major problem, but I tripped over it while following the instructions, so I suspect it may irritate others as well.

Thus, I made that small addition.

refs #565

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
