### PR TITLE
feat: option to provide dependencies related filters from yaml

### DIFF
--- a/docs/filters.mdx
+++ b/docs/filters.mdx
@@ -102,3 +102,20 @@ melos exec --depends-on="flutter" --depends-on="firebase_core" -- flutter test
 
 Use `--no-depends-on` to filter packages that do not depend on the given
 dependencies.
+
+## --include-dependencies
+
+Takes the filtered list of packages, and expands them to include those packages'
+transitive dependencies (ignoring filters).
+
+```bash
+melos list --scope=some_package --include-dependencies
+```
+
+## --include-dependents
+Takes the filtered list of packages, and expands them to include those packages'
+transitive dependents (ignoring filters).
+
+```bash
+melos list --scope=some_package --include-dependents
+```

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -102,6 +102,12 @@ configuration file if the default is unsuitable.
     - Include only packages that depend on a specific package.
   - `--no-depends-on=<noDependantPackageName>`
     - Include only packages that _don't_ depend on a specific package.
+  - `--include-dependencies`
+    - Expands the filtered list of packages to include those packages'
+      transitive dependencies (ignoring filters).
+  - `--include-dependents`
+      Expands the filtered list of packages to include those packages'
+      transitive dependents (ignoring filters).
 - ♨️ Advanced support for IntelliJ IDEs with automatic creation of
   [run configurations for workspace defined scripts and more](https://melos.invertase.dev/~melos-latest/ide-support)
   on workspace bootstrap.

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -169,6 +169,20 @@ class PackageFilters {
       path: path,
     );
 
+    final includeDependents = assertKeyIsA<bool?>(
+          key: filterOptionIncludeDependents.camelCased,
+          map: yaml,
+          path: path,
+        ) ??
+        false;
+
+    final includeDependencies = assertKeyIsA<bool?>(
+          key: filterOptionIncludeDependencies.camelCased,
+          map: yaml,
+          path: path,
+        ) ??
+        false;
+
     final noPrivateOptionKey = filterOptionNoPrivate.camelCased;
     final excludePrivatePackagesTmp = assertKeyIsA<bool?>(
       key: noPrivateOptionKey,
@@ -227,6 +241,8 @@ class PackageFilters {
       dependsOn: dependsOn,
       noDependsOn: noDependsOn,
       diff: diff,
+      includeDependents: includeDependents,
+      includeDependencies: includeDependencies,
       includePrivatePackages: includePrivatePackages,
       published: published,
       nullSafe: nullSafe,

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -162,6 +162,39 @@ void main() {
           ),
         );
       });
+
+      test('can decode packageFilters values', () {
+        expect(
+          VersionCommandConfigs.fromYaml(
+            const {
+              'changelogs': [
+                {
+                  'path': 'FOO_CHANGELOG.md',
+                  'packageFilters': {
+                    'flutter': true,
+                    'includeDependencies': true,
+                    'includeDependents': true,
+                  },
+                }
+              ],
+            },
+            workspacePath: '.',
+          ),
+          VersionCommandConfigs(
+            aggregateChangelogs: [
+              AggregateChangelogConfig.workspace(),
+              AggregateChangelogConfig(
+                path: 'FOO_CHANGELOG.md',
+                packageFilters: PackageFilters(
+                  flutter: true,
+                  includeDependencies: true,
+                  includeDependents: true,
+                ),
+              ),
+            ],
+          ),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Description

I noticed that [the filters documentation](https://melos.invertase.dev/filters) was missing the information about `--include-dependencies` and `--include-dependents` options that were implemented in https://github.com/invertase/melos/pull/83, so it is added in this PR. In addition to that, I made it possible to provide these options in the `packageFilters` yaml configuration.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
