### PR TITLE
fix: melos analyze concurrency flag log output

### DIFF
--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -265,5 +265,16 @@ $ melos analyze
 '''),
       );
     });
+
+    test('should run analysis with --concurrency flag', () async {
+      // when concurrency is set to a number bigger than 1 then
+      // the output should appears as the following
+      await melos.analyze(concurrency: 2);
+
+      final regex =
+          RegExp(r'\$ melos analyze\s+└> dart analyze --concurrency 2');
+
+      expect(regex.hasMatch(logger.output.normalizeNewLines()), isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR aims to fix a problem with the log output of the analyze command when the concurrency flag is used, as reported in issue #668. 

Closes #668

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
