### PR TITLE
feat: built-in melos command for analyzing projects

### DIFF
--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -1,0 +1,49 @@
+---
+title: Analyze Command
+description: Learn more about the `analyze` command in Melos.
+---
+
+# Analyze Command
+
+<Info>Supports all [Melos filtering](/filters) flags.</Info>
+
+This command analyzes all local packages in your workspace.
+
+```bash
+melos analyze
+```
+
+<Info>
+  To learn more, visit the [Dart Analyze](https://dart.dev/tools/dart-analyze) documentation.
+</Info>
+
+
+## --fatal-infos
+Enforces a strict analysis by treating info-level issues as critical errors.
+
+```bash
+melos analyze --fatal-infos
+```
+
+## --fatal-warnings
+Enables treating warnings as fatal errors. When enabled, any warning will cause the analyzer to fail.
+
+```bash
+melos analyze --fatal-warnings
+```
+
+## --no-fatal-warnings
+This option configures the melos analyze command to ignore warnings, allowing the analysis process to complete successfully even if warnings are present.
+
+```bash
+melos analyze --no-fatal-warnings
+```
+
+## concurrency (-c)
+
+Defines the max concurrency value of how many packages will execute the command in at any one time. Defaults to `1`.
+
+```bash
+# Set a 5 concurrency
+melos analyze -c 5
+```

--- a/melos.yaml
+++ b/melos.yaml
@@ -63,10 +63,6 @@ scripts:
     description: Check formatting of Dart code.
     run: dart format --output none --set-exit-if-changed .
 
-  analyze:
-    description: Analyze Dart code.
-    run: dart analyze . --fatal-infos
-
   test:
     description: Run tests in a specific package.
     run: dart test

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -180,16 +180,25 @@ Usage: melos <command> [arguments]
 Global options:
 -h, --help        Print this usage information.
     --verbose     Enable verbose logging.
-    --sdk-path    Path to the Dart/Flutter SDK that should be used. This command line option has precedence over the `sdkPath` option in the `melos.yaml` configuration file and the `MELOS_SDK_PATH` environment variable. To use the system-wide SDK, provide the special value "auto".
+    --sdk-path    Path to the Dart/Flutter SDK that should be used. This command line option has
+                  precedence over the `sdkPath` option in the `melos.yaml` configuration file and the
+                  `MELOS_SDK_PATH` environment variable. To use the system-wide SDK, provide the
+                  special value "auto".
 
 Available commands:
-  bootstrap   Initialize the workspace, link local packages together and install remaining package dependencies. Supports all package filtering options.
-  clean       Clean this workspace and all packages. This deletes the temporary pub & ide files such as ".packages" & ".flutter-plugins". Supports all package filtering options.
+  analyze     Analyzes all packages in your project for potential issues in a single run. Optionally
+              configure severity levels. Supports all package filtering options.
+  bootstrap   Initialize the workspace, link local packages together and install remaining package
+              dependencies. Supports all package filtering options.
+  clean       Clean this workspace and all packages. This deletes the temporary pub & ide files such
+              as ".packages" & ".flutter-plugins". Supports all package filtering options.
   exec        Execute an arbitrary command in each package. Supports all package filtering options.
   list        List local packages in various output formats. Supports all package filtering options.
-  publish     Publish any unpublished packages or package versions in your repository to pub.dev. Dry run is on by default.
+  publish     Publish any unpublished packages or package versions in your repository to pub.dev. Dry
+              run is on by default.
   run         Run a script by name defined in the workspace melos.yaml config file.
-  version     Automatically version and generate changelogs based on the Conventional Commits specification. Supports all package filtering options.
+  version     Automatically version and generate changelogs based on the Conventional Commits
+              specification. Supports all package filtering options.
 
 Run "melos help <command>" for more information about a command.
 ```

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -25,6 +25,7 @@ import 'package:cli_util/cli_logging.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 import '../version.g.dart';
+import 'command_runner/analyze.dart';
 import 'command_runner/bootstrap.dart';
 import 'command_runner/clean.dart';
 import 'command_runner/exec.dart';
@@ -34,8 +35,8 @@ import 'command_runner/run.dart';
 import 'command_runner/script.dart';
 import 'command_runner/version.dart';
 import 'common/exception.dart';
-import 'common/utils.dart';
 import 'common/utils.dart' as utils;
+import 'common/utils.dart';
 import 'logging.dart';
 import 'workspace_configs.dart';
 
@@ -77,6 +78,7 @@ class MelosCommandRunner extends CommandRunner<void> {
     addCommand(ListCommand(config));
     addCommand(PublishCommand(config));
     addCommand(VersionCommand(config));
+    addCommand(AnalyzeCommand(config));
 
     // Keep this last to exclude all built-in commands listed above
     final script = ScriptCommand.fromConfig(config, exclude: commands.keys);

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -28,8 +28,8 @@ class AnalyzeCommand extends MelosCommand {
     argParser.addFlag(
       'fatal-infos',
       negatable: false,
-      help: 'Enables treating info-lever issues as fatal errors,'
-          ' stopping the process if any are encountered.',
+      help: 'Enables treating info-lever issues as fatal errors, '
+          'stopping the process if any are encountered.',
     );
 
     argParser.addFlag(

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -15,8 +15,6 @@
  *
  */
 
-import 'dart:io';
-
 import '../commands/runner.dart';
 import '../common/utils.dart';
 import 'base.dart';
@@ -50,15 +48,6 @@ class AnalyzeCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    if (argResults!.rest.isNotEmpty) {
-      logger.log('No additional command line arguments are needed');
-      logger.log(description);
-      logger.log(argParser.usage);
-
-      exitCode = 1;
-      return;
-    }
-
     final fatalInfos = argResults?['fatal-infos'] as bool;
     final fatalWarnings = argResults!.optional('fatal-warnings') as bool?;
     final concurrency = int.parse(argResults!['concurrency'] as String);

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import 'dart:io';
+
+import '../commands/runner.dart';
+import '../common/utils.dart';
+import 'base.dart';
+
+class AnalyzeCommand extends MelosCommand {
+  AnalyzeCommand(super.config) {
+    setupPackageFilterParser();
+    argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
+    argParser.addFlag(
+      'fatal-infos',
+      negatable: false,
+      help: 'Enables treating info-lever issues as fatal errors,'
+          ' stopping the process if any are encountered.',
+    );
+
+    argParser.addFlag(
+      'fatal-warnings',
+      help: 'Enables or disables treating warnings as fatal errors. '
+          'When enabled, any warning will cause the command to fail.',
+    );
+  }
+
+  @override
+  final String name = 'analyze';
+
+  @override
+  final String description =
+      '''Analyzes all packages in your project for potential issues in a single run. Optionally configure severity levels. Supports all package filtering options.''';
+
+  @override
+  Future<void> run() async {
+    if (argResults!.rest.isNotEmpty) {
+      logger.log('No additional command line arguments are needed');
+      logger.log(description);
+      logger.log(argParser.usage);
+
+      exitCode = 1;
+      return;
+    }
+
+    final fatalInfos = argResults?['fatal-infos'] as bool;
+    final fatalWarnings = argResults!.optional('fatal-warnings') as bool?;
+    final concurrency = int.parse(argResults!['concurrency'] as String);
+
+    final melos = Melos(logger: logger, config: config);
+
+    return melos.analyze(
+      global: global,
+      packageFilters: parsePackageFilters(config.path),
+      concurrency: concurrency,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+    );
+  }
+}

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -44,7 +44,9 @@ class AnalyzeCommand extends MelosCommand {
 
   @override
   final String description =
-      '''Analyzes all packages in your project for potential issues in a single run. Optionally configure severity levels. Supports all package filtering options.''';
+      'Analyzes all packages in your project for potential issues '
+      'in a single run. Optionally configure severity levels. '
+      'Supports all package filtering options.';
 
   @override
   Future<void> run() async {

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -1,0 +1,165 @@
+part of 'runner.dart';
+
+mixin _AnalyzeMixin on _Melos {
+  Future<void> analyze({
+    GlobalOptions? global,
+    PackageFilters? packageFilters,
+    bool fatalInfos = false,
+    bool? fatalWarnings,
+    int concurrency = 1,
+  }) async {
+    final workspace =
+        await createWorkspace(global: global, packageFilters: packageFilters);
+    final packages = workspace.filteredPackages.values;
+
+    await _analyzeForAllPackages(
+      workspace,
+      packages,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+      concurrency: concurrency,
+    );
+  }
+
+  Future<void> _analyzeForAllPackages(
+    MelosWorkspace workspace,
+    Iterable<Package> packages, {
+    required bool fatalInfos,
+    bool? fatalWarnings,
+    required int concurrency,
+  }) async {
+    final failures = <String, int?>{};
+    final pool = Pool(concurrency);
+    final analyzeArgs = _getAnalyzeArgs(
+      workspace,
+      fatalInfos,
+      fatalWarnings,
+    );
+    final analyzeArgsString = analyzeArgs.join(' ');
+    final prefixLogs = concurrency != 1 && packages.length != 1;
+
+    logger.command('melos analyze', withDollarSign: true);
+
+    logger
+        .child(targetStyle(analyzeArgsString))
+        .child('$runningLabel (in ${packages.length} packages)')
+        .newLine();
+    if (prefixLogs) {
+      logger.horizontalLine();
+    }
+
+    final packageResults = Map.fromEntries(
+      packages.map((package) => MapEntry(package.name, Completer<int?>())),
+    );
+
+    await pool.forEach<Package, void>(packages, (package) async {
+      if (!prefixLogs) {
+        logger
+          ..horizontalLine()
+          ..log(AnsiStyles.bgBlack.bold.italic('${package.name}:'));
+      }
+
+      final packageExitCode = await _analyzeForPackage(
+        workspace,
+        package,
+        analyzeArgs,
+      );
+
+      packageResults[package.name]?.complete(packageExitCode);
+
+      if (packageExitCode > 0) {
+        failures[package.name] = packageExitCode;
+      } else if (!prefixLogs) {
+        logger.log(
+          AnsiStyles.bgBlack.bold.italic('${package.name}: ') +
+              AnsiStyles.bgBlack(successLabel),
+        );
+      }
+    }).drain<void>();
+
+    logger
+      ..horizontalLine()
+      ..newLine()
+      ..command('melos analyze', withDollarSign: true);
+
+    final resultLogger = logger.child(targetStyle(analyzeArgsString));
+
+    if (failures.isNotEmpty) {
+      final failuresLogger =
+          resultLogger.child('$failedLabel (in ${failures.length} packages)');
+      for (final packageName in failures.keys) {
+        failuresLogger.child(
+          '${errorPackageNameStyle(packageName)} '
+          '${failures[packageName] == null ? '(dependency failed)' : '('
+              'with exit code ${failures[packageName]})'}',
+        );
+      }
+      exitCode = 1;
+    } else {
+      resultLogger.child(successLabel);
+    }
+  }
+
+  List<String> _getAnalyzeArgs(
+    MelosWorkspace workspace,
+    bool fatalInfos,
+    bool? fatalWarnings,
+  ) {
+    final options = _getOptionsArgs(fatalInfos, fatalWarnings);
+    return <String>[
+      ..._analyzeCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
+      ),
+      options,
+    ];
+  }
+
+  String _getOptionsArgs(bool fatalInfos, bool? fatalWarnings) {
+    var options = '';
+
+    if (fatalInfos) {
+      options = '--fatal-infos';
+    }
+
+    if (fatalWarnings != null) {
+      options = fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings';
+    }
+
+    return options;
+  }
+
+  Future<int> _analyzeForPackage(
+    MelosWorkspace workspace,
+    Package package,
+    List<String> analyzeArgs,
+  ) async {
+    final environment = {
+      EnvironmentVariableKey.melosRootPath: config.path,
+      if (workspace.sdkPath != null)
+        EnvironmentVariableKey.melosSdkPath: workspace.sdkPath!,
+      if (workspace.childProcessPath != null)
+        EnvironmentVariableKey.path: workspace.childProcessPath!,
+    };
+
+    return startCommand(
+      analyzeArgs,
+      logger: logger,
+      environment: environment,
+      workingDirectory: package.path,
+    );
+  }
+
+  List<String> _analyzeCommandExecArgs({
+    required bool useFlutter,
+    required MelosWorkspace workspace,
+  }) {
+    return [
+      if (useFlutter)
+        workspace.sdkTool('flutter')
+      else
+        workspace.sdkTool('dart'),
+      'analyze',
+    ];
+  }
+}

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -116,17 +116,17 @@ mixin _AnalyzeMixin on _Melos {
   }
 
   String _getOptionsArgs(bool fatalInfos, bool? fatalWarnings) {
-    var options = '';
+    final options = <String>[];
 
     if (fatalInfos) {
-      options = '--fatal-infos';
+      options.add('--fatal-infos');
     }
 
     if (fatalWarnings != null) {
-      options = fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings';
+      options.add(fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings');
     }
 
-    return options;
+    return options.join(' ');
   }
 
   Future<int> _analyzeForPackage(

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -48,6 +48,7 @@ part 'list.dart';
 part 'publish.dart';
 part 'run.dart';
 part 'version.dart';
+part 'analyze.dart';
 
 enum _CommandWithLifecycle {
   bootstrap,
@@ -63,7 +64,8 @@ class Melos extends _Melos
         _RunMixin,
         _ExecMixin,
         _VersionMixin,
-        _PublishMixin {
+        _PublishMixin,
+        _AnalyzeMixin {
   Melos({
     required this.config,
     Logger? logger,

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -209,5 +209,61 @@ $ melos analyze
 '''),
       );
     });
+
+    test('should run analysis with --fatal-infos and --fatal-warnings',
+        () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalInfos: true, fatalWarnings: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(r'''
+$ melos analyze
+  └> dart analyze --fatal-infos --fatal-warnings
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos analyze
+  └> dart analyze --fatal-infos --fatal-warnings
+     └> FAILED (in 1 packages)
+        └> a (with exit code 2)
+'''),
+      );
+    });
   });
 }

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec/pubspec.dart';
+import 'package:test/test.dart';
+
+import '../matchers.dart';
+import '../utils.dart';
+
+void main() {
+  group('Melos Analyze', () {
+    late Melos melos;
+    late TestLogger logger;
+    late Directory workspaceDir;
+    late Directory aDir;
+
+    setUp(() async {
+      workspaceDir = await createTemporaryWorkspace();
+
+      aDir = await createProject(
+        workspaceDir,
+        PubSpec(
+          name: 'a',
+          dependencies: {'c': HostedReference(VersionConstraint.any)},
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'b'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(
+          name: 'c',
+        ),
+      );
+
+      logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      melos = Melos(
+        logger: logger,
+        config: config,
+      );
+    });
+
+    test('should run analysis with --fatal-infos flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+          for (var i = 0; i < 10; i++) {
+            print('hello ${i + 1}');
+          }
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalInfos: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          r'''
+$ melos analyze
+  └> dart analyze --fatal-infos
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+   info - main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+2 issues found.
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos analyze
+  └> dart analyze --fatal-infos
+     └> FAILED (in 1 packages)
+        └> a (with exit code 1)
+''',
+        ),
+      );
+    });
+
+    test('should run analysis with --fatal-warnings flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalWarnings: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(r'''
+$ melos analyze
+  └> dart analyze --fatal-warnings
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos analyze
+  └> dart analyze --fatal-warnings
+     └> FAILED (in 1 packages)
+        └> a (with exit code 2)
+'''),
+      );
+    });
+
+    test('should run analysis with --no-fatal-warnings flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalWarnings: false);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(r'''
+$ melos analyze
+  └> dart analyze --no-fatal-warnings
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+a: SUCCESS
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos analyze
+  └> dart analyze --no-fatal-warnings
+     └> SUCCESS
+'''),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

First things first, I'm really excited to work on this issue because this year I made a personal goal to contribute more to open source projects. It makes me happy to be able to do it for a tool that I use every day. 

Usually, melos projects use a script to run either `dart analyze` or `flutter analyze`, as mentioned by @jpnurmi  in issue #424. However, I agree that it would be better to have a built-in command for this. Some newbies to the tool might try running this command and then realize they need extra setup to get the same results.

So, this pull request aims to address this problem by adding the needed functionality. It also includes features like running tasks concurrently, filtering, and support for `--fatal-infos` and `--[no-]fatal-warnings` options.

I also took the time to update the readme file and provide the latest help section, as well as update the `melos.yaml` file and remove the old way to run the analyzer.

Dear maintainers, please feel free to review, modify, or add code to this contribution :)

## Type of Change
- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore

Closes #424
