### PR TITLE
feat: add support for combining scripts

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -63,16 +63,17 @@ scripts:
   pre-commit:
     description: pre-commit git hook script
     steps:
+      - echo 'hello world'
       - format
       - analyze
   format:
     description: Format Dart code.
-    run: melos format
+    run: dart format .
     exec:
       concurrency: 5
   analyze:
     description: Analyze Dart code
-    run: melos analyze
+    run: dart analyze .
     exec:
       concurrency: 5
 ```

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -52,6 +52,36 @@ A short description, shown when using `melos run` with no argument.
 
 The command to execute.
 
+## steps
+
+Enables the combination of multiple scripts within a single script definition. 
+In the example below, the 'pre-commit' is configured to sequentially invoke the 
+format and analyze scripts.
+
+```yaml
+scripts:
+  pre-commit:
+    description: pre-commit git hook script
+    steps:
+      - format
+      - analyze
+  format:
+    description: Format Dart code.
+    run: melos format
+    exec:
+      concurrency: 5
+  analyze:
+    description: Analyze Dart code
+    run: melos analyze
+    exec:
+      concurrency: 5
+```
+
+Note: When utilizing the `steps`, it's important to understand that options 
+related to exec — such as concurrency — or `packageFilters` cannot be directly 
+applied within the steps configuration. Instead, these options should be 
+configured in the individual scripts that are being called as part of the step.
+
 ## exec
 
 Execute a script in multiple packages through `melos exec`.

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -21,11 +21,6 @@ mixin _RunMixin on _Melos {
     }
 
     if (script.steps != null && script.steps!.isNotEmpty) {
-      //TODO(jessica): Reevaluate the design decision regarding execution
-      // options (e.g., concurrency) for scripts with steps.
-      // Current concern: Allowing execution options for scripts with steps
-      // might introduce complexity and unpredictability, especially if nested
-      // scripts also utilize concurrency.
       if (script.exec != null) {
         throw ScriptExecOptionsException._(
           scriptName,
@@ -82,7 +77,6 @@ mixin _RunMixin on _Melos {
   /// eventually leads back to the original script, it indicates a
   /// recursive script call, which can result in an infinite loop during
   /// execution.
-  ///
   void _detectRecursiveScriptCalls(Script script) {
     final visitedScripts = <String>{};
 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -41,7 +41,7 @@ mixin _RunMixin on _Melos {
       return;
     }
 
-    if (script.run!.isEmpty && script.exec is! String) {
+    if (script.run == null && script.exec is! String) {
       throw MissingScriptCommandException._(
         scriptName,
       );

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -255,7 +255,6 @@ mixin _RunMixin on _Melos {
       final scriptCommand =
           scripts.containsKey(step) ? 'melos run $step' : step;
 
-      /// TODO: return scripts.containsKey(step) if true
       final scriptSourceCode = targetStyle(
         step.withoutTrailing('\n'),
       );

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -116,11 +116,12 @@ ExecOptions(
 class Script {
   const Script({
     required this.name,
-    required this.run,
+    this.run,
     this.description,
     this.env = const {},
     this.packageFilters,
     this.exec,
+    this.steps = const [],
   });
 
   factory Script.fromYaml(
@@ -129,15 +130,18 @@ class Script {
     required String workspacePath,
   }) {
     final scriptPath = 'scripts/$name';
-    String run;
+    var run = '';
     String? description;
     var env = <String, String>{};
+    var steps = <String>[];
     PackageFilters? packageFilters;
     ExecOptions? exec;
 
     if (yaml is String) {
       run = yaml;
-    } else if (yaml is Map<Object?, Object?>) {
+    }
+
+    if (yaml is Map<Object?, Object?>) {
       final execYaml = yaml['exec'];
       if (execYaml is String) {
         if (yaml['run'] is String) {
@@ -147,12 +151,47 @@ class Script {
           );
         }
         run = execYaml;
+      }
+
+      if (execYaml is String) {
+        exec = const ExecOptions();
       } else {
-        run = assertKeyIsA<String>(
-          key: 'run',
+        final execMap = assertKeyIsA<Map<Object?, Object?>?>(
+          key: 'exec',
           map: yaml,
           path: scriptPath,
         );
+
+        exec = execMap != null
+            ? execOptionsFromYaml(execMap, scriptName: name)
+            : null;
+      }
+
+      final stepsList = yaml['steps'];
+      if (stepsList is List && stepsList.isNotEmpty) {
+        steps = assertListIsA<String>(
+          key: 'steps',
+          map: yaml,
+          isRequired: false,
+          assertItemIsA: (index, value) {
+            return assertIsA<String>(
+              value: value,
+              index: index,
+              path: scriptPath,
+            );
+          },
+        );
+      }
+
+      final runYaml = yaml['run'];
+      if (runYaml is String && runYaml.isNotEmpty) {
+        run = execYaml is String
+            ? execYaml
+            : assertKeyIsA<String>(
+                key: 'run',
+                map: yaml,
+                path: scriptPath,
+              );
       }
 
       description = assertKeyIsA<String?>(
@@ -189,27 +228,12 @@ class Script {
               path: 'scripts/$name/packageFilters',
               workspacePath: workspacePath,
             );
-
-      if (execYaml is String) {
-        exec = const ExecOptions();
-      } else {
-        final execMap = assertKeyIsA<Map<Object?, Object?>?>(
-          key: 'exec',
-          map: yaml,
-          path: scriptPath,
-        );
-
-        exec = execMap == null
-            ? null
-            : execOptionsFromYaml(execMap, scriptName: name);
-      }
-    } else {
-      throw MelosConfigException('Unsupported value for script $name');
     }
 
     return Script(
       name: name,
       run: run,
+      steps: steps,
       description: description,
       env: env,
       packageFilters: packageFilters,
@@ -266,7 +290,14 @@ class Script {
   final String name;
 
   /// The command specified by the user.
-  final String run;
+  final String? run;
+
+  /// A list of individual command steps to be executed as part of this script.
+  /// Each string in the list represents a separate command to be run.
+  /// These steps are executed in sequence. This is an alternative to
+  /// specifying a single command in the [run] variable. If [steps] is
+  /// provided, [run] should not be used.
+  final List<String>? steps;
 
   /// A short description, shown when using `melos run` with no argument.
   final String? description;
@@ -286,7 +317,7 @@ class Script {
   List<String> command([List<String>? extraArgs]) {
     String quoteScript(String script) => '"${script.replaceAll('"', r'\"')}"';
 
-    final scriptCommand = run.split(' ').toList();
+    final scriptCommand = run!.split(' ').toList();
     if (extraArgs != null && extraArgs.isNotEmpty) {
       scriptCommand.addAll(extraArgs);
     }
@@ -318,7 +349,9 @@ class Script {
   /// Validates the script. Throws a [MelosConfigException] if the script is
   /// invalid.
   void validate() {
-    if (exec != null && run.startsWith(_leadingMelosExecRegExp)) {
+    if (exec != null &&
+        run != null &&
+        run!.startsWith(_leadingMelosExecRegExp)) {
       throw MelosConfigException(
         'Do not use "melos exec" in "run" when also providing options in '
         '"exec". In this case the script in "run" is already being executed by '
@@ -337,6 +370,7 @@ class Script {
       if (description != null) 'description': description,
       if (env.isNotEmpty) 'env': env,
       if (packageFilters != null) 'packageFilters': packageFilters!.toJson(),
+      if (steps != null) 'steps': steps,
       if (exec != null) 'exec': exec!.toJson(),
     };
   }
@@ -350,6 +384,7 @@ class Script {
       other.description == description &&
       const DeepCollectionEquality().equals(other.env, env) &&
       other.packageFilters == packageFilters &&
+      other.steps == steps &&
       other.exec == exec;
 
   @override
@@ -360,6 +395,7 @@ class Script {
       description.hashCode ^
       const DeepCollectionEquality().hash(env) ^
       packageFilters.hashCode ^
+      steps.hashCode ^
       exec.hashCode;
 
   @override
@@ -371,6 +407,7 @@ Script(
   description: $description,
   env: $env,
   packageFilters: ${packageFilters.toString().indent('  ')},
+  steps: $steps,
   exec: ${exec.toString().indent('  ')},
 )''';
   }

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -149,9 +149,6 @@ class Script {
           );
         }
         run = execYaml;
-      }
-
-      if (execYaml is String) {
         exec = const ExecOptions();
       } else {
         final execMap = assertKeyIsA<Map<Object?, Object?>?>(

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -130,7 +130,7 @@ class Script {
     required String workspacePath,
   }) {
     final scriptPath = 'scripts/$name';
-    var run = '';
+    String? run;
     String? description;
     var env = <String, String>{};
     var steps = <String>[];
@@ -139,9 +139,7 @@ class Script {
 
     if (yaml is String) {
       run = yaml;
-    }
-
-    if (yaml is Map<Object?, Object?>) {
+    } else if (yaml is Map<Object?, Object?>) {
       final execYaml = yaml['exec'];
       if (execYaml is String) {
         if (yaml['run'] is String) {
@@ -228,6 +226,8 @@ class Script {
               path: 'scripts/$name/packageFilters',
               workspacePath: workspacePath,
             );
+    } else {
+      throw MelosConfigException('Unsupported value for script $name');
     }
 
     return Script(

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -361,5 +361,195 @@ melos run test_script
         ),
       );
     });
+
+    test('throws an error if neither run, steps, nor exec are provided',
+        () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'test_script': Script(
+              name: 'test_script',
+            ),
+          }),
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      expect(() => melos.run(scriptName: 'test_script'), throwsException);
+    });
+
+    test(
+        'throws an error if neither run or steps are provided, and exec '
+        'are options', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'test_script': Script(
+              name: 'test_script',
+              exec: ExecOptions(),
+            ),
+          }),
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      expect(() => melos.run(scriptName: 'test_script'), throwsException);
+    });
+  });
+
+  group('multiple scripts', () {
+    test(
+        'verifies that a melos script can successfully call another '
+        'script as a step and execute commands', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'hello_script': Script(
+              name: 'hello_script',
+              steps: ['test_script', 'echo "hello world"'],
+            ),
+            'test_script': Script(
+              name: 'test_script',
+              run: 'echo "test_script"',
+            ),
+          }),
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'hello_script', noSelect: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          '''
+melos run hello_script
+  └> test_script
+     └> RUNNING
+
+melos run test_script
+  └> echo "test_script"
+     └> RUNNING
+
+test_script
+
+melos run test_script
+  └> echo "test_script"
+     └> SUCCESS
+
+melos run hello_script
+  └> test_script
+     └> SUCCESS
+
+melos run hello_script
+  └> echo "hello world"
+     └> RUNNING
+
+hello world
+
+melos run hello_script
+  └> echo "hello world"
+     └> SUCCESS
+
+''',
+        ),
+      );
+    });
+
+    test(
+        'throws an error if a script defined with steps also includes exec '
+        'options', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'hello_script': Script(
+              name: 'hello_script',
+              steps: ['test_script', 'echo "hello world"'],
+              exec: ExecOptions(
+                concurrency: 5,
+              ),
+            ),
+            'test_script': Script(
+              name: 'test_script',
+              run: 'echo "test_script"',
+            ),
+          }),
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      expect(
+        () => melos.run(scriptName: 'hello_script'),
+        throwsException,
+      );
+    });
   });
 }

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -482,7 +482,7 @@ melos run test_script
   └> echo "test_script"
      └> RUNNING
 
-test_script
+${currentPlatform.isWindows ? '"test_script"' : 'test_script'}
 
 melos run test_script
   └> echo "test_script"
@@ -496,7 +496,7 @@ melos run hello_script
   └> echo "hello world"
      └> RUNNING
 
-hello world
+${currentPlatform.isWindows ? '"hello world"' : 'hello world'}
 
 melos run hello_script
   └> echo "hello world"


### PR DESCRIPTION
## Description

This PR adds the capability to combine multiple scripts into a single script definition. In the provided example, the `pre-commit` script is configured to invoke a simple command as `echo 'hello world'`, and also individual scripts such as `format` and `analyze`.

### YAML file
```yaml
scripts:
  pre-commit:
    description: pre-commit git hook script
    steps:
      - echo 'hello world'
      - format
      - analyze
  format:
    description: Format Dart code.
    run: dart format .
    exec:
      concurrency: 5
  analyze:
    description: Analyze Dart code
    run: dart analyze .
    exec:
      concurrency: 5
```

### Output
```console
┌─(~/Development/melos)──────────────────────────────────────────────────────────────────────────────────────────────────────────(jessica@jessicas-MacBook-Air:s005)─┐
└─(21:14:01 on feature/multiple-steps-script ✹)──> melos run pre-commit                                                                                ──(Sat,Mar16)─┘
Building package executable... 
Built melos:melos.
melos run pre-commit
  └> echo 'hello world'
     └> RUNNING

hello world

melos run pre-commit
  └> echo 'hello world'
     └> SUCCESS

melos run pre-commit
  └> format
     └> RUNNING

melos run format
  └> melos exec --concurrency 5 -- "dart format ."
     └> RUNNING

$ melos exec
  └> dart format .
     └> RUNNING (in 3 packages)

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
[conventional_commit]: Formatted 3 files (0 changed) in 0.18 seconds.
[melos]: Formatted 85 files (0 changed) in 0.60 seconds.
[melos_workspace]: Formatted 90 files (0 changed) in 0.61 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------

$ melos exec
  └> dart format .
     └> SUCCESS

melos run format
  └> melos exec --concurrency 5 -- "dart format ."
     └> SUCCESS

melos run pre-commit
  └> format
     └> SUCCESS

melos run pre-commit
  └> analyze
     └> RUNNING

melos run analyze
  └> melos exec --concurrency 5 -- "dart analyze ."
     └> RUNNING

$ melos exec
  └> dart analyze .
     └> RUNNING (in 3 packages)

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
[conventional_commit]: Analyzing ....
[melos]: Analyzing ....
[melos_workspace]: Analyzing ....
[conventional_commit]: No issues found!
[melos]: No issues found!
[melos_workspace]: No issues found!
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------

$ melos exec
  └> dart analyze .
     └> SUCCESS

melos run analyze
  └> melos exec --concurrency 5 -- "dart analyze ."
     └> SUCCESS

melos run pre-commit
  └> analyze
     └> SUCCESS
```
As it stands, when using the multiple script definition, we are not allowed to use execution options like concurrency or `packageFilter` option, because that would increase the level of complexity and could cause several problems, so my suggestion for now is to be able to configure these things in the individual scripts.

Closes #653 

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
