### PR TITLE
fix: tryParse line-length to int when it's not already an integer

### DIFF
--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -38,6 +38,7 @@ class FormatCommand extends MelosCommand {
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final lineLength = switch (argResults?['line-length']) {
       final int length => length,
+      final String length => int.tryParse(length),
       _ => null,
     };
 

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -263,5 +263,39 @@ $ melos format
         skip: 'Differ at offset 1261',
       );
     });
+
+    test('should run format with --line-length flag', () async {
+      const code = '''
+void main() {
+  print('a very long line that should be wrapped with default dart settings but we use a longer line length');
+}
+''';
+
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        code,
+      );
+
+      final result = await Process.run(
+        'melos',
+        ['format', '--set-exit-if-changed', '--line-length', '150'],
+        workingDirectory: workspaceDir.path,
+        runInShell: Platform.isWindows,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+      );
+
+      expect(result.exitCode, equals(0));
+
+      expect(
+        result.stdout,
+        contains(
+          r'''
+$ melos format
+  └> dart format --set-exit-if-changed --line-length 150 .
+     └> SUCCESS''',
+        ),
+      );
+    });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The flag `--line-length` was added, but it seems like it doesn't work as ArgParser doesn't seem to transform this param to int by default. This fix takes the `String` argument and tries parsing it to an `int`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
