### PR TITLE
fix: exec command with failFast should fail immediately

### DIFF
--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -23,7 +23,11 @@ import 'base.dart';
 class ExecCommand extends MelosCommand {
   ExecCommand(super.config) {
     setupPackageFilterParser();
-    argParser.addOption('concurrency', defaultsTo: Platform.numberOfProcessors.toString(), abbr: 'c');
+    argParser.addOption(
+      'concurrency',
+      defaultsTo: Platform.numberOfProcessors.toString(),
+      abbr: 'c',
+    );
     argParser.addFlag(
       'fail-fast',
       abbr: 'f',

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -23,7 +23,7 @@ import 'base.dart';
 class ExecCommand extends MelosCommand {
   ExecCommand(super.config) {
     setupPackageFilterParser();
-    argParser.addOption('concurrency', defaultsTo: '5', abbr: 'c');
+    argParser.addOption('concurrency', defaultsTo: Platform.numberOfProcessors.toString(), abbr: 'c');
     argParser.addFlag(
       'fail-fast',
       abbr: 'f',

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -132,18 +132,12 @@ mixin _ExecMixin on _Melos {
                 .whereNotNull(),
           );
 
-          final dependencyFailed = dependenciesResults
-              .any((exitCode) => exitCode == null || exitCode > 0);
+          final dependencyFailed = dependenciesResults.any(
+            (exitCode) => exitCode == null || exitCode > 0,
+          );
           if (dependencyFailed) {
             packageResults[package.name]?.complete();
             failures[package.name] = null;
-            package.allDependentsInWorkspace.forEach((_, dependent) {
-              failures[dependent.name] = null;
-            });
-
-            // cancel in case of dependency failure, irrespective of failFast
-            // or not
-            await operation.cancel();
 
             return;
           }

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -182,6 +182,10 @@ mixin _ExecMixin on _Melos {
 
     await operation.valueOrCancellation();
 
+    if (failFast) {
+      runningPids.forEach(Process.killPid);
+    }
+
     logger
       ..horizontalLine()
       ..newLine()
@@ -231,9 +235,6 @@ mixin _ExecMixin on _Melos {
         }
       }
 
-      if (failFast) {
-        runningPids.forEach(Process.killPid);
-      }
       exitCode = 1;
     } else {
       resultLogger.child(successLabel);

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -5,10 +5,11 @@ mixin _ExecMixin on _Melos {
     List<String> execArgs, {
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    int concurrency = 5,
+    int? concurrency,
     bool failFast = false,
     bool orderDependents = false,
   }) async {
+    concurrency ??= Platform.numberOfProcessors;
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
     final packages = workspace.filteredPackages.values;

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:ansi_styles/ansi_styles.dart';
+import 'package:async/async.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:collection/collection.dart';
 import 'package:file/local.dart';
@@ -31,8 +32,8 @@ import '../common/pending_package_update.dart';
 import '../common/platform.dart';
 import '../common/utils.dart' as utils;
 import '../common/utils.dart';
-import '../common/versioning.dart';
 import '../common/versioning.dart' as versioning;
+import '../common/versioning.dart';
 import '../global_options.dart';
 import '../lifecycle_hooks/lifecycle_hooks.dart';
 import '../logging.dart';

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -457,6 +457,10 @@ Future<Process> startCommandRaw(
   );
 }
 
+final _runningPids = <int>[];
+
+List<int> get runningPids => UnmodifiableListView(_runningPids);
+
 Future<int> startCommand(
   List<String> command, {
   String? prefix,
@@ -478,6 +482,8 @@ Future<int> startCommand(
     environment: environment,
     includeParentEnvironment: includeParentEnvironment,
   );
+
+  _runningPids.add(process.pid);
 
   var stdoutStream = process.stdout;
   var stderrStream = process.stderr;
@@ -533,6 +539,8 @@ Future<int> startCommand(
   await processStdoutCompleter.future;
   await processStderrCompleter.future;
   final exitCode = await process.exitCode;
+
+  _runningPids.remove(process.pid);
 
   if (onlyOutputOnError && exitCode > 0) {
     logger.stdout(utf8.decode(processStdout, allowMalformed: true));

--- a/packages/melos/lib/src/logging.dart
+++ b/packages/melos/lib/src/logging.dart
@@ -24,6 +24,7 @@ final successLabel = successLableColor(labelStyle('SUCCESS'));
 final warningLabel = warningLabelColor(labelStyle('WARNING'));
 final errorLabel = errorLabelColor(labelStyle('ERROR'));
 final failedLabel = errorLabelColor(labelStyle('FAILED'));
+final canceledLabel = errorLabelColor(labelStyle('CANCELED'));
 final hintLabel = hintLabelColor(labelStyle('HINT'));
 final runningLabel = commandLabelColor(labelStyle('RUNNING'));
 final checkLabel = AnsiStyles.greenBright('✓');

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -17,6 +17,7 @@ executables:
 dependencies:
   ansi_styles: ^0.3.2+1
   args: ^2.4.2
+  async: ^2.11.0
   cli_launcher: ^0.3.1
   cli_util: ^0.4.1
   collection: ^1.18.0

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -214,8 +214,9 @@ ${'-' * terminalWidth}
         );
 
         final logger = TestLogger();
-        final config =
-        await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
         final melos = Melos(
           logger: logger,
           config: config,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The expected behavior of failFast option is to fail the whole exec command as soon as a single fail occurs, and it works as expected if concurrency=1. But if concurrency > 1, it diverges from the expected behavior and instead keeps running until all pooled jobs have finished executing.

This PR fixes this divergence, and the exec command will fail immediately on a single fail irrespective of concurrency value.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
