### PR TITLE
feat: add `--line-length` option to `melos format` command

### DIFF
--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -21,7 +21,6 @@ class FormatCommand extends MelosCommand {
     );
     argParser.addOption(
       'line-length',
-      defaultsTo: '80',
       help: 'The line length to format the code to.',
     );
   }

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -19,6 +19,11 @@ class FormatCommand extends MelosCommand {
           '[write]              Overwrite formatted files on disk.\n',
       abbr: 'o',
     );
+    argParser.addOption(
+      'line-length',
+      defaultsTo: '80',
+      help: 'The line length to format the code to.',
+    );
   }
 
   @override
@@ -32,6 +37,7 @@ class FormatCommand extends MelosCommand {
     final setExitIfChanged = argResults?['set-exit-if-changed'] as bool;
     final output = argResults?['output'] as String?;
     final concurrency = int.parse(argResults!['concurrency'] as String);
+    final lineLength = int.parse(argResults!['line-length'] as String);
 
     final melos = Melos(logger: logger, config: config);
 
@@ -41,6 +47,7 @@ class FormatCommand extends MelosCommand {
       concurrency: concurrency,
       setExitIfChanged: setExitIfChanged,
       output: output,
+      lineLength: lineLength,
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -36,7 +36,10 @@ class FormatCommand extends MelosCommand {
     final setExitIfChanged = argResults?['set-exit-if-changed'] as bool;
     final output = argResults?['output'] as String?;
     final concurrency = int.parse(argResults!['concurrency'] as String);
-    final lineLength = int.tryParse(argResults?['line-length'] as String);
+    final lineLength = switch (argResults?['line-length']) {
+      final int length => length,
+      _ => null,
+    };
 
     final melos = Melos(logger: logger, config: config);
 

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -36,7 +36,7 @@ class FormatCommand extends MelosCommand {
     final setExitIfChanged = argResults?['set-exit-if-changed'] as bool;
     final output = argResults?['output'] as String?;
     final concurrency = int.parse(argResults!['concurrency'] as String);
-    final lineLength = int.parse(argResults!['line-length'] as String);
+    final lineLength = int.tryParse(argResults?['line-length'] as String);
 
     final melos = Melos(logger: logger, config: config);
 

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -7,7 +7,7 @@ mixin _FormatMixin on _Melos {
     int concurrency = 1,
     bool setExitIfChanged = false,
     String? output,
-    int lineLength = 80,
+    int? lineLength,
   }) async {
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
@@ -29,7 +29,7 @@ mixin _FormatMixin on _Melos {
     required int concurrency,
     required bool setExitIfChanged,
     String? output,
-    required int lineLength,
+    int? lineLength,
   }) async {
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
@@ -38,7 +38,7 @@ mixin _FormatMixin on _Melos {
       'format',
       if (setExitIfChanged) '--set-exit-if-changed',
       if (output != null) '--output $output',
-      '--line-length $lineLength',
+      if (lineLength != null) '--line-length $lineLength',
       '.',
     ];
     final formatArgsString = formatArgs.join(' ');

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -7,6 +7,7 @@ mixin _FormatMixin on _Melos {
     int concurrency = 1,
     bool setExitIfChanged = false,
     String? output,
+    int lineLength = 80,
   }) async {
     final workspace =
         await createWorkspace(global: global, packageFilters: packageFilters);
@@ -18,6 +19,7 @@ mixin _FormatMixin on _Melos {
       concurrency: concurrency,
       setExitIfChanged: setExitIfChanged,
       output: output,
+      lineLength: lineLength,
     );
   }
 
@@ -27,6 +29,7 @@ mixin _FormatMixin on _Melos {
     required int concurrency,
     required bool setExitIfChanged,
     String? output,
+    required int lineLength,
   }) async {
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
@@ -35,6 +38,7 @@ mixin _FormatMixin on _Melos {
       'format',
       if (setExitIfChanged) '--set-exit-if-changed',
       if (output != null) '--output $output',
+      '--line-length $lineLength',
       '.',
     ];
     final formatArgsString = formatArgs.join(' ');

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -64,7 +64,7 @@ void main() {
 
         expect(
           logger.output.normalizeNewLines(),
-          ignoringAnsii(
+          ignoringDependencyMessages(
             '''
 melos run test_script
   └> melos exec -- "echo hello"
@@ -147,7 +147,7 @@ melos run test_script
 
           expect(
             logger.output.normalizeNewLines(),
-            ignoringAnsii(
+            ignoringDependencyMessages(
               '''
 melos run test_script
   └> melos exec -- "echo hello"
@@ -216,7 +216,7 @@ melos run test_script
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           '''
 melos run hello
   └> echo foo bar baz
@@ -272,7 +272,7 @@ melos run hello
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           r'''
 melos run hello
   └> melos exec -- "echo foo bar baz"
@@ -337,7 +337,7 @@ melos run hello
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           '''
 melos run test_script
   └> melos exec --concurrency 1 -- "echo \\"hello\\""
@@ -704,7 +704,7 @@ melos run hello_script
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           '''
 melos run hello_script
   └> analyze
@@ -906,7 +906,7 @@ melos run hello_script
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(
+        ignoringDependencyMessages(
           '''
 melos run hello_script
   └> analyze --fatal-infos


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

This pull request adds a `--line-length` option to the `melos format` command, 
allowing users to specify the desired line length when formatting Dart code across packages in a Melos workspace.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
