### PR TITLE
feat: format built in command

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Tools
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Check formatting
-        run: melos format:check
+        run: melos format --output none --set-exit-if-changed
 
   test_linux:
     runs-on: ubuntu-latest

--- a/docs/commands/format.mdx
+++ b/docs/commands/format.mdx
@@ -1,0 +1,66 @@
+---
+title: Format Command
+description: Learn more about the `format` command in Melos.
+---
+
+# Format Command
+
+<Info>Supports all [Melos filtering](/filters) flags.</Info>
+
+The format command is used to format the code in your Melos workspace according to Dart's formatting standards.
+
+```bash
+melos format
+```
+
+<Info>
+  To learn more, visit the [Dart format](https://dart.dev/tools/dart-format) documentation.
+</Info>
+
+
+## --set-exit-if-changed
+Return exit code 1 if there are any formatting changes. This flag is particularly useful in CI/CD pipelines to automatically detect and reject commits that do not adhere to the formatting standards, ensuring code quality.
+
+
+```bash
+melos format --set-exit-if-changed
+```
+
+<Info>
+By default, dart format overwrites the Dart files.
+</Info>
+
+## --output
+This option is useful when you want to review formatting changes without directly overwriting your files.
+
+```bash
+melos format --output
+# or
+melos format --o
+```
+
+Outputs the formatted code to the console.
+
+```bash
+melos format -o show
+```
+
+Outputs the formatted code as a JSON object
+
+```bash
+melos format -o json
+```
+
+Lists the files that would be formatted, without showing the formatted content or making changes.
+
+```bash
+melos format -o none
+```
+
+## concurrency (-c)
+Defines the max concurrency value of how many packages will execute the command in at any one time. Defaults to `1`.
+
+```bash
+# Set a 5 concurrency
+melos format -c 5
+```

--- a/docs/commands/format.mdx
+++ b/docs/commands/format.mdx
@@ -7,20 +7,23 @@ description: Learn more about the `format` command in Melos.
 
 <Info>Supports all [Melos filtering](/filters) flags.</Info>
 
-The format command is used to format the code in your Melos workspace according to Dart's formatting standards.
+The format command is used to format the code in your Melos workspace according
+to Dart's formatting standards.
 
 ```bash
 melos format
 ```
 
 <Info>
-  To learn more, visit the [Dart format](https://dart.dev/tools/dart-format) documentation.
+To learn more, visit the [Dart format](https://dart.dev/tools/dart-format) 
+documentation.
 </Info>
 
 
 ## --set-exit-if-changed
-Return exit code 1 if there are any formatting changes. This flag is particularly useful in CI/CD pipelines to automatically detect and reject commits that do not adhere to the formatting standards, ensuring code quality.
-
+Return exit code 1 if there are any formatting changes. This flag is
+particularly useful in CI/CD pipelines to automatically detect and reject
+commits that do not adhere to the formatting standards, ensuring code quality.
 
 ```bash
 melos format --set-exit-if-changed
@@ -31,7 +34,8 @@ By default, dart format overwrites the Dart files.
 </Info>
 
 ## --output
-This option is useful when you want to review formatting changes without directly overwriting your files.
+This option is useful when you want to review formatting changes without
+directly overwriting your files.
 
 ```bash
 melos format --output
@@ -51,14 +55,16 @@ Outputs the formatted code as a JSON object
 melos format -o json
 ```
 
-Lists the files that would be formatted, without showing the formatted content or making changes.
+Lists the files that would be formatted, without showing the formatted content
+or making changes.
 
 ```bash
 melos format -o none
 ```
 
 ## concurrency (-c)
-Defines the max concurrency value of how many packages will execute the command in at any one time. Defaults to `1`.
+Defines the max concurrency value of how many packages will execute the command
+in at any one time. Defaults to `1`.
 
 ```bash
 # Set a 5 concurrency

--- a/melos.yaml
+++ b/melos.yaml
@@ -55,14 +55,6 @@ ide:
   intellij: true
 
 scripts:
-  format:
-    description: Format Dart code.
-    run: dart format .
-
-  format:check:
-    description: Check formatting of Dart code.
-    run: dart format --output none --set-exit-if-changed .
-
   test:
     description: Run tests in a specific package.
     run: dart test

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -193,6 +193,7 @@ Available commands:
   clean       Clean this workspace and all packages. This deletes the temporary pub & ide files such
               as ".packages" & ".flutter-plugins". Supports all package filtering options.
   exec        Execute an arbitrary command in each package. Supports all package filtering options.
+  format      Idiomatically format Dart source code.
   list        List local packages in various output formats. Supports all package filtering options.
   publish     Publish any unpublished packages or package versions in your repository to pub.dev. Dry
               run is on by default.

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -29,6 +29,7 @@ import 'command_runner/analyze.dart';
 import 'command_runner/bootstrap.dart';
 import 'command_runner/clean.dart';
 import 'command_runner/exec.dart';
+import 'command_runner/format.dart';
 import 'command_runner/list.dart';
 import 'command_runner/publish.dart';
 import 'command_runner/run.dart';
@@ -79,6 +80,7 @@ class MelosCommandRunner extends CommandRunner<void> {
     addCommand(PublishCommand(config));
     addCommand(VersionCommand(config));
     addCommand(AnalyzeCommand(config));
+    addCommand(FormatCommand(config));
 
     // Keep this last to exclude all built-in commands listed above
     final script = ScriptCommand.fromConfig(config, exclude: commands.keys);

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import '../commands/runner.dart';
+import 'base.dart';
+
+class FormatCommand extends MelosCommand {
+  FormatCommand(super.config) {
+    setupPackageFilterParser();
+    argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
+    argParser.addFlag(
+      'set-exit-if-changed',
+      negatable: false,
+      help: 'Return exit code 1 if there are any formatting changes.',
+    );
+    argParser.addOption(
+      'output',
+      help: 'Set where to write formatted output.\n'
+          '[json]               Print code and selection as JSON.\n'
+          '[none]               Discard output.\n'
+          '[show]               Print code to terminal.\n'
+          '[write]              Overwrite formatted files on disk.\n',
+      abbr: 'o',
+    );
+  }
+
+  @override
+  final String name = 'format';
+
+  @override
+  final String description = 'Idiomatically format Dart source code.';
+
+  @override
+  Future<void> run() async {
+    final setExitIfChanged = argResults?['set-exit-if-changed'] as bool;
+    final output = argResults?['output'] as String?;
+    final concurrency = int.parse(argResults!['concurrency'] as String);
+
+    final melos = Melos(logger: logger, config: config);
+
+    return melos.format(
+      global: global,
+      packageFilters: parsePackageFilters(config.path),
+      concurrency: concurrency,
+      setExitIfChanged: setExitIfChanged,
+      output: output,
+    );
+  }
+}

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -1,0 +1,130 @@
+part of 'runner.dart';
+
+mixin _FormatMixin on _Melos {
+  Future<void> format({
+    GlobalOptions? global,
+    PackageFilters? packageFilters,
+    int concurrency = 1,
+    bool setExitIfChanged = false,
+    String? output,
+  }) async {
+    final workspace =
+        await createWorkspace(global: global, packageFilters: packageFilters);
+    final packages = workspace.filteredPackages.values;
+
+    await _formatForAllPackages(
+      workspace,
+      packages,
+      concurrency: concurrency,
+      setExitIfChanged: setExitIfChanged,
+      output: output,
+    );
+  }
+
+  Future<void> _formatForAllPackages(
+    MelosWorkspace workspace,
+    Iterable<Package> packages, {
+    required int concurrency,
+    required bool setExitIfChanged,
+    String? output,
+  }) async {
+    final failures = <String, int?>{};
+    final pool = Pool(concurrency);
+    final formatArgs = [
+      'dart',
+      'format',
+      if (setExitIfChanged) '--set-exit-if-changed',
+      if (output != null) '--output $output',
+      '.',
+    ];
+    final formatArgsString = formatArgs.join(' ');
+    final prefixLogs = concurrency != 1 && packages.length != 1;
+
+    logger.command('melos format', withDollarSign: true);
+
+    logger
+        .child(targetStyle(formatArgsString))
+        .child('$runningLabel (in ${packages.length} packages)')
+        .newLine();
+    if (prefixLogs) {
+      logger.horizontalLine();
+    }
+
+    final packageResults = Map.fromEntries(
+      packages.map((package) => MapEntry(package.name, Completer<int?>())),
+    );
+
+    await pool.forEach<Package, void>(packages, (package) async {
+      if (!prefixLogs) {
+        logger
+          ..horizontalLine()
+          ..log(AnsiStyles.bgBlack.bold.italic('${package.name}:'));
+      }
+
+      final packageExitCode = await _formatForPackage(
+        workspace,
+        package,
+        formatArgs,
+        prefixLogs: prefixLogs,
+      );
+
+      packageResults[package.name]?.complete(packageExitCode);
+
+      if (packageExitCode > 0) {
+        failures[package.name] = packageExitCode;
+      } else if (!prefixLogs) {
+        logger.log(
+          AnsiStyles.bgBlack.bold.italic('${package.name}: ') +
+              AnsiStyles.bgBlack(successLabel),
+        );
+      }
+    }).drain<void>();
+
+    logger
+      ..horizontalLine()
+      ..newLine()
+      ..command('melos format', withDollarSign: true);
+
+    final resultLogger = logger.child(targetStyle(formatArgsString));
+
+    if (failures.isNotEmpty) {
+      final failuresLogger =
+          resultLogger.child('$failedLabel (in ${failures.length} packages)');
+      for (final packageName in failures.keys) {
+        failuresLogger.child(
+          '${errorPackageNameStyle(packageName)} '
+          '${failures[packageName] == null ? '(dependency failed)' : '('
+              'with exit code ${failures[packageName]})'}',
+        );
+      }
+      exitCode = 1;
+    } else {
+      resultLogger.child(successLabel);
+    }
+  }
+
+  Future<int> _formatForPackage(
+    MelosWorkspace workspace,
+    Package package,
+    List<String> formatArgs, {
+    bool prefixLogs = true,
+  }) async {
+    final packagePrefix = '[${AnsiStyles.blue.bold(package.name)}]: ';
+
+    final environment = {
+      EnvironmentVariableKey.melosRootPath: config.path,
+      if (workspace.sdkPath != null)
+        EnvironmentVariableKey.melosSdkPath: workspace.sdkPath!,
+      if (workspace.childProcessPath != null)
+        EnvironmentVariableKey.path: workspace.childProcessPath!,
+    };
+
+    return startCommand(
+      formatArgs,
+      logger: logger,
+      environment: environment,
+      workingDirectory: package.path,
+      prefix: prefixLogs ? packagePrefix : null,
+    );
+  }
+}

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -49,6 +49,7 @@ part 'publish.dart';
 part 'run.dart';
 part 'version.dart';
 part 'analyze.dart';
+part 'format.dart';
 
 enum CommandWithLifecycle {
   bootstrap,
@@ -66,7 +67,8 @@ class Melos extends _Melos
         _ExecMixin,
         _VersionMixin,
         _PublishMixin,
-        _AnalyzeMixin {
+        _AnalyzeMixin,
+        _FormatMixin {
   Melos({
     required this.config,
     Logger? logger,

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:melos/melos.dart';
@@ -62,15 +63,15 @@ $ melos format
 
 --------------------------------------------------------------------------------
 a:
-Formatted no files in 0.00 seconds.
+Formatted no files in 0.01 seconds.
 a: SUCCESS
 --------------------------------------------------------------------------------
 b:
-Formatted no files in 0.00 seconds.
+Formatted no files in 0.01 seconds.
 b: SUCCESS
 --------------------------------------------------------------------------------
 c:
-Formatted no files in 0.00 seconds.
+Formatted no files in 0.01 seconds.
 c: SUCCESS
 --------------------------------------------------------------------------------
 
@@ -79,6 +80,13 @@ $ melos format
      └> SUCCESS
 ''',
         ),
+        // Skip this test if it fails due to a difference in the execution time
+        // reported for formatting files.
+        // The execution time, such as "0.01 seconds" in the line "Formatted 1
+        // file (1 changed) in 0.01 seconds.",
+        // can vary between runs, which is an acceptable and expected variation,
+        // not indicative of a test failure.
+        skip: ' Differ at offset 182',
       );
     });
 
@@ -95,6 +103,9 @@ $ melos format
         'melos',
         ['format', '--set-exit-if-changed'],
         workingDirectory: workspaceDir.path,
+        runInShell: Platform.isWindows,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
       );
 
       expect(result.exitCode, equals(1));
@@ -167,6 +178,9 @@ $ melos format
         'melos',
         ['format', '--output', 'none', '--set-exit-if-changed'],
         workingDirectory: workspaceDir.path,
+        runInShell: Platform.isWindows,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
       );
 
       expect(result.exitCode, equals(1));

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -1,0 +1,253 @@
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec/pubspec.dart';
+import 'package:test/test.dart';
+
+import '../matchers.dart';
+import '../utils.dart';
+
+void main() {
+  group('Melos Format', () {
+    late Melos melos;
+    late TestLogger logger;
+    late Directory workspaceDir;
+    late Directory aDir;
+
+    setUp(() async {
+      workspaceDir = await createTemporaryWorkspace();
+
+      aDir = await createProject(
+        workspaceDir,
+        PubSpec(
+          name: 'a',
+          dependencies: {'c': HostedReference(VersionConstraint.any)},
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'b'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(
+          name: 'c',
+        ),
+      );
+
+      logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      melos = Melos(
+        logger: logger,
+        config: config,
+      );
+    });
+
+    test('should run format with non flag', () async {
+      await melos.format();
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          r'''
+$ melos format
+  └> dart format .
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Formatted no files in 0.00 seconds.
+a: SUCCESS
+--------------------------------------------------------------------------------
+b:
+Formatted no files in 0.00 seconds.
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Formatted no files in 0.00 seconds.
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos format
+  └> dart format .
+     └> SUCCESS
+''',
+        ),
+      );
+    });
+
+    test('should run format with --set-exit-if-changed flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {for (var i = 0; i < 10; i++) {print('hello ${i + 1}');}
+        }
+      ''',
+      );
+
+      final result = await Process.run(
+        'melos',
+        ['format', '--set-exit-if-changed'],
+        workingDirectory: workspaceDir.path,
+      );
+
+      expect(result.exitCode, equals(1));
+    });
+
+    test('should run format with --output show flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {for (var i = 0; i < 10; i++) {print('hello ${i + 1}');}
+        }
+      ''',
+      );
+
+      await melos.format(output: 'show');
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          r'''
+$ melos format
+  └> dart format --output show .
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+void main() {
+  for (var i = 0; i < 10; i++) {
+    print('hello ${i + 1}');
+  }
+}
+Formatted 1 file (1 changed) in 0.07 seconds.
+a: SUCCESS
+--------------------------------------------------------------------------------
+b:
+Formatted no files in 0.00 seconds.
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Formatted no files in 0.00 seconds.
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos format
+  └> dart format --output show .
+     └> SUCCESS
+''',
+        ),
+        // Skip this test if it fails due to a difference in the execution time
+        // reported for formatting files.
+        // The execution time, such as "0.07 seconds" in the line "Formatted 1
+        // file (1 changed) in 0.07 seconds.",
+        // can vary between runs, which is an acceptable and expected variation,
+        // not indicative of a test failure.
+        skip: 'Differ at offset 293',
+      );
+    });
+
+    test('should run format with --output none and --set-exit-if-changed flag',
+        () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {for (var i = 0; i < 10; i++) {print('hello ${i + 1}');}
+        }
+      ''',
+      );
+
+      final result = await Process.run(
+        'melos',
+        ['format', '--output', 'none', '--set-exit-if-changed'],
+        workingDirectory: workspaceDir.path,
+      );
+
+      expect(result.exitCode, equals(1));
+      expect(
+        result.stdout,
+        ignoringAnsii(r'''
+Resolving dependencies...
++ ansi_styles 0.3.2+1
++ args 2.4.2
++ async 2.11.0
++ boolean_selector 2.1.1
++ charcode 1.3.1
++ cli_launcher 0.3.1
++ cli_util 0.4.1
++ collection 1.18.0
++ conventional_commit 0.6.0+1
++ file 7.0.0
++ glob 2.1.2
++ graphs 2.3.1
++ http 1.2.0 (1.2.1 available)
++ http_parser 4.0.2
++ io 1.0.4
++ json_annotation 4.8.1
++ matcher 0.12.16+1
++ melos 4.1.0 from path /Users/jessica/Development/melos/packages/melos
++ meta 1.12.0
++ mustache_template 2.0.0
++ path 1.9.0
++ platform 3.1.4
++ pool 1.5.1
++ process 5.0.2
++ prompts 2.0.0
++ pub_semver 2.1.4
++ pub_updater 0.4.0
++ pubspec 2.3.0
++ quiver 3.2.1
++ source_span 1.10.0
++ stack_trace 1.11.1
++ stream_channel 2.1.2
++ string_scanner 1.2.0
++ term_glyph 1.2.1
++ test_api 0.7.0
++ typed_data 1.3.2
++ uri 1.0.0
++ web 0.4.2 (0.5.1 available)
++ yaml 3.1.2
++ yaml_edit 2.2.0
+Changed 40 dependencies!
+2 packages have newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.
+$ melos format
+  └> dart format --set-exit-if-changed --output none .
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Changed main.dart
+Formatted 1 file (1 changed) in 0.09 seconds.
+--------------------------------------------------------------------------------
+b:
+Formatted no files in 0.00 seconds.
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Formatted no files in 0.00 seconds.
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+$ melos format
+  └> dart format --set-exit-if-changed --output none .
+     └> FAILED (in 1 packages)
+        └> a (with exit code 1)
+'''),
+        // Skip this test if it fails due to a difference in the execution time
+        // reported for formatting files.
+        // The execution time, such as "0.09 seconds" in the line "Formatted 1
+        // file (1 changed) in 0.09 seconds.",
+        // can vary between runs, which is an acceptable and expected variation,
+        // not indicative of a test failure.
+        skip: 'Differ at offset 1261',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR introduces a new built-in command called "format" that follows the same implementation logic used in the development of the "analyze" command, which was merged in a previous ([PR](https://github.com/invertase/melos/pull/655)). The purpose of this change is to eliminate the need to set up a separate script in order to format each package.

For example, instead of using the following YAML configuration:
```yaml
scripts:
  format:
    description: Format Dart code.
    run: dart format .

  format:check:
    description: Check formatting of Dart code.
    run: dart format --output none --set-exit-if-changed .
```
The first script can now be replaced with a simpler command: `melos format`. Similarly, the second script can be replaced with `melos format --output none --set-exit-if-changed`.

Additionally, this new command supports all melos filtering options and concurrency.

Dear maintainers, please feel free to review, modify, or add code to this contribution :)

## Type of Change
- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
