### PR TITLE
feat!: make run script use melos_packages env variable scope

### DIFF
--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -63,7 +63,8 @@ package' name ends with `example`
 ### `MELOS_PACKAGES`
 
 Define a comma delimited list of package names that Melos should focus on. This
-bypasses all filtering flags if defined.
+will act as the `scope` global package filter, and it will override the `scope`
+for all the filtering options defined in the `packageFilters` section.
 
 ### `MELOS_SDK_PATH`
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -147,7 +147,7 @@ mixin _RunMixin on _Melos {
           : packages[selectedPackageIndex - 1].name;
       // MELOS_PACKAGES environment is detected by melos itself when through
       // a defined script, this comma delimited list of package names used to
-      // scope the `packageFilers` if it is present.
+      // scope the `packageFilters` if it is present.
       environment[envKeyMelosPackages] = packagesEnv;
     }
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -147,7 +147,7 @@ mixin _RunMixin on _Melos {
           : packages[selectedPackageIndex - 1].name;
       // MELOS_PACKAGES environment is detected by melos itself when through
       // a defined script, this comma delimited list of package names used to
-      // scope the packageFilers if it is present.
+      // scope the `packageFilers` if it is present.
       environment[envKeyMelosPackages] = packagesEnv;
     }
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -80,14 +80,12 @@ mixin _RunMixin on _Melos {
     bool noSelect = false,
     List<String> extraArgs = const [],
   }) async {
-    final workspace = await MelosWorkspace.fromConfig(
-      config,
+    final workspace = await createWorkspace(
       global: global,
       packageFilters: script.packageFilters?.copyWithUpdatedIgnore([
         ...script.packageFilters!.ignore,
         ...config.ignore,
       ]),
-      logger: logger,
     )
       ..validate();
 
@@ -148,8 +146,8 @@ mixin _RunMixin on _Melos {
           ? packages.map((e) => e.name).toList().join(',')
           : packages[selectedPackageIndex - 1].name;
       // MELOS_PACKAGES environment is detected by melos itself when through
-      // a defined script, this comma delimited list of package names is used
-      // instead of any filters if detected.
+      // a defined script, this comma delimited list of package names used to
+      // scope the packageFilers if it is present.
       environment[envKeyMelosPackages] = packagesEnv;
     }
 

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -97,9 +97,7 @@ abstract class _Melos {
 
       filterWithEnv = packageFilters == null
           ? PackageFilters(scope: filteredPackagesScopeFromEnv)
-          : packageFilters.copyWith(
-              scopeValueProvider: () => filteredPackagesScopeFromEnv,
-            );
+          : packageFilters.copyWith(scope: filteredPackagesScopeFromEnv);
     }
 
     return (await MelosWorkspace.fromConfig(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -84,7 +84,7 @@ abstract class _Melos {
 
     if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
       // MELOS_PACKAGES environment variable is a comma delimited list of
-      // package names - used to scope the packageFilers if it is present.
+      // package names - used to scope the `packageFilers` if it is present.
       // This can be user defined or can come from package selection in
       // `melos run`.
       final filteredPackagesScopeFromEnv =

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -84,17 +84,20 @@ abstract class _Melos {
 
     if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
       // MELOS_PACKAGES environment variable is a comma delimited list of
-      // package names - used instead of filters if it is present.
+      // package names - used to scope the packageFilers if it is present.
       // This can be user defined or can come from package selection in
       // `melos run`.
-      filterWithEnv = PackageFilters(
-        scope: currentPlatform.environment[envKeyMelosPackages]!
-            .split(',')
-            .map(
-              (e) => createGlob(e, currentDirectoryPath: config.path),
-            )
-            .toList(),
-      );
+      final filteredPackagesScopeFromEnv =
+          currentPlatform.environment[envKeyMelosPackages]!
+              .split(',')
+              .map(
+                (e) => createGlob(e, currentDirectoryPath: config.path),
+              )
+              .toList();
+
+      filterWithEnv = packageFilters == null
+          ? PackageFilters(scope: filteredPackagesScopeFromEnv)
+          : packageFilters.copyWithUpdatedScope(filteredPackagesScopeFromEnv);
     }
 
     return (await MelosWorkspace.fromConfig(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -97,7 +97,9 @@ abstract class _Melos {
 
       filterWithEnv = packageFilters == null
           ? PackageFilters(scope: filteredPackagesScopeFromEnv)
-          : packageFilters.copyWithUpdatedScope(filteredPackagesScopeFromEnv);
+          : packageFilters.copyWith(
+              scopeValueProvider: () => filteredPackagesScopeFromEnv,
+            );
     }
 
     return (await MelosWorkspace.fromConfig(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -84,7 +84,7 @@ abstract class _Melos {
 
     if (currentPlatform.environment.containsKey(envKeyMelosPackages)) {
       // MELOS_PACKAGES environment variable is a comma delimited list of
-      // package names - used to scope the `packageFilers` if it is present.
+      // package names - used to scope the `packageFilters` if it is present.
       // This can be user defined or can come from package selection in
       // `melos run`.
       final filteredPackagesScopeFromEnv =

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -77,7 +77,7 @@ extension Let<T> on T? {
 String multiLine(List<String> lines) => lines.join('\n');
 
 // MELOS_PACKAGES environment variable is a comma delimited list of
-// package names - used to scope the packageFilers if it is present.
+// package names - used to scope the `packageFilers` if it is present.
 // This can be user defined or can come from package selection in `melos run`.
 const envKeyMelosPackages = 'MELOS_PACKAGES';
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -77,7 +77,7 @@ extension Let<T> on T? {
 String multiLine(List<String> lines) => lines.join('\n');
 
 // MELOS_PACKAGES environment variable is a comma delimited list of
-// package names - used to scope the `packageFilers` if it is present.
+// package names - used to scope the `packageFilters` if it is present.
 // This can be user defined or can come from package selection in `melos run`.
 const envKeyMelosPackages = 'MELOS_PACKAGES';
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -77,7 +77,7 @@ extension Let<T> on T? {
 String multiLine(List<String> lines) => lines.join('\n');
 
 // MELOS_PACKAGES environment variable is a comma delimited list of
-// package names - used instead of filters if it is present.
+// package names - used to scope the packageFilers if it is present.
 // This can be user defined or can come from package selection in `melos run`.
 const envKeyMelosPackages = 'MELOS_PACKAGES';
 

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -367,46 +367,36 @@ class PackageFilters {
   }
 
   PackageFilters copyWith({
-    ValueProvider<List<String>>? dependsOnValueProvider,
-    ValueProvider<List<String>>? dirExistsValueProvider,
-    ValueProvider<List<String>>? fileExistsValueProvider,
-    ValueProvider<List<Glob>>? ignoreValueProvider,
+    List<String>? dependsOn,
+    List<String>? dirExists,
+    List<String>? fileExists,
+    List<Glob>? ignore,
     ValueProvider<bool?>? includePrivatePackagesValueProvider,
-    ValueProvider<List<String>>? noDependsOnValueProvider,
+    List<String>? noDependsOn,
     ValueProvider<bool?>? nullSafeValueProvider,
     ValueProvider<bool?>? publishedValueProvider,
-    ValueProvider<List<Glob>>? scopeValueProvider,
+    List<Glob>? scope,
     ValueProvider<String?>? diffValueProvider,
-    ValueProvider<bool>? includeDependenciesValueProvider,
-    ValueProvider<bool>? includeDependentsValueProvider,
+    bool? includeDependencies,
+    bool? includeDependents,
   }) {
     return PackageFilters._(
-      dependsOn:
-          dependsOnValueProvider == null ? dependsOn : dependsOnValueProvider(),
-      dirExists:
-          dirExistsValueProvider == null ? dirExists : dirExistsValueProvider(),
-      fileExists: fileExistsValueProvider == null
-          ? fileExists
-          : fileExistsValueProvider(),
-      ignore: ignoreValueProvider == null ? ignore : ignoreValueProvider(),
+      dependsOn: dependsOn ?? this.dependsOn,
+      dirExists: dirExists ?? this.dirExists,
+      fileExists: fileExists ?? this.fileExists,
+      ignore: ignore ?? this.ignore,
       includePrivatePackages: includePrivatePackagesValueProvider == null
           ? includePrivatePackages
           : includePrivatePackagesValueProvider(),
-      noDependsOn: noDependsOnValueProvider == null
-          ? noDependsOn
-          : noDependsOnValueProvider(),
+      noDependsOn: noDependsOn ?? this.noDependsOn,
       nullSafe:
           nullSafeValueProvider == null ? nullSafe : nullSafeValueProvider(),
       published:
           publishedValueProvider == null ? published : publishedValueProvider(),
-      scope: scopeValueProvider == null ? scope : scopeValueProvider(),
+      scope: scope ?? this.scope,
       diff: diffValueProvider == null ? diff : diffValueProvider(),
-      includeDependencies: includeDependenciesValueProvider == null
-          ? includeDependencies
-          : includeDependenciesValueProvider(),
-      includeDependents: includeDependentsValueProvider == null
-          ? includeDependents
-          : includeDependentsValueProvider(),
+      includeDependencies: includeDependencies ?? this.includeDependencies,
+      includeDependents: includeDependents ?? this.includeDependents,
     );
   }
 

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -366,20 +366,47 @@ class PackageFilters {
     );
   }
 
-  PackageFilters copyWithUpdatedScope(List<Glob> scope) {
+  PackageFilters copyWith({
+    ValueProvider<List<String>>? dependsOnValueProvider,
+    ValueProvider<List<String>>? dirExistsValueProvider,
+    ValueProvider<List<String>>? fileExistsValueProvider,
+    ValueProvider<List<Glob>>? ignoreValueProvider,
+    ValueProvider<bool?>? includePrivatePackagesValueProvider,
+    ValueProvider<List<String>>? noDependsOnValueProvider,
+    ValueProvider<bool?>? nullSafeValueProvider,
+    ValueProvider<bool?>? publishedValueProvider,
+    ValueProvider<List<Glob>>? scopeValueProvider,
+    ValueProvider<String?>? diffValueProvider,
+    ValueProvider<bool>? includeDependenciesValueProvider,
+    ValueProvider<bool>? includeDependentsValueProvider,
+  }) {
     return PackageFilters._(
-      dependsOn: dependsOn,
-      dirExists: dirExists,
-      fileExists: fileExists,
-      ignore: ignore,
-      includePrivatePackages: includePrivatePackages,
-      noDependsOn: noDependsOn,
-      nullSafe: nullSafe,
-      published: published,
-      scope: scope,
-      diff: diff,
-      includeDependencies: includeDependencies,
-      includeDependents: includeDependents,
+      dependsOn:
+          dependsOnValueProvider == null ? dependsOn : dependsOnValueProvider(),
+      dirExists:
+          dirExistsValueProvider == null ? dirExists : dirExistsValueProvider(),
+      fileExists: fileExistsValueProvider == null
+          ? fileExists
+          : fileExistsValueProvider(),
+      ignore: ignoreValueProvider == null ? ignore : ignoreValueProvider(),
+      includePrivatePackages: includePrivatePackagesValueProvider == null
+          ? includePrivatePackages
+          : includePrivatePackagesValueProvider(),
+      noDependsOn: noDependsOnValueProvider == null
+          ? noDependsOn
+          : noDependsOnValueProvider(),
+      nullSafe:
+          nullSafeValueProvider == null ? nullSafe : nullSafeValueProvider(),
+      published:
+          publishedValueProvider == null ? published : publishedValueProvider(),
+      scope: scopeValueProvider == null ? scope : scopeValueProvider(),
+      diff: diffValueProvider == null ? diff : diffValueProvider(),
+      includeDependencies: includeDependenciesValueProvider == null
+          ? includeDependencies
+          : includeDependenciesValueProvider(),
+      includeDependents: includeDependentsValueProvider == null
+          ? includeDependents
+          : includeDependentsValueProvider(),
     );
   }
 
@@ -435,6 +462,8 @@ PackageFilters(
 )''';
   }
 }
+
+typedef ValueProvider<T> = T Function();
 
 class InvalidPackageFiltersException extends MelosException {
   InvalidPackageFiltersException(this.message);

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -366,6 +366,23 @@ class PackageFilters {
     );
   }
 
+  PackageFilters copyWithUpdatedScope(List<Glob> scope) {
+    return PackageFilters._(
+      dependsOn: dependsOn,
+      dirExists: dirExists,
+      fileExists: fileExists,
+      ignore: ignore,
+      includePrivatePackages: includePrivatePackages,
+      noDependsOn: noDependsOn,
+      nullSafe: nullSafe,
+      published: published,
+      scope: scope,
+      diff: diff,
+      includeDependencies: includeDependencies,
+      includeDependents: includeDependents,
+    );
+  }
+
   @override
   bool operator ==(Object other) =>
       other is PackageFilters &&

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -371,12 +371,12 @@ class PackageFilters {
     List<String>? dirExists,
     List<String>? fileExists,
     List<Glob>? ignore,
-    ValueProvider<bool?>? includePrivatePackagesValueProvider,
+    bool? includePrivatePackages,
     List<String>? noDependsOn,
-    ValueProvider<bool?>? nullSafeValueProvider,
-    ValueProvider<bool?>? publishedValueProvider,
+    bool? nullSafe,
+    bool? published,
     List<Glob>? scope,
-    ValueProvider<String?>? diffValueProvider,
+    String? diff,
     bool? includeDependencies,
     bool? includeDependents,
   }) {
@@ -385,16 +385,13 @@ class PackageFilters {
       dirExists: dirExists ?? this.dirExists,
       fileExists: fileExists ?? this.fileExists,
       ignore: ignore ?? this.ignore,
-      includePrivatePackages: includePrivatePackagesValueProvider == null
-          ? includePrivatePackages
-          : includePrivatePackagesValueProvider(),
+      includePrivatePackages:
+          includePrivatePackages ?? this.includePrivatePackages,
       noDependsOn: noDependsOn ?? this.noDependsOn,
-      nullSafe:
-          nullSafeValueProvider == null ? nullSafe : nullSafeValueProvider(),
-      published:
-          publishedValueProvider == null ? published : publishedValueProvider(),
+      nullSafe: nullSafe ?? this.nullSafe,
+      published: published ?? this.published,
       scope: scope ?? this.scope,
-      diff: diffValueProvider == null ? diff : diffValueProvider(),
+      diff: diff ?? this.diff,
       includeDependencies: includeDependencies ?? this.includeDependencies,
       includeDependents: includeDependents ?? this.includeDependents,
     );
@@ -452,8 +449,6 @@ PackageFilters(
 )''';
   }
 }
-
-typedef ValueProvider<T> = T Function();
 
 class InvalidPackageFiltersException extends MelosException {
   InvalidPackageFiltersException(this.message);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

There are **2 key changes here**:
- `melos run` command now also takes `MELOS_PACKAGES` value into account.
- `MELOS_PACKAGES` is not used instead of filters, but it adds or replaces the `scope` in the `PackageFilters`.

Considering [the current definition](https://melos.invertase.dev/environment-variables#melos_packages) of  `MELOS_PACKAGES` that says 'This bypasses all filtering flags if defined.' the current change looks like a breaking change to me.

**A bit more context**:
We have quite a big monorepo (100+ packages) on my current project. In our CI pipeline, we trigger the CI checks for certain subfolders/packages (based on which areas are affected by a PR). 
We already have this kind of setup running with Melos 2.9, but it was achieved by different means, and we'd love to migrate to the latest version of Melos.
With Melos 4.0 it looks like the proposed change to `MELOS_PACKAGES` is the easiest way to achieve the granularity desired in our case.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
