### PR TITLE
fix!: Make `melos analyze` always use `dart analyze`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "dart.runPubGetOnPubspecChanges": "always"
+  "dart.runPubGetOnPubspecChanges": "always",
+  "dart.lineLength": 80,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "dart.runPubGetOnPubspecChanges": "always",
-  "dart.lineLength": 80,
+  "dart.runPubGetOnPubspecChanges": "always"
 }

--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -20,7 +20,7 @@ melos analyze
 
 ## --fatal-infos
 Enforces a strict analysis by treating info-level issues as critical errors.
-By default, the this option is disabled.
+By default this option is disabled.
 
 ```bash
 melos analyze --fatal-infos
@@ -28,7 +28,7 @@ melos analyze --fatal-infos
 
 ## --fatal-warnings
 Enables treating warnings as fatal errors. When enabled, any warning will cause the analyzer to fail.
-By default, the this option is enabled.
+By default this option is enabled.
 
 ```bash
 melos analyze --fatal-warnings

--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -20,6 +20,7 @@ melos analyze
 
 ## --fatal-infos
 Enforces a strict analysis by treating info-level issues as critical errors.
+By default, the this option is disabled.
 
 ```bash
 melos analyze --fatal-infos
@@ -27,6 +28,7 @@ melos analyze --fatal-infos
 
 ## --fatal-warnings
 Enables treating warnings as fatal errors. When enabled, any warning will cause the analyzer to fail.
+By default, the this option is enabled.
 
 ```bash
 melos analyze --fatal-warnings

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -110,10 +110,8 @@ mixin _AnalyzeMixin on _Melos {
   }) {
     final options = _getOptionsArgs(fatalInfos, fatalWarnings, concurrency);
     return <String>[
-      ..._analyzeCommandExecArgs(
-        useFlutter: workspace.isFlutterWorkspace,
-        workspace: workspace,
-      ),
+      workspace.sdkTool('dart'),
+      'analyze',
       options,
     ];
   }
@@ -161,18 +159,5 @@ mixin _AnalyzeMixin on _Melos {
       workingDirectory: package.path,
       group: group,
     );
-  }
-
-  List<String> _analyzeCommandExecArgs({
-    required bool useFlutter,
-    required MelosWorkspace workspace,
-  }) {
-    return [
-      if (useFlutter)
-        workspace.sdkTool('flutter')
-      else
-        workspace.sdkTool('dart'),
-      'analyze',
-    ];
   }
 }


### PR DESCRIPTION
## Description

The recent `melos analyze` changes came as a breaking change surprise for our project. On our project, we do not treat info-level issues as errors because we have some `deprecated` info lints in our codebase. 

The change introduced in https://github.com/invertase/melos/pull/655 results in the call to `flutter analyze` or `dart analyze` depending on the Flutter dependency presence.

**The issue is that those commands have different default behavior and configuration options.**

 While `dart analyze` does not fail on info-level issues by default,
<img width="504" alt="image" src="https://github.com/invertase/melos/assets/8143332/a2d60906-093a-4970-9cfe-667af5ed7ffb">

the `flutter analyze` does fail on info-level issues.
<img width="859" alt="image" src="https://github.com/invertase/melos/assets/8143332/10308bf3-5f5b-4300-beb7-d6b5ead9a695">

This results in inconsistent behavior. Also, it is not aligned with the [current documentation/API](https://melos.invertase.dev/commands/analyze#--fatal-infos) of `melos analyze`.

Since `dart analyze` is suitable for both `dart` and `flutter` packages I do not see a problem using just this command. That will fix the inconsistency and make things simpler.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
