### PR TITLE
feat: implement reversed-filter-group-priority option

### DIFF
--- a/docs/filters.mdx
+++ b/docs/filters.mdx
@@ -5,9 +5,21 @@ description: Learn more about all the package filtering flags in Melos.
 
 # Filtering Packages
 
-Each Melos command can be used alongside the following global filters:
+Each Melos command can be used alongside the following global filters.
 
-## --no-private
+The filters are divided into 2 priority groups. The priority determines the
+order of their application. The grouping has been introduced with backward
+compatibility in mind. It is possible to reverse the order of the priority
+groups to achive different filtering result.
+
+## --reversed-filter-group-priority
+Reverses the priority of filtering groups. Useful for applying diff-based
+filtering first, allowing the filters from the other group to further narrow
+down the packages.
+
+## 1st Priority Group
+
+### --no-private
 
 Exclude private packages (`publish_to: none`). They are included by default.
 
@@ -15,7 +27,7 @@ Exclude private packages (`publish_to: none`). They are included by default.
 melos bootstrap --no-private
 ```
 
-## --published
+### --published
 
 Filter packages where the current local package version exists on pub.dev.
 
@@ -26,7 +38,7 @@ melos bootstrap --published
 Use `--no-published` to filter packages that have not had their current version
 published yet.
 
-## --scope
+### --scope
 
 Include only packages with names matching the given glob. This option can be
 repeated.
@@ -36,7 +48,7 @@ repeated.
 melos exec --scope="*example*" -- flutter build ios
 ```
 
-## --ignore
+### --ignore
 
 Exclude packages with names matching the given glob. This option can be
 repeated.
@@ -46,7 +58,48 @@ repeated.
 melos exec --ignore="*internal*" -- flutter build ios
 ```
 
-## --diff
+### --dir-exists
+
+Include only packages where a specific directory exists inside the package.
+
+```bash
+# Only bootstrap packages with an example directory
+melos bootstrap --dir-exists="example"
+```
+
+### --file-exists
+
+Include only packages where a specific file exists in the package.
+
+```bash
+# Only bootstrap packages with an README.md file
+melos bootstrap --file-exists="README.md"
+```
+
+### --flutter
+
+Filter packages where the package depends on the Flutter SDK.
+
+```bash
+melos exec --flutter -- flutter test
+```
+
+Use `--no-flutter` to filter packages that do not depend on the Flutter SDK.
+
+### --depends-on
+
+Include only packages that depend on specific dependencies.
+
+```bash
+melos exec --depends-on="flutter" --depends-on="firebase_core" -- flutter test
+```
+
+Use `--no-depends-on` to filter packages that do not depend on the given
+dependencies.
+
+## 2nd Priority Group
+
+### --diff
 
 Filter packages based on whether there were changes between a commit and the
 current HEAD or within a range of commits.
@@ -62,48 +115,14 @@ melos exec --diff=<commit hash> -- flutter build ios
 # Run `flutter build ios` on all packages that are different between remote
 # `main` branch and HEAD.
 melos exec --diff=origin/main...HEAD -- flutter build ios
+
+# Find all packages that are different between remote `main` branch and HEAD,
+# add their dependents to the list, filter out packages without `test`
+# directory and run `flutter test` on them.
+melos exec --diff=origin/main...HEAD --include-dependents --reversed-filter-group-priority --dir-exists="test" -- flutter test
 ```
 
-## --dir-exists
-
-Include only packages where a specific directory exists inside the package.
-
-```bash
-# Only bootstrap packages with an example directory
-melos bootstrap --dir-exists="example"
-```
-
-## --file-exists
-
-Include only packages where a specific file exists in the package.
-
-```bash
-# Only bootstrap packages with an README.md file
-melos bootstrap --file-exists="README.md"
-```
-
-## --flutter
-
-Filter packages where the package depends on the Flutter SDK.
-
-```bash
-melos exec --flutter -- flutter test
-```
-
-Use `--no-flutter` to filter packages that do not depend on the Flutter SDK.
-
-## --depends-on
-
-Include only packages that depend on specific dependencies.
-
-```bash
-melos exec --depends-on="flutter" --depends-on="firebase_core" -- flutter test
-```
-
-Use `--no-depends-on` to filter packages that do not depend on the given
-dependencies.
-
-## --include-dependencies
+### --include-dependencies
 
 Takes the filtered list of packages, and expands them to include those packages'
 transitive dependencies (ignoring filters).
@@ -112,7 +131,7 @@ transitive dependencies (ignoring filters).
 melos list --scope=some_package --include-dependencies
 ```
 
-## --include-dependents
+### --include-dependents
 Takes the filtered list of packages, and expands them to include those packages'
 transitive dependents (ignoring filters).
 

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -42,7 +42,8 @@ abstract class MelosCommand extends Command<void> {
     argParser.addFlag(
       filterOptionPrivate,
       help: 'Whether to include or exclude packages with `publish_to: "none"`. '
-          'By default, the filter has no effect.',
+          'By default, the filter has no effect.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
       defaultsTo: null,
     );
 
@@ -51,7 +52,8 @@ abstract class MelosCommand extends Command<void> {
       defaultsTo: null,
       help: 'Filter packages where the current local package version exists on '
           'pub.dev. Or "-no-published" to filter packages that have not had '
-          'their current version published yet.',
+          'their current version published yet.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addFlag(
@@ -60,7 +62,8 @@ abstract class MelosCommand extends Command<void> {
       help:
           'Filter packages where the current local version uses a "nullsafety" '
           'prerelease preid. Or "-no-nullsafety" to filter packages where '
-          'their current version does not have a "nullsafety" preid.',
+          'their current version does not have a "nullsafety" preid.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addFlag(
@@ -68,44 +71,39 @@ abstract class MelosCommand extends Command<void> {
       defaultsTo: null,
       help: 'Filter packages where the package depends on the Flutter SDK. Or '
           '"-no-flutter" to filter packages that do not depend on the Flutter '
-          'SDK.',
+          'SDK.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addMultiOption(
       filterOptionScope,
       valueHelp: 'glob',
       help: 'Include only packages with names matching the given glob. This '
-          'option can be repeated.',
+          'option can be repeated.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addMultiOption(
       filterOptionIgnore,
       valueHelp: 'glob',
       help: 'Exclude packages with names matching the given glob. This option '
-          'can be repeated.',
-    );
-
-    argParser.addOption(
-      filterOptionDiff,
-      valueHelp: 'ref',
-      help: 'Filter packages based on whether there were changes between a '
-          'commit and the current HEAD or within a range of commits. A range '
-          'of commits can be specified using the git short hand syntax '
-          '`<start-commit>..<end-commit>` and `<start-commit>...<end-commit>`',
+          'can be repeated.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addMultiOption(
       filterOptionDirExists,
       valueHelp: 'dirRelativeToPackageRoot',
       help: 'Include only packages where a specific directory exists inside '
-          'the package.',
+          'the package.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addMultiOption(
       filterOptionFileExists,
       valueHelp: 'fileRelativeToPackageRoot',
-      help:
-          'Include only packages where a specific file exists in the package.',
+      help: 'Include only packages where a specific file exists in the package.'
+          ' ${FilterGroup.belongsToFirstPriorityGroupFilterDescription}',
     );
 
     argParser.addMultiOption(
@@ -122,20 +120,37 @@ abstract class MelosCommand extends Command<void> {
           'This option can be repeated.',
     );
 
+    argParser.addOption(
+      filterOptionDiff,
+      valueHelp: 'ref',
+      help: 'Filter packages based on whether there were changes between a '
+          'commit and the current HEAD or within a range of commits. A range '
+          'of commits can be specified using the git short hand syntax '
+          '`<start-commit>..<end-commit>` and `<start-commit>...<end-commit>`.'
+          ' ${FilterGroup.belongsToSecondPriorityGroupFilterDescription}',
+    );
+
     argParser.addFlag(
       filterOptionIncludeDependents,
       negatable: false,
       help: 'Include all transitive dependents for each package that matches '
-          'the other filters. The included packages skip --ignore and '
-          '--diff checks.',
+          'the other filters.'
+          ' ${FilterGroup.belongsToSecondPriorityGroupFilterDescription}',
     );
 
     argParser.addFlag(
       filterOptionIncludeDependencies,
       negatable: false,
       help: 'Include all transitive dependencies for each package that '
-          'matches the other filters. The included packages skip --ignore '
-          'and --diff checks.',
+          'matches the other filters.'
+          ' ${FilterGroup.belongsToSecondPriorityGroupFilterDescription}',
+    );
+
+    argParser.addFlag(
+      filterOptionReversedFilterGroupPriority,
+      negatable: false,
+      help: 'Filters are divided into several groups based on their priority '
+          'of execution. This flag reverses the priority of these groups.',
     );
   }
 
@@ -172,6 +187,8 @@ abstract class MelosCommand extends Command<void> {
       noDependsOn: argResults![filterOptionNoDependsOn] as List<String>? ?? [],
       includeDependents: argResults![filterOptionIncludeDependents] as bool,
       includeDependencies: argResults![filterOptionIncludeDependencies] as bool,
+      reversedFilterGroupPriority:
+          argResults![filterOptionReversedFilterGroupPriority] as bool,
     );
   }
 }

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -39,6 +39,8 @@ const filterOptionDependsOn = 'depends-on';
 const filterOptionNoDependsOn = 'no-depends-on';
 const filterOptionIncludeDependents = 'include-dependents';
 const filterOptionIncludeDependencies = 'include-dependencies';
+const filterOptionReversedFilterGroupPriority =
+    'reversed-filter-group-priority';
 
 const publishOptionDryRun = 'dry-run';
 const publishOptionNoDryRun = 'no-dry-run';

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -174,6 +174,7 @@ void main() {
                     'flutter': true,
                     'includeDependencies': true,
                     'includeDependents': true,
+                    'reversedFilterGroupPriority': true,
                   },
                 }
               ],
@@ -189,6 +190,7 @@ void main() {
                   flutter: true,
                   includeDependencies: true,
                   includeDependents: true,
+                  reversedFilterGroupPriority: true,
                 ),
               ),
             ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR adds a new filtering option that implements the problem/desired behavior described in [this issue](https://github.com/invertase/melos/issues/675).

The implementation is backward compatible, so the default filtering behavior should stay as it is.

Ideally, I'd love to have the possibility to prioritize filters based on the order of their input, but it seems to me that would require way more changes, so this is the simpler trade-off solution I have come up with so far.

---

The alternative approach I ended up implementing in the CI workflow of our big project implies setting the global `MELOS_PACKAGES` scope filter with the values from `melos list --diff=origin/main...HEAD --include-dependents`. The approach is described in https://itnext.io/flutter-selective-ci-checks-2d79ffbd26e5 article. Hopefully, it is helpful for other looking for optimization in their CI pipelines!

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
