### PR TITLE
feat: Default to number of processors for exec concurrency

### DIFF
--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -23,7 +23,11 @@ import 'base.dart';
 class ExecCommand extends MelosCommand {
   ExecCommand(super.config) {
     setupPackageFilterParser();
-    argParser.addOption('concurrency', defaultsTo: Platform.numberOfProcessors.toString(), abbr: 'c');
+    argParser.addOption(
+      'concurrency',
+      defaultsTo: Platform.numberOfProcessors.toString(),
+      abbr: 'c',
+    );
     argParser.addFlag(
       'fail-fast',
       abbr: 'f',

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -23,7 +23,7 @@ import 'base.dart';
 class ExecCommand extends MelosCommand {
   ExecCommand(super.config) {
     setupPackageFilterParser();
-    argParser.addOption('concurrency', defaultsTo: '5', abbr: 'c');
+    argParser.addOption('concurrency', defaultsTo: Platform.numberOfProcessors.toString(), abbr: 'c');
     argParser.addFlag(
       'fail-fast',
       abbr: 'f',

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -5,10 +5,11 @@ mixin _ExecMixin on _Melos {
     List<String> execArgs, {
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    int concurrency = 5,
+    int? concurrency,
     bool failFast = false,
     bool orderDependents = false,
   }) async {
+    concurrency ??= Platform.numberOfProcessors;
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
     final packages = workspace.filteredPackages.values;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR removes the hardcoded (5) value of concurrency for exec and replaces it with a dynamic value based on the number of processors in the computer.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
