### PR TITLE
feat: add support for `melos bs --skip-linking`

### DIFF
--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -90,7 +90,7 @@ melos bootstrap --diff="main"
     - This will run `pub get` with the `--no-example` flag.
 - The `--enforce-lockfile` flag is used to enforce versions from `.lock` files.
     - Ensure .lock files exist, as failure may occur if they're not checked in.
-- The `--skip-linking` flag is used to skip the local linking for workspace packages.
+- The `--skip-linking` flag is used to skip the local linking of workspace packages.
 
 
 In addition to the above flags, the `melos bootstrap` command supports a few different flags that can be defined in

--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -90,6 +90,7 @@ melos bootstrap --diff="main"
     - This will run `pub get` with the `--no-example` flag.
 - The `--enforce-lockfile` flag is used to enforce versions from `.lock` files.
     - Ensure .lock files exist, as failure may occur if they're not checked in.
+- The `--skip-linking` flag is used to skip the local linking for workspace packages.
 
 
 In addition to the above flags, the `melos bootstrap` command supports a few different flags that can be defined in

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -34,6 +34,11 @@ class BootstrapCommand extends MelosCommand {
       help: 'Run pub get with --enforce-lockfile to enforce versions from .lock'
           ' files, ensure .lockfile exist for all packages.',
     );
+    argParser.addFlag(
+      'skip-linking',
+      negatable: false,
+      help: 'Skips locally linking workspace packages.',
+    );
   }
 
   @override
@@ -55,6 +60,7 @@ class BootstrapCommand extends MelosCommand {
       packageFilters: parsePackageFilters(config.path),
       enforceLockfile: argResults?['enforce-lockfile'] as bool? ?? false,
       noExample: argResults?['no-example'] as bool,
+      skipLinking: argResults?['skip-linking'] as bool,
     );
   }
 }

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -6,6 +6,7 @@ mixin _BootstrapMixin on _CleanMixin {
     PackageFilters? packageFilters,
     bool noExample = false,
     bool enforceLockfile = false,
+    bool skipLinking = false,
   }) async {
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
@@ -33,7 +34,6 @@ mixin _BootstrapMixin on _CleanMixin {
           ..child(targetStyle(workspace.path))
           ..newLine();
 
-        logger.log('Running "$pubCommandForLogging" in workspace packages...');
         if (!utils.isCI && workspace.filteredPackages.keys.length > 20) {
           logger.warning(
             'Note: this may take a while in large workspaces such as this one.',
@@ -45,6 +45,8 @@ mixin _BootstrapMixin on _CleanMixin {
           if (bootstrapCommandConfig.environment != null ||
               bootstrapCommandConfig.dependencies != null ||
               bootstrapCommandConfig.devDependencies != null) {
+            logger.log('Updating common dependencies in workspace packages...');
+
             final filteredPackages = workspace.filteredPackages.values;
             await Stream.fromIterable(filteredPackages).parallel((package) {
               return _setSharedDependenciesForPackage(
@@ -54,19 +56,27 @@ mixin _BootstrapMixin on _CleanMixin {
                 devDependencies: bootstrapCommandConfig.devDependencies,
               );
             }).drain<void>();
+
+            logger.child(successLabel, prefix: '> ');
           }
 
-          await _linkPackagesWithPubspecOverrides(
-            workspace,
-            enforceLockfile: enforceLockfile,
-            noExample: noExample,
-          );
+          if (!skipLinking) {
+            logger
+              ..newLine()
+              ..log('Running "$pubCommandForLogging" in workspace packages...');
+
+            await _linkPackagesWithPubspecOverrides(
+              workspace,
+              enforceLockfile: enforceLockfile,
+              noExample: noExample,
+            );
+
+            logger.child(successLabel, prefix: '> ');
+          }
         } on BootstrapException catch (exception) {
           _logBootstrapException(exception, workspace);
           rethrow;
         }
-
-        logger.child(successLabel, prefix: '> ');
 
         if (workspace.config.ide.intelliJ.enabled) {
           logger
@@ -282,7 +292,7 @@ mixin _BootstrapMixin on _CleanMixin {
       ];
       if (message.isNotEmpty) {
         logger
-            .child(packageNameStyle(package.name), prefix: '')
+            .child(packageNameStyle(package.name), prefix: '$checkLabel ')
             .child(message.join('\n'));
       }
     }

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -57,13 +57,15 @@ mixin _BootstrapMixin on _CleanMixin {
               );
             }).drain<void>();
 
-            logger.child(successLabel, prefix: '> ');
+            logger
+              ..child(successLabel, prefix: '> ')
+              ..newLine();
           }
 
           if (!skipLinking) {
-            logger
-              ..newLine()
-              ..log('Running "$pubCommandForLogging" in workspace packages...');
+            logger.log(
+              'Running "$pubCommandForLogging" in workspace packages...',
+            );
 
             await _linkPackagesWithPubspecOverrides(
               workspace,
@@ -71,7 +73,9 @@ mixin _BootstrapMixin on _CleanMixin {
               noExample: noExample,
             );
 
-            logger.child(successLabel, prefix: '> ');
+            logger
+              ..child(successLabel, prefix: '> ')
+              ..newLine();
           }
         } on BootstrapException catch (exception) {
           _logBootstrapException(exception, workspace);
@@ -79,19 +83,17 @@ mixin _BootstrapMixin on _CleanMixin {
         }
 
         if (workspace.config.ide.intelliJ.enabled) {
-          logger
-            ..newLine()
-            ..log('Generating IntelliJ IDE files...');
+          logger.log('Generating IntelliJ IDE files...');
 
           await cleanIntelliJ(workspace);
           await workspace.ide.intelliJ.generate();
-          logger.child(successLabel, prefix: '> ');
+          logger
+            ..child(successLabel, prefix: '> ')
+            ..newLine();
         }
-        logger
-          ..newLine()
-          ..log(
-            ' -> ${workspace.filteredPackages.length} packages bootstrapped',
-          );
+        logger.log(
+          ' -> ${workspace.filteredPackages.length} packages bootstrapped',
+        );
       },
     );
   }

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -835,65 +835,7 @@ Generating IntelliJ IDE files...
       );
     });
 
-    test(
-      'should work fine with environment config',
-      () async {
-        final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: (path) => MelosWorkspaceConfig(
-            name: 'Melos',
-            packages: [
-              createGlob('packages/**', currentDirectoryPath: path),
-            ],
-            commands: CommandConfigs(
-              bootstrap: BootstrapCommandConfigs(
-                environment: Environment(
-                  VersionConstraint.parse('>=2.18.0 <3.0.0'),
-                  {'flutter': '>=2.18.0 <3.0.0'},
-                ),
-              ),
-            ),
-            path: path,
-          ),
-        );
-
-        await createProject(
-          workspaceDir,
-          const PubSpec(name: 'a'),
-        );
-
-        final logger = TestLogger();
-        final config =
-            await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
-        final melos = Melos(logger: logger, config: config);
-
-        await runMelosBootstrap(melos, logger, skipLinking: true);
-
-        expect(
-          logger.output,
-          ignoringAnsii(
-            '''
-melos bootstrap
-  └> ${workspaceDir.path}
-
-Updating common dependencies in workspace packages...
-  ✓ a
-    └> Updated environment
-  > SUCCESS
-
-Generating IntelliJ IDE files...
-  > SUCCESS
-
- -> 1 packages bootstrapped
-''',
-          ),
-        );
-      },
-    );
-  });
-
-  test(
-    'can skip package linking if --skip-linking is enabled',
-    () async {
+    test('should work fine with environment config', () async {
       final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           name: 'Melos',
@@ -942,8 +884,8 @@ Generating IntelliJ IDE files...
 ''',
         ),
       );
-    },
-  );
+    });
+  });
 }
 
 Future<void> runMelosBootstrap(


### PR DESCRIPTION
## Description

Fixes: #682 
Adds a new flag `--skip-linking` to the melos `bs`.

### Logs
- with `--skip-linking` enabled
```zsh
melos bootstrap
  └> /Users/sahilkumar/StudioProjects/melos

Updating common dependencies in workspace packages...
  ✓ melos
    └> Updated environment
  ✓ melos_workspace
    └> Updated environment
  ✓ conventional_commit
    └> Updated environment
  > SUCCESS

Generating IntelliJ IDE files...
  > SUCCESS

 -> 3 packages bootstrapped
```

- with `--skip-linking` disabled
```zsh
melos bootstrap
  └> /Users/sahilkumar/StudioProjects/melos

Updating common dependencies in workspace packages...
  ✓ conventional_commit
    └> Updated environment
  ✓ melos
    └> Updated environment
  ✓ melos_workspace
    └> Updated environment
  > SUCCESS

Running "dart pub get" in workspace packages...
  ✓ conventional_commit
    └> packages/conventional_commit
  ✓ melos_workspace
    └> .
  ✓ melos
    └> packages/melos
  > SUCCESS

Generating IntelliJ IDE files...
  > SUCCESS

 -> 3 packages bootstrapped
```

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
