### PR TITLE
feat: add config for the format command

### DIFF
--- a/packages/melos/lib/src/command_configs/command_configs.dart
+++ b/packages/melos/lib/src/command_configs/command_configs.dart
@@ -4,6 +4,7 @@ import '../common/utils.dart';
 import '../common/validation.dart';
 import 'bootstrap.dart';
 import 'clean.dart';
+import 'format.dart';
 import 'publish.dart';
 import 'version.dart';
 
@@ -19,6 +20,7 @@ class CommandConfigs {
     this.clean = CleanCommandConfigs.empty,
     this.version = VersionCommandConfigs.empty,
     this.publish = PublishCommandConfigs.empty,
+    this.format = FormatCommandConfigs.empty,
   });
 
   factory CommandConfigs.fromYaml(
@@ -50,6 +52,12 @@ class CommandConfigs {
       path: 'command',
     );
 
+    final formatMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'format',
+      map: yaml,
+      path: 'command',
+    );
+
     return CommandConfigs(
       bootstrap: BootstrapCommandConfigs.fromYaml(
         bootstrapMap ?? const {},
@@ -69,6 +77,7 @@ class CommandConfigs {
         workspacePath: workspacePath,
         repositoryIsConfigured: repositoryIsConfigured,
       ),
+      format: FormatCommandConfigs.fromYaml(formatMap ?? const {}),
     );
   }
 
@@ -78,6 +87,7 @@ class CommandConfigs {
   final CleanCommandConfigs clean;
   final VersionCommandConfigs version;
   final PublishCommandConfigs publish;
+  final FormatCommandConfigs format;
 
   Map<String, Object?> toJson() {
     return {
@@ -85,6 +95,7 @@ class CommandConfigs {
       'clean': clean.toJson(),
       'version': version.toJson(),
       'publish': publish.toJson(),
+      'format': format.toJson(),
     };
   }
 
@@ -95,7 +106,8 @@ class CommandConfigs {
       other.bootstrap == bootstrap &&
       other.clean == clean &&
       other.version == version &&
-      other.publish == publish;
+      other.publish == publish &&
+      other.format == format;
 
   @override
   int get hashCode => Object.hash(
@@ -104,6 +116,7 @@ class CommandConfigs {
         clean,
         version,
         publish,
+        format,
       );
 
   @override
@@ -114,6 +127,7 @@ CommandConfigs(
   clean: ${clean.toString().indent('  ')},
   version: ${version.toString().indent('  ')},
   publish: ${publish.toString().indent('  ')},
+  format: ${format.toString().indent('  ')},
 )
 ''';
   }

--- a/packages/melos/lib/src/command_configs/format.dart
+++ b/packages/melos/lib/src/command_configs/format.dart
@@ -1,0 +1,69 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+
+/// Configurations for `melos format`.
+@immutable
+class FormatCommandConfigs {
+  const FormatCommandConfigs({
+    this.setExitIfChanged,
+    this.lineLength,
+  });
+
+  factory FormatCommandConfigs.fromYaml(
+    Map<Object?, Object?> yaml,
+  ) {
+    final setExitIfChanged = assertKeyIsA<bool?>(
+      key: 'setExitIfChanged',
+      map: yaml,
+      path: 'command/format',
+    );
+
+    final lineLength = assertKeyIsA<int?>(
+      key: 'lineLength',
+      map: yaml,
+      path: 'command/format',
+    );
+
+    return FormatCommandConfigs(
+      setExitIfChanged: setExitIfChanged,
+      lineLength: lineLength,
+    );
+  }
+
+  static const FormatCommandConfigs empty = FormatCommandConfigs();
+
+  /// Declares if `--set-exit-if-changed` flag is passed
+  /// to the `dart format` command.
+  final bool? setExitIfChanged;
+
+  /// The `--line-length` passed to the `dart format` command.
+  final int? lineLength;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (lineLength != null) 'lineLength': lineLength,
+      if (setExitIfChanged != null) 'setExitIfChanged': setExitIfChanged,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is FormatCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.setExitIfChanged == setExitIfChanged &&
+      other.lineLength == lineLength;
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ setExitIfChanged.hashCode ^ lineLength.hashCode;
+
+  @override
+  String toString() {
+    return '''
+FormatCommandConfigs(
+  setExitIfChanged: $setExitIfChanged,
+  lineLength: $lineLength,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -8,6 +8,7 @@ class FormatCommand extends MelosCommand {
     argParser.addFlag(
       'set-exit-if-changed',
       negatable: false,
+      defaultsTo: null,
       help: 'Return exit code 1 if there are any formatting changes.',
     );
     argParser.addOption(
@@ -33,7 +34,7 @@ class FormatCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final setExitIfChanged = argResults?['set-exit-if-changed'] as bool;
+    final setExitIfChanged = argResults?['set-exit-if-changed'] as bool?;
     final output = argResults?['output'] as String?;
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final lineLength = switch (argResults?['line-length']) {

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -5,7 +5,7 @@ mixin _FormatMixin on _Melos {
     GlobalOptions? global,
     PackageFilters? packageFilters,
     int concurrency = 1,
-    bool setExitIfChanged = false,
+    bool? setExitIfChanged,
     String? output,
     int? lineLength,
   }) async {
@@ -27,7 +27,7 @@ mixin _FormatMixin on _Melos {
     MelosWorkspace workspace,
     Iterable<Package> packages, {
     required int concurrency,
-    required bool setExitIfChanged,
+    bool? setExitIfChanged,
     String? output,
     int? lineLength,
   }) async {
@@ -36,7 +36,7 @@ mixin _FormatMixin on _Melos {
     final formatArgs = [
       'dart',
       'format',
-      if (setExitIfChanged) '--set-exit-if-changed',
+      if (setExitIfChanged ?? false) '--set-exit-if-changed',
       if (output != null) '--output $output',
       if (lineLength != null) '--line-length $lineLength',
       '.',

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -31,6 +31,11 @@ mixin _FormatMixin on _Melos {
     String? output,
     int? lineLength,
   }) async {
+    final formatConfig = workspace.config.commands.format;
+
+    setExitIfChanged = setExitIfChanged ?? formatConfig.setExitIfChanged;
+    lineLength = lineLength ?? formatConfig.lineLength;
+
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
     final formatArgs = [


### PR DESCRIPTION
## Description

Added a configuration for the `melos format` command to manage `lineLength` and `setExitIfChanged` using the config.

CLI input will overwrite the config values, but if config states `true` for `setExitIfChanged` it cannot be overwritten b/c `--set-exit-if-changed` is not negatable.

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
