### PR TITLE
feat: support for melos command within script steps

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -54,9 +54,10 @@ The command to execute.
 
 ## steps
 
-Enables the combination of multiple scripts within a single script definition. 
-In the example below, the 'pre-commit' is configured to sequentially invoke the 
-format and analyze scripts.
+Enables the combination of multiple scripts within a single script definition
+for complex workflows. In the example below, the pre-commit script is
+configured to sequentially invoke a simple command echo 'hello world',
+followed by Melos commands: format and analyze, each with specific arguments.
 
 ```yaml
 scripts:
@@ -64,18 +65,8 @@ scripts:
     description: pre-commit git hook script
     steps:
       - echo 'hello world'
-      - format
-      - analyze
-  format:
-    description: Format Dart code.
-    run: dart format .
-    exec:
-      concurrency: 5
-  analyze:
-    description: Analyze Dart code
-    run: dart analyze .
-    exec:
-      concurrency: 5
+      - format --output none --set-exit-if-changed
+      - analyze --fatal-infos
 ```
 
 Note: When utilizing the `steps`, it's important to understand that options 

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -313,7 +313,6 @@ mixin _RunMixin on _Melos {
 
     if (exitCode != 0) {
       resultLogger.child(failedLabel);
-      throw ScriptException._(script.name);
     } else {
       resultLogger.child(successLabel);
     }

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -258,12 +258,12 @@ mixin _RunMixin on _Melos {
   }
 
   String _buildScriptCommand(String step, Scripts scripts) {
-    if (_isStepACommand(step)) {
-      return 'melos $step';
-    }
-
     if (scripts.containsKey(step)) {
       return 'melos run $step';
+    }
+
+    if (_isStepACommand(step)) {
+      return 'melos $step';
     }
 
     return step;

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -239,6 +239,33 @@ mixin _RunMixin on _Melos {
     await _executeScriptSteps(steps, scripts, script, environment);
   }
 
+  /// Checks if the given [step] is a recognized Melos command.
+  bool _isStepACommand(String step) {
+    const melosCommands = {
+      'analyze',
+      'format',
+      'bs',
+      'bootstrap',
+      'clean',
+      'list',
+      'publish',
+    };
+
+    return melosCommands.contains(step);
+  }
+
+  String _buildScriptCommand(String step, Scripts scripts) {
+    if (_isStepACommand(step)) {
+      return 'melos $step';
+    }
+
+    if (scripts.containsKey(step)) {
+      return 'melos run $step';
+    }
+
+    return step;
+  }
+
   Future<void> _executeScriptSteps(
     List<String> steps,
     Scripts scripts,
@@ -246,8 +273,7 @@ mixin _RunMixin on _Melos {
     Map<String, String> environment,
   ) async {
     for (final step in steps) {
-      final scriptCommand =
-          scripts.containsKey(step) ? 'melos run $step' : step;
+      final scriptCommand = _buildScriptCommand(step, scripts);
 
       final scriptSourceCode = targetStyle(
         step.withoutTrailing('\n'),

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -241,6 +241,9 @@ mixin _RunMixin on _Melos {
 
   /// Checks if the given [step] is a recognized Melos command.
   bool _isStepACommand(String step) {
+    // Split the step by spaces to separate the command from its flags/arguments.
+    final command = step.split(' ')[0];
+
     const melosCommands = {
       'analyze',
       'format',
@@ -251,7 +254,7 @@ mixin _RunMixin on _Melos {
       'publish',
     };
 
-    return melosCommands.contains(step);
+    return melosCommands.contains(command);
   }
 
   String _buildScriptCommand(String step, Scripts scripts) {

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -834,10 +834,10 @@ melos run analyze
 
 Analyzing ....
 
-   info - packages/a/main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
-   info - packages/a/main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+${currentPlatform.isWindows ? r"warning - pubspec.yaml:6:11 - The path d:\a\melos\melos\packages\melos isn't a POSIX-style path. Try converting the value to a POSIX-style path. - path_not_posix" : "   info - ${currentPlatform.isWindows ? r'packages\a\main.dart' : 'packages/a/main.dart'}:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print"}
+   info - ${currentPlatform.isWindows ? r'packages\a\main.dart' : 'packages/a/main.dart'}:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
-2 issues found.
+${currentPlatform.isWindows ? '3' : '2'} issues found.
 
 melos run analyze
   └> dart analyze . --fatal-warnings

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -759,6 +759,120 @@ melos run hello_script
     });
 
     test(
+        'verifies that a melos script can call another script containing '
+        'melos commands with flags, and ensures the script is successfully '
+        'executed', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'hello_script': Script(
+              name: 'hello_script',
+              steps: ['analyze --fatal-infos', 'echo "hello world"'],
+            ),
+          }),
+        ),
+      );
+
+      aDir = await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'b'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(
+          name: 'c',
+        ),
+      );
+
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+          for (var i = 0; i < 10; i++) {
+            print('hello ${i + 1}');
+          }
+        }
+      ''',
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'hello_script', noSelect: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          '''
+melos run hello_script
+  └> analyze --fatal-infos
+     └> RUNNING
+
+\$ melos analyze
+  └> dart analyze --fatal-infos
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+   info - main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+2 issues found.
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+\$ melos analyze
+  └> dart analyze --fatal-infos
+     └> FAILED (in 1 packages)
+        └> a (with exit code 1)
+
+melos run hello_script
+  └> analyze --fatal-infos
+     └> FAILED
+
+melos run hello_script
+  └> echo "hello world"
+     └> RUNNING
+
+${currentPlatform.isWindows ? '"hello world"' : 'hello world'}
+
+melos run hello_script
+  └> echo "hello world"
+     └> SUCCESS
+
+''',
+        ),
+      );
+    });
+
+    test(
         'throw an error if correctly identifies when a script indirectly '
         'calls itself through another script, leading to a recursive call',
         () async {

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -773,11 +773,11 @@ melos run hello_script
           scripts: const Scripts({
             'hello_script': Script(
               name: 'hello_script',
-              steps: ['analyze', 'echo "hello world"'],
+              steps: ['list', 'echo "hello world"'],
             ),
-            'analyze': Script(
-              name: 'hello_script',
-              run: 'dart analyze . --fatal-warnings',
+            'list': Script(
+              name: 'list script',
+              run: 'echo "list script"',
             ),
           }),
         ),
@@ -800,17 +800,6 @@ melos run hello_script
         ),
       );
 
-      writeTextFile(
-        p.join(aDir.path, 'main.dart'),
-        r'''
-        void main() {
-          for (var i = 0; i < 10; i++) {
-            print('hello ${i + 1}');
-          }
-        }
-      ''',
-      );
-
       final logger = TestLogger();
       final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final melos = Melos(
@@ -822,29 +811,24 @@ melos run hello_script
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           '''
 melos run hello_script
-  └> analyze
+  └> list
      └> RUNNING
 
-melos run analyze
-  └> dart analyze . --fatal-warnings
+melos run list
+  └> echo "list script"
      └> RUNNING
 
-Analyzing ....
+${currentPlatform.isWindows ? '"list script"' : 'list script'}
 
-${currentPlatform.isWindows ? r"warning - pubspec.yaml:6:11 - The path d:\a\melos\melos\packages\melos isn't a POSIX-style path. Try converting the value to a POSIX-style path. - path_not_posix" : "   info - ${currentPlatform.isWindows ? r'packages\a\main.dart' : 'packages/a/main.dart'}:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print"}
-   info - ${currentPlatform.isWindows ? r'packages\a\main.dart' : 'packages/a/main.dart'}:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
-
-${currentPlatform.isWindows ? '3' : '2'} issues found.
-
-melos run analyze
-  └> dart analyze . --fatal-warnings
+melos run list
+  └> echo "list script"
      └> SUCCESS
 
 melos run hello_script
-  └> analyze
+  └> list
      └> SUCCESS
 
 melos run hello_script

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:melos/melos.dart';
 import 'package:melos/src/commands/runner.dart';
 import 'package:melos/src/common/environment_variable_key.dart';
@@ -433,6 +435,8 @@ melos run test_script
   });
 
   group('multiple scripts', () {
+    late Directory aDir;
+
     test(
         'verifies that a melos script can successfully call another '
         'script as a step and execute commands', () async {
@@ -623,6 +627,120 @@ melos run test_script
 
 melos run hello_script
   └> test_script
+     └> SUCCESS
+
+melos run hello_script
+  └> echo "hello world"
+     └> RUNNING
+
+${currentPlatform.isWindows ? '"hello world"' : 'hello world'}
+
+melos run hello_script
+  └> echo "hello world"
+     └> SUCCESS
+
+''',
+        ),
+      );
+    });
+
+    test(
+        'verifies that a melos script can call another script containing '
+        'melos commands, and ensures the script is successfully executed',
+        () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        runPubGet: true,
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'hello_script': Script(
+              name: 'hello_script',
+              steps: ['analyze', 'echo "hello world"'],
+            ),
+          }),
+        ),
+      );
+
+      aDir = await createProject(
+        workspaceDir,
+        const PubSpec(name: 'a'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(name: 'b'),
+      );
+
+      await createProject(
+        workspaceDir,
+        const PubSpec(
+          name: 'c',
+        ),
+      );
+
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+          for (var i = 0; i < 10; i++) {
+            print('hello ${i + 1}');
+          }
+        }
+      ''',
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'hello_script', noSelect: true);
+
+      expect(
+        logger.output.normalizeNewLines(),
+        ignoringAnsii(
+          '''
+melos run hello_script
+  └> analyze
+     └> RUNNING
+
+\$ melos analyze
+  └> dart analyze 
+     └> RUNNING (in 3 packages)
+
+--------------------------------------------------------------------------------
+a:
+Analyzing a...
+
+   info - main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+2 issues found.
+a: SUCCESS
+--------------------------------------------------------------------------------
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+--------------------------------------------------------------------------------
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+--------------------------------------------------------------------------------
+
+\$ melos analyze
+  └> dart analyze 
+     └> SUCCESS
+
+melos run hello_script
+  └> analyze
      └> SUCCESS
 
 melos run hello_script


### PR DESCRIPTION
## Description

This pull request introduces support for melos command within script steps, as suggested in issue #653. An example configuration demonstrating this new capability is as follows:

```yaml
scripts:
  pre-commit:
    description: pre-commit git hook script
    steps:
      - echo 'hello world'
      - format --output none --set-exit-if-changed
      - analyze --fatal-infos
``` 


I'll need some help on determining the appropriate range of commands to support. Should we use every command possible?  
Currently, the following commands are under consideration:

```dart
    const melosCommands = {
      'analyze',
      'format',
      'bs',
      'bootstrap',
      'clean',
      'list',
      'publish',
    };

```

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
