### PR TITLE
docs: remove `amplify-flutter` from projects using Melos

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -38,7 +38,6 @@ The following projects are using Melos:
 
 - [firebase/flutterfire](https://github.com/firebase/flutterfire)
 - [Flame-Engine/Flame](https://github.com/flame-engine/flame)
-- [aws-amplify/amplify-flutter](https://github.com/aws-amplify/amplify-flutter)
 - [fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)
 - [GetStream/stream-chat-flutter](https://github.com/GetStream/stream-chat-flutter)
 - [4itworks/opensource_qwkin_dart](https://github.com/4itworks/opensource_qwkin_dart)

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -120,7 +120,6 @@ The following projects are using Melos:
 
 - [firebase/flutterfire](https://github.com/firebase/flutterfire)
 - [Flame-Engine/Flame](https://github.com/flame-engine/flame)
-- [aws-amplify/amplify-flutter](https://github.com/aws-amplify/amplify-flutter)
 - [fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)
 - [GetStream/stream-chat-flutter](https://github.com/GetStream/stream-chat-flutter)
 - [4itworks/opensource_qwkin_dart](https://github.com/4itworks/opensource_qwkin_dart)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I was going through the list of projects using Melos in the docs and noticed that [amplify-flutter](https://github.com/aws-amplify/amplify-flutter) doesn't use Melos anymore. It migrated away from using it in [this PR](https://github.com/aws-amplify/amplify-flutter/pull/3065/files). So, let's reflect that in the documentation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
