### PR TITLE
feat: Add `git-commit-version` flag to control commit creation

### DIFF
--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -92,7 +92,8 @@ class VersionCommand extends MelosCommand {
       abbr: 'C',
       defaultsTo: true,
       help: 'By default, melos version will commit changes to pubspec.yaml '
-          'files. Pass --no-git-commit-version to disable the behaviour.',
+          'files. Pass --no-git-commit-version to disable the behaviour, '
+          'passing this also implies --no-git-tag-version.',
     );
     argParser.addFlag(
       'release-url',

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -91,9 +91,9 @@ class VersionCommand extends MelosCommand {
       'git-commit-version',
       abbr: 'C',
       defaultsTo: true,
-      help: 'By default, melos version will commit changes to pubspec.yaml and changelog '
-          'files. Pass --no-git-commit-version to disable the behaviour, '
-          'passing this also implies --no-git-tag-version.',
+      help: 'By default, melos version will commit changes to pubspec.yaml and '
+          'changelog files. Pass --no-git-commit-version to disable the '
+          'behaviour, passing this also implies --no-git-tag-version.',
     );
     argParser.addFlag(
       'release-url',

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -91,7 +91,7 @@ class VersionCommand extends MelosCommand {
       'git-commit-version',
       abbr: 'C',
       defaultsTo: true,
-      help: 'By default, melos version will commit changes to pubspec.yaml '
+      help: 'By default, melos version will commit changes to pubspec.yaml and changelog '
           'files. Pass --no-git-commit-version to disable the behaviour, '
           'passing this also implies --no-git-tag-version.',
     );

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -84,10 +84,15 @@ class VersionCommand extends MelosCommand {
       'git-tag-version',
       abbr: 't',
       defaultsTo: true,
-      help:
-          'By default, melos version will commit changes to pubspec.yaml files '
-          'and tag the release. Pass --no-git-tag-version to disable the '
-          'behaviour.',
+      help: 'By default, melos version will tag the release. Pass '
+          '--no-git-tag-version to disable the behaviour.',
+    );
+    argParser.addFlag(
+      'git-commit-version',
+      abbr: 'C',
+      defaultsTo: true,
+      help: 'By default, melos version will commit changes to pubspec.yaml '
+          'files. Pass --no-git-commit-version to disable the behaviour.',
     );
     argParser.addFlag(
       'release-url',
@@ -167,6 +172,7 @@ class VersionCommand extends MelosCommand {
     final updateDependentsConstraints =
         argResults!['dependent-constraints'] as bool;
     final tag = argResults!['git-tag-version'] as bool;
+    final commit = argResults!['git-commit-version'] as bool;
     final releaseUrl = argResults!.optional('release-url') as bool?;
     final changelog = argResults!['changelog'] as bool;
     final commitMessage =
@@ -196,6 +202,7 @@ class VersionCommand extends MelosCommand {
         manualVersions: {packageName: versionChange},
         force: force,
         gitTag: tag,
+        gitCommit: commit,
         releaseUrl: releaseUrl,
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
@@ -238,6 +245,7 @@ class VersionCommand extends MelosCommand {
         packageFilters: parsePackageFilters(config.path),
         force: force,
         gitTag: tag,
+        gitCommit: commit,
         releaseUrl: releaseUrl,
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -371,7 +371,7 @@ mixin _VersionMixin on _RunMixin {
       );
     }
 
-    if (gitTag) {
+    if (gitTag && gitCommit) {
       await _gitTagChanges(
         pendingPackageUpdates,
         updateDependentsVersions: updateDependentsVersions,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -354,25 +354,24 @@ mixin _VersionMixin on _RunMixin {
       logger.newLine();
     }
 
+    await _gitStageChanges(
+      workspace,
+      pendingPackageUpdates,
+      updateDependentsVersions: updateDependentsVersions,
+    );
+    await _gitCommitChanges(
+      workspace,
+      pendingPackageUpdates,
+      commitMessageTemplate,
+      updateDependentsVersions: updateDependentsVersions,
+    );
+
     if (gitTag) {
-      await _gitStageChanges(
-        workspace,
-        pendingPackageUpdates,
-        updateDependentsVersions: updateDependentsVersions,
-      );
-      await _gitCommitChanges(
-        workspace,
-        pendingPackageUpdates,
-        commitMessageTemplate,
-        updateDependentsVersions: updateDependentsVersions,
-      );
       await _gitTagChanges(
         pendingPackageUpdates,
         updateDependentsVersions: updateDependentsVersions,
       );
-    }
 
-    if (gitTag) {
       logger.success(
         'Versioning successful. '
         'Ensure you push your git changes and tags (if applicable) via '

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -12,6 +12,7 @@ mixin _VersionMixin on _RunMixin {
     bool updateDependentsConstraints = true,
     bool updateDependentsVersions = true,
     bool gitTag = true,
+    bool gitCommit = true,
     bool? releaseUrl,
     String? message,
     bool force = false,
@@ -59,6 +60,7 @@ mixin _VersionMixin on _RunMixin {
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
         gitTag: gitTag,
+        gitCommit: gitCommit,
         releaseUrl: releaseUrl,
         message: message,
         force: force,
@@ -81,6 +83,7 @@ mixin _VersionMixin on _RunMixin {
     bool updateDependentsConstraints = true,
     bool updateDependentsVersions = true,
     bool gitTag = true,
+    bool gitCommit = true,
     bool? releaseUrl,
     String? message,
     bool force = false,
@@ -354,17 +357,19 @@ mixin _VersionMixin on _RunMixin {
       logger.newLine();
     }
 
-    await _gitStageChanges(
-      workspace,
-      pendingPackageUpdates,
-      updateDependentsVersions: updateDependentsVersions,
-    );
-    await _gitCommitChanges(
-      workspace,
-      pendingPackageUpdates,
-      commitMessageTemplate,
-      updateDependentsVersions: updateDependentsVersions,
-    );
+    if (gitCommit) {
+      await _gitStageChanges(
+        workspace,
+        pendingPackageUpdates,
+        updateDependentsVersions: updateDependentsVersions,
+      );
+      await _gitCommitChanges(
+        workspace,
+        pendingPackageUpdates,
+        commitMessageTemplate,
+        updateDependentsVersions: updateDependentsVersions,
+      );
+    }
 
     if (gitTag) {
       await _gitTagChanges(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This adds the `--git-commit-version`/`--no-git-commit-version` flags to control commit creation, since this no longer will be omitted after #625 is merged and `-t` is used.

This PR has #625 as a base, so that needs to be merged first.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
