### PR TITLE
feat: Add lifecycle hooks for `publish`

### DIFF
--- a/docs/commands/publish.mdx
+++ b/docs/commands/publish.mdx
@@ -49,3 +49,29 @@ Note that tags are automatically created as part of `melos version` (unless
 `--no-git-tag-version` is specified when running the version command) so this is
 usually not required on `melos publish` unless you're doing a manual version and
 publish of packages.
+
+## Hooks
+
+Melos supports various command [lifecycle hooks](/configuration/scripts#hooks)
+that can be defined in your `melos.yaml`.
+
+For example, if you needed to run something such as a build runner automatically
+before `melos publish` is run and then remove the generated files after
+publishing is done, you can add a `pre` hook and a `post` hook script:
+
+```yaml
+# melos.yaml
+# ...
+command:
+  publish:
+    hooks:
+      pre: dart pub run build_runner build
+      post: dart pub run build_runner clean
+# ...
+```
+
+The pre-hook will run before `melos publish` and the post-hook will run after
+`melos publish` is done. It only runs once, even if multiple packages are
+published and it also runs when you are doing a `dry-run` publish.
+You can detect whether it is a dry-run by checking the `MELOS_PUBLISH_DRY_RUN`
+environment variable.

--- a/docs/commands/publish.mdx
+++ b/docs/commands/publish.mdx
@@ -55,9 +55,10 @@ publish of packages.
 Melos supports various command [lifecycle hooks](/configuration/scripts#hooks)
 that can be defined in your `melos.yaml`.
 
-For example, if you needed to run something such as a build runner automatically
+For example, if you need to run something such as a build runner automatically
 before `melos publish` is run and then remove the generated files after
-publishing is done, you can add a `pre` hook and a `post` hook script:
+publishing is done, you can add `pre` and `post` hook scripts to your
+`melos.yaml` file:
 
 ```yaml
 # melos.yaml

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -156,3 +156,4 @@ Currently, the following Melos commands support hooks:
 - [`bootstrap`](/commands/bootstrap)
 - [`clean`](/commands/clean)
 - [`version`](/commands/version)
+- [`publish`](/commands/publish)

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -48,6 +48,11 @@ executing a script (when using `melos exec`).
 The path of the parent package of the current package that's currently executing
 a script (when using `melos exec`).
 
+### `MELOS_PUBLISH_DRY_RUN`
+
+Whether the current publish is a dry run or not. This is `true` when running
+`melos publish --dry-run` and `false` otherwise.
+
 #### What is a 'parent package'
 
 If a package exists in a directory that is also a child of another package, then

--- a/packages/melos/lib/src/command_configs/command_configs.dart
+++ b/packages/melos/lib/src/command_configs/command_configs.dart
@@ -4,6 +4,7 @@ import '../common/utils.dart';
 import '../common/validation.dart';
 import 'bootstrap.dart';
 import 'clean.dart';
+import 'publish.dart';
 import 'version.dart';
 
 export 'bootstrap.dart';
@@ -17,6 +18,7 @@ class CommandConfigs {
     this.bootstrap = BootstrapCommandConfigs.empty,
     this.clean = CleanCommandConfigs.empty,
     this.version = VersionCommandConfigs.empty,
+    this.publish = PublishCommandConfigs.empty,
   });
 
   factory CommandConfigs.fromYaml(
@@ -42,6 +44,12 @@ class CommandConfigs {
       path: 'command',
     );
 
+    final publishMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'publish',
+      map: yaml,
+      path: 'command',
+    );
+
     return CommandConfigs(
       bootstrap: BootstrapCommandConfigs.fromYaml(
         bootstrapMap ?? const {},
@@ -56,6 +64,11 @@ class CommandConfigs {
         workspacePath: workspacePath,
         repositoryIsConfigured: repositoryIsConfigured,
       ),
+      publish: PublishCommandConfigs.fromYaml(
+        publishMap ?? const {},
+        workspacePath: workspacePath,
+        repositoryIsConfigured: repositoryIsConfigured,
+      ),
     );
   }
 
@@ -64,12 +77,14 @@ class CommandConfigs {
   final BootstrapCommandConfigs bootstrap;
   final CleanCommandConfigs clean;
   final VersionCommandConfigs version;
+  final PublishCommandConfigs publish;
 
   Map<String, Object?> toJson() {
     return {
       'bootstrap': bootstrap.toJson(),
       'clean': clean.toJson(),
       'version': version.toJson(),
+      'publish': publish.toJson(),
     };
   }
 
@@ -79,14 +94,17 @@ class CommandConfigs {
       runtimeType == other.runtimeType &&
       other.bootstrap == bootstrap &&
       other.clean == clean &&
-      other.version == version;
+      other.version == version &&
+      other.publish == publish;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      bootstrap.hashCode ^
-      clean.hashCode ^
-      version.hashCode;
+  int get hashCode => Object.hash(
+        runtimeType,
+        bootstrap,
+        clean,
+        version,
+        publish,
+      );
 
   @override
   String toString() {
@@ -95,6 +113,7 @@ CommandConfigs(
   bootstrap: ${bootstrap.toString().indent('  ')},
   clean: ${clean.toString().indent('  ')},
   version: ${version.toString().indent('  ')},
+  publish: ${publish.toString().indent('  ')},
 )
 ''';
   }

--- a/packages/melos/lib/src/command_configs/publish.dart
+++ b/packages/melos/lib/src/command_configs/publish.dart
@@ -1,0 +1,281 @@
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+import '../../melos.dart';
+import '../common/validation.dart';
+import '../lifecycle_hooks/publish.dart';
+import '../workspace_configs.dart';
+
+/// Configurations for `melos publish`.
+@immutable
+class PublishCommandConfigs {
+  const PublishCommandConfigs({
+    this.branch,
+    this.message,
+    this.includeScopes = true,
+    this.linkToCommits = false,
+    this.includeCommitId = false,
+    this.includeCommitBody = false,
+    this.commitBodyOnlyBreaking = true,
+    this.updateGitTagRefs = false,
+    this.releaseUrl = false,
+    List<AggregateChangelogConfig>? aggregateChangelogs,
+    this.fetchTags = true,
+    this.hooks = PublishLifecycleHooks.empty,
+  }) : _aggregateChangelogs = aggregateChangelogs;
+
+  factory PublishCommandConfigs.fromYaml(
+    Map<Object?, Object?> yaml, {
+    required String workspacePath,
+    bool repositoryIsConfigured = false,
+  }) {
+    final branch = assertKeyIsA<String?>(
+      key: 'branch',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final message = assertKeyIsA<String?>(
+      key: 'message',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final includeScopes = assertKeyIsA<bool?>(
+      key: 'includeScopes',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final includeCommitId = assertKeyIsA<bool?>(
+      key: 'includeCommitId',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final linkToCommits = assertKeyIsA<bool?>(
+      key: 'linkToCommits',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final updateGitTagRefs = assertKeyIsA<bool?>(
+      key: 'updateGitTagRefs',
+      map: yaml,
+      path: 'command/publish',
+    );
+    final releaseUrl = assertKeyIsA<bool?>(
+      key: 'releaseUrl',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final workspaceChangelog = assertKeyIsA<bool?>(
+      key: 'workspaceChangelog',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final aggregateChangelogs = <AggregateChangelogConfig>[];
+    if (workspaceChangelog ?? true) {
+      aggregateChangelogs.add(AggregateChangelogConfig.workspace());
+    }
+
+    final changelogsYaml = assertKeyIsA<List<Object?>?>(
+      key: 'changelogs',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    if (changelogsYaml != null) {
+      for (var i = 0; i < changelogsYaml.length; i++) {
+        final entry = changelogsYaml[i]! as Map<Object?, Object?>;
+
+        final path = assertKeyIsA<String>(
+          map: entry,
+          path: 'command/publish/changelogs[$i]',
+          key: 'path',
+        );
+
+        final packageFiltersMap = assertKeyIsA<Map<Object?, Object?>>(
+          map: entry,
+          key: 'packageFilters',
+          path: 'command/publish/changelogs[$i]',
+        );
+        final packageFilters = PackageFilters.fromYaml(
+          packageFiltersMap,
+          path: 'command/publish/changelogs[$i]',
+          workspacePath: workspacePath,
+        );
+
+        final description = assertKeyIsA<String?>(
+          map: entry,
+          path: 'command/publish/changelogs[$i]',
+          key: 'description',
+        );
+        final changelogConfig = AggregateChangelogConfig(
+          path: path,
+          packageFilters: packageFilters,
+          description: description,
+        );
+
+        aggregateChangelogs.add(changelogConfig);
+      }
+    }
+
+    final fetchTags = assertKeyIsA<bool?>(
+      key: 'fetchTags',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'hooks',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final hooks = hooksMap != null
+        ? PublishLifecycleHooks.fromYaml(
+            hooksMap,
+            workspacePath: workspacePath,
+          )
+        : PublishLifecycleHooks.empty;
+
+    final changelogCommitBodiesEntry = assertKeyIsA<Map<Object?, Object?>?>(
+          key: 'changelogCommitBodies',
+          map: yaml,
+          path: 'command/publish',
+        ) ??
+        const {};
+
+    final includeCommitBodies = assertKeyIsA<bool?>(
+      key: 'include',
+      map: changelogCommitBodiesEntry,
+      path: 'command/publish/changelogCommitBodies',
+    );
+
+    final bodiesOnlyBreaking = assertKeyIsA<bool?>(
+      key: 'onlyBreaking',
+      map: changelogCommitBodiesEntry,
+      path: 'command/publish/changelogCommitBodies',
+    );
+
+    return PublishCommandConfigs(
+      branch: branch,
+      message: message,
+      includeScopes: includeScopes ?? true,
+      includeCommitId: includeCommitId ?? false,
+      includeCommitBody: includeCommitBodies ?? false,
+      commitBodyOnlyBreaking: bodiesOnlyBreaking ?? true,
+      linkToCommits: linkToCommits ?? repositoryIsConfigured,
+      updateGitTagRefs: updateGitTagRefs ?? false,
+      releaseUrl: releaseUrl ?? false,
+      aggregateChangelogs: aggregateChangelogs,
+      fetchTags: fetchTags ?? true,
+      hooks: hooks,
+    );
+  }
+
+  static const PublishCommandConfigs empty = PublishCommandConfigs();
+
+  /// If specified, prevents `melos publish` from being used inside branches
+  /// other than the one specified.
+  final String? branch;
+
+  /// A custom header for the generated CHANGELOG.md.
+  final String? message;
+
+  /// Whether to include conventional commit scopes in the generated
+  /// CHANGELOG.md.
+  final bool includeScopes;
+
+  /// Whether to add commits ids in the generated CHANGELOG.md.
+  final bool includeCommitId;
+
+  /// Wheter to include commit bodies in the generated CHANGELOG.md.
+  final bool includeCommitBody;
+
+  /// Whether to only include commit bodies for breaking changes.
+  final bool commitBodyOnlyBreaking;
+
+  /// Whether to add links to commits in the generated CHANGELOG.md.
+  final bool linkToCommits;
+
+  /// Whether to also update pubspec with git referenced packages.
+  final bool updateGitTagRefs;
+
+  /// Whether to generate and print a link to the prefilled release creation
+  /// page for each package after publishing.
+  final bool releaseUrl;
+
+  /// A list of changelogs configurations that will be used to generate
+  /// changelogs which describe the changes in multiple packages.
+  List<AggregateChangelogConfig> get aggregateChangelogs =>
+      _aggregateChangelogs ?? [AggregateChangelogConfig.workspace()];
+
+  final List<AggregateChangelogConfig>? _aggregateChangelogs;
+
+  /// Whether to fetch tags from the `origin` remote before publishing.
+  final bool fetchTags;
+
+  /// Lifecycle hooks for this command.
+  final PublishLifecycleHooks hooks;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (branch != null) 'branch': branch,
+      if (message != null) 'message': message,
+      'includeScopes': includeScopes,
+      'includeCommitId': includeCommitId,
+      'linkToCommits': linkToCommits,
+      'updateGitTagRefs': updateGitTagRefs,
+      'aggregateChangelogs':
+          aggregateChangelogs.map((config) => config.toJson()).toList(),
+      'fetchTags': fetchTags,
+      'hooks': hooks.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is PublishCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.branch == branch &&
+      other.message == message &&
+      other.includeScopes == includeScopes &&
+      other.includeCommitId == includeCommitId &&
+      other.linkToCommits == linkToCommits &&
+      other.updateGitTagRefs == updateGitTagRefs &&
+      other.releaseUrl == releaseUrl &&
+      const DeepCollectionEquality()
+          .equals(other.aggregateChangelogs, aggregateChangelogs) &&
+      other.fetchTags == fetchTags &&
+      other.hooks == hooks;
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      branch.hashCode ^
+      message.hashCode ^
+      includeScopes.hashCode ^
+      includeCommitId.hashCode ^
+      linkToCommits.hashCode ^
+      updateGitTagRefs.hashCode ^
+      releaseUrl.hashCode ^
+      const DeepCollectionEquality().hash(aggregateChangelogs) ^
+      fetchTags.hashCode ^
+      hooks.hashCode;
+
+  @override
+  String toString() {
+    return '''
+PublishCommandConfigs(
+  branch: $branch,
+  message: $message,
+  includeScopes: $includeScopes,
+  includeCommitId: $includeCommitId,
+  linkToCommits: $linkToCommits,
+  updateGitTagRefs: $updateGitTagRefs,
+  releaseUrl: $releaseUrl,
+  aggregateChangelogs: $aggregateChangelogs,
+  fetchTags: $fetchTags,
+  hooks: $hooks,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -16,26 +16,26 @@
  */
 
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class PublishCommand extends MelosCommand {
   PublishCommand(super.config) {
     setupPackageFilterParser();
     argParser.addFlag(
-      'dry-run',
+      publishOptionDryRun,
       abbr: 'n',
       defaultsTo: true,
       help: 'Validate but do not publish the package.',
     );
     argParser.addFlag(
-      'git-tag-version',
+      publishOptionGitTagVersion,
       abbr: 't',
-      negatable: false,
       help: 'Add any missing git tags for release. '
           'Note tags are only created if --no-dry-run is also set.',
     );
     argParser.addFlag(
-      'yes',
+      publishOptionYes,
       abbr: 'y',
       negatable: false,
       help: 'Skip the Y/n confirmation prompt when using --no-dry-run.',
@@ -52,9 +52,9 @@ class PublishCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final dryRun = argResults!['dry-run'] as bool;
-    final gitTagVersion = argResults!['git-tag-version'] as bool;
-    final yes = argResults!['yes'] as bool || false;
+    final dryRun = argResults![publishOptionDryRun] as bool;
+    final gitTagVersion = argResults![publishOptionGitTagVersion] as bool;
+    final yes = argResults![publishOptionYes] as bool || false;
 
     final melos = Melos(logger: logger, config: config);
     final packageFilters = parsePackageFilters(config.path);

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -12,7 +12,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
     return _runLifecycle(
       workspace,
-      _CommandWithLifecycle.bootstrap,
+      CommandWithLifecycle.bootstrap,
       () async {
         final bootstrapCommandConfig = workspace.config.commands.bootstrap;
         final shouldEnforceLockfile =

--- a/packages/melos/lib/src/commands/clean.dart
+++ b/packages/melos/lib/src/commands/clean.dart
@@ -10,7 +10,7 @@ mixin _CleanMixin on _Melos {
 
     return _runLifecycle(
       workspace,
-      _CommandWithLifecycle.clean,
+      CommandWithLifecycle.clean,
       () async {
         logger.log('Cleaning workspace...');
 

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -8,6 +8,7 @@ mixin _ExecMixin on _Melos {
     int? concurrency,
     bool failFast = false,
     bool orderDependents = false,
+    Map<String, String> extraEnvironment = const {},
   }) async {
     concurrency ??= Platform.numberOfProcessors;
     final workspace =
@@ -21,6 +22,7 @@ mixin _ExecMixin on _Melos {
       failFast: failFast,
       concurrency: concurrency,
       orderDependents: orderDependents,
+      additionalEnvironment: extraEnvironment,
     );
   }
 
@@ -30,11 +32,13 @@ mixin _ExecMixin on _Melos {
     Package package,
     List<String> execArgs, {
     bool prefixLogs = true,
+    Map<String, String> extraEnvironment = const {},
   }) async {
     final packagePrefix = '[${AnsiStyles.blue.bold(package.name)}]: ';
 
     final environment = {
       ...currentPlatform.environment,
+      ...extraEnvironment,
       EnvironmentVariableKey.melosPackageName: package.name,
       EnvironmentVariableKey.melosPackageVersion: package.version.toString(),
       EnvironmentVariableKey.melosPackagePath: package.path,
@@ -85,6 +89,7 @@ mixin _ExecMixin on _Melos {
     required int concurrency,
     required bool failFast,
     required bool orderDependents,
+    Map<String, String> additionalEnvironment = const {},
   }) async {
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
@@ -144,6 +149,7 @@ mixin _ExecMixin on _Melos {
         package,
         execArgs,
         prefixLogs: prefixLogs,
+        extraEnvironment: additionalEnvironment,
       );
 
       packageResults[package.name]?.complete(packageExitCode);

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -49,10 +49,11 @@ part 'publish.dart';
 part 'run.dart';
 part 'version.dart';
 
-enum _CommandWithLifecycle {
+enum CommandWithLifecycle {
   bootstrap,
   clean,
   version,
+  publish,
 }
 
 class Melos extends _Melos
@@ -115,8 +116,8 @@ abstract class _Melos {
 
   Future<void> _runLifecycle(
     MelosWorkspace workspace,
-    _CommandWithLifecycle command,
-    FutureOr<void> Function() cb,
+    CommandWithLifecycle command,
+    FutureOr<void> Function() callback,
   ) async {
     final hooks = workspace.config.commands.lifecycleHooksFor(command);
     final preScript = hooks.pre;
@@ -128,7 +129,7 @@ abstract class _Melos {
     }
 
     try {
-      await cb();
+      await callback();
     } finally {
       if (postScript != null) {
         logger.newLine();
@@ -139,7 +140,7 @@ abstract class _Melos {
 
   Future<void> _runLifecycleScript(
     Script script, {
-    required _CommandWithLifecycle command,
+    required CommandWithLifecycle command,
   }) async {
     logger
       ..command('melos ${command.name} [${script.name}]')
@@ -165,14 +166,16 @@ abstract class _Melos {
 }
 
 extension _ResolveLifecycleHooks on CommandConfigs {
-  LifecycleHooks lifecycleHooksFor(_CommandWithLifecycle command) {
+  LifecycleHooks lifecycleHooksFor(CommandWithLifecycle command) {
     switch (command) {
-      case _CommandWithLifecycle.bootstrap:
+      case CommandWithLifecycle.bootstrap:
         return bootstrap.hooks;
-      case _CommandWithLifecycle.clean:
+      case CommandWithLifecycle.clean:
         return clean.hooks;
-      case _CommandWithLifecycle.version:
+      case CommandWithLifecycle.version:
         return version.hooks;
+      case CommandWithLifecycle.publish:
+        return publish.hooks;
     }
   }
 }

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -49,7 +49,7 @@ mixin _VersionMixin on _RunMixin {
       packageFilters: packageFilters?.copyWithDiff(null),
     );
 
-    return _runLifecycle(workspace, _CommandWithLifecycle.version, () {
+    return _runLifecycle(workspace, CommandWithLifecycle.version, () {
       return _version(
         workspace: workspace,
         global: global,
@@ -352,7 +352,7 @@ mixin _VersionMixin on _RunMixin {
       logger.newLine();
       await _runLifecycleScript(
         preCommit,
-        command: _CommandWithLifecycle.version,
+        command: CommandWithLifecycle.version,
       );
       logger.newLine();
     }

--- a/packages/melos/lib/src/common/environment_variable_key.dart
+++ b/packages/melos/lib/src/common/environment_variable_key.dart
@@ -9,6 +9,7 @@ class EnvironmentVariableKey {
   static const String melosParentPackageVersion =
       'MELOS_PARENT_PACKAGE_VERSION';
   static const String melosParentPackagePath = 'MELOS_PARENT_PACKAGE_PATH';
+  static const String melosPublishDryRun = 'MELOS_PUBLISH_DRY_RUN';
   static const String melosScript = 'MELOS_SCRIPT';
   static const String melosTest = 'MELOS_TEST';
 
@@ -35,6 +36,7 @@ class EnvironmentVariableKey {
         melosParentPackageName,
         melosParentPackageVersion,
         melosParentPackagePath,
+        melosPublishDryRun,
         melosScript,
         melosTest,
         melosPackages,

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -57,6 +57,13 @@ const filterOptionNoDependsOn = 'no-depends-on';
 const filterOptionIncludeDependents = 'include-dependents';
 const filterOptionIncludeDependencies = 'include-dependencies';
 
+const publishOptionDryRun = 'dry-run';
+const publishOptionNoDryRun = 'no-dry-run';
+const publishOptionGitTagVersion = 'git-tag-version';
+const publishOptionNoGitTagVersion = 'no-git-tag-version';
+const publishOptionYes = 'yes';
+const publishOptionForce = 'force';
+
 extension Let<T> on T? {
   R? let<R>(R Function(T value) cb) {
     if (this == null) return null;

--- a/packages/melos/lib/src/lifecycle_hooks/publish.dart
+++ b/packages/melos/lib/src/lifecycle_hooks/publish.dart
@@ -1,0 +1,42 @@
+import 'package:meta/meta.dart';
+
+import '../../melos.dart';
+import 'lifecycle_hooks.dart';
+
+/// [LifecycleHooks] for the `publish` command.
+@immutable
+class PublishLifecycleHooks extends LifecycleHooks {
+  const PublishLifecycleHooks({super.pre, super.post});
+
+  factory PublishLifecycleHooks.fromYaml(
+    Map<Object?, Object?> yaml, {
+    required String workspacePath,
+  }) {
+    return PublishLifecycleHooks(
+      pre: Script.fromName('pre', yaml, workspacePath),
+      post: Script.fromName('post', yaml, workspacePath),
+    );
+  }
+
+  static const PublishLifecycleHooks empty = PublishLifecycleHooks();
+
+  @override
+  bool operator ==(Object other) =>
+      other is PublishLifecycleHooks &&
+      runtimeType == other.runtimeType &&
+      other.pre == pre &&
+      other.post == post;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pre, post);
+
+  @override
+  String toString() {
+    return '''
+PublishLifecycleHooks(
+  pre: $pre,
+  post: $post,
+)
+''';
+  }
+}

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -1,9 +1,15 @@
 import 'package:melos/melos.dart';
+import 'package:melos/src/command_configs/command_configs.dart';
+import 'package:melos/src/command_configs/publish.dart';
+import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/utils.dart';
+import 'package:melos/src/lifecycle_hooks/publish.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec/pubspec.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
+
+import '../utils.dart';
 
 void main() {
   group('publish', () {
@@ -47,6 +53,66 @@ void main() {
           () => sortPackagesForPublishing(packages),
           returnsNormally,
         );
+      });
+    });
+
+    group('lifecycle hooks', () {
+      test('are called in the correct order', () async {
+        final logger = TestLogger();
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              publish: PublishCommandConfigs(
+                hooks: PublishLifecycleHooks(
+                  pre: Script(name: 'pre', run: 'echo pre'),
+                  post: Script(name: 'post', run: 'echo post'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        for (final package in ['a', 'b']) {
+          await createProject(
+            workspaceDir,
+            PubSpec(name: package),
+            path: 'packages',
+          );
+        }
+
+        final config =
+            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+        final melos = Melos(
+          logger: logger,
+          config: config,
+        );
+
+        await melos.publish();
+        final order = [
+          'melos publish [pre]',
+          'pre',
+          'melos publish --dry-run',
+          'melos publish [post]',
+          'post',
+        ];
+        final output = logger.output.normalizeNewLines().split('\n');
+        var previousIndex = -1;
+
+        for (final line in order) {
+          final index = output.indexOf(line);
+          expect(index, isNonNegative, reason: 'Line not found: $line');
+          expect(
+            index,
+            greaterThan(previousIndex),
+            reason: 'Line $line is out of order',
+          );
+          previousIndex = index;
+        }
       });
     });
   });


### PR DESCRIPTION
## Description

This PR adds lifecycle hooks (`pre` and `post`) to the `publish` command.
It runs `pre` once before publishing runs and `post` once afterwards (even though several packages might be published).

It also runs in `--dry-run` mode, to better emulate a real publish.
The environment variable `MELOS_PUBLISH_DRY_RUN` is introduced so that the user can know whether it is in `dry-run` mode or not in the scripts.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
