### PR TITLE
docs: fix misalignment in readme

### DIFF
--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -106,7 +106,7 @@ configuration file if the default is unsuitable.
     - Expands the filtered list of packages to include those packages'
       transitive dependencies (ignoring filters).
   - `--include-dependents`
-      Expands the filtered list of packages to include those packages'
+    - Expands the filtered list of packages to include those packages'
       transitive dependents (ignoring filters).
 - ♨️ Advanced support for IntelliJ IDEs with automatic creation of
   [run configurations for workspace defined scripts and more](https://melos.invertase.dev/~melos-latest/ide-support)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

It fixes the tiny misalignment in the Readme file I made [in the previous PR](https://github.com/invertase/melos/pull/698).

![image](https://github.com/invertase/melos/assets/8143332/7f806bd4-533b-4f23-8a23-58b60dc6afd0)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
