### PR TITLE
chore: update all_lint_rules list

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -22,8 +22,8 @@ linter:
     - always_specify_types
     - always_use_package_imports
     - annotate_overrides
+    - annotate_redeclares
     - avoid_annotating_with_dynamic
-    # - avoid_as
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -78,6 +78,7 @@ linter:
     - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
+    - deprecated_member_use_from_same_package
     - diagnostic_describe_all_properties
     - directives_ordering
     - discarded_futures
@@ -85,7 +86,6 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - enable_null_safety
     - eol_at_end_of_file
     - exhaustive_cases
     - file_names
@@ -93,8 +93,8 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
-    - invariant_booleans
-    - iterable_contains_unrelated_type
+    - implicit_reopen
+    - invalid_case_patterns
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -102,16 +102,19 @@ linter:
     - library_prefixes
     - library_private_types_in_public_api
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
+    - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString
+    - no_self_assignments
+    - no_wildcard_variable_uses
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
@@ -127,7 +130,6 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_asserts_with_message
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -137,7 +139,6 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
-    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each
@@ -177,12 +178,12 @@ linter:
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - type_init_formals
+    - type_literal_in_constant_pattern
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps

--- a/packages/melos/lib/src/common/pub_dependency_list.dart
+++ b/packages/melos/lib/src/common/pub_dependency_list.dart
@@ -22,7 +22,7 @@ import 'package:string_scanner/string_scanner.dart';
 
 class PubDependencyList extends VersionedEntry {
   PubDependencyList._(
-    super.entry,
+    super.other,
     this.sdks,
     this.sections,
   ) : super.copy();

--- a/packages/melos/lib/src/workspace_configs.dart
+++ b/packages/melos/lib/src/workspace_configs.dart
@@ -1258,7 +1258,7 @@ class MelosWorkspaceConfig {
     }
 
     final linkToCommits = commands.version.linkToCommits;
-    if (linkToCommits == true && repository == null) {
+    if (linkToCommits && repository == null) {
       throw MelosConfigException(
         'repository must be specified if commands/version/linkToCommits is true',
       );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Updated `all_lint_rules.yaml` file with the actual rules that are listed at `https://dart.dev/tools/linter-rules/all`. 
I don't expect any issues even though this auto-generated list of rules is based on Dart 3.3.0 and the current SDK constraint on the package level is `>=3.0.0 <4.0.0`. 
The fact that the removed from rules do not exist anymore can be checked on https://dart.dev/tools/linter-rules page, for example https://dart.dev/tools/linter-rules/avoid_as.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
