### PR TITLE
fix: `updateDependentsVersions` disabled with packages still mentioned in changelogs

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -265,6 +265,11 @@ mixin _VersionMixin on _RunMixin {
     );
 
     for (final package in dependentPackagesToVersion) {
+      // If updateDependentsVersions is set to false, we do not perform updates.
+      if (!updateDependentsVersions) {
+        continue;
+      }
+
       final packageHasPendingUpdate = pendingPackageUpdates.any(
         (packageToVersion) => packageToVersion.package.name == package.name,
       );
@@ -309,15 +314,10 @@ mixin _VersionMixin on _RunMixin {
       return;
     }
 
-    final pendingPackageUpdatesCount = updateDependentsVersions
-        ? pendingPackageUpdates.length
-        : pendingPackageUpdates
-            .where((update) => update.reason != PackageUpdateReason.dependency)
-            .length;
     logger.log(
       AnsiStyles.magentaBright(
         'The following '
-        '${packageNameStyle(pendingPackageUpdatesCount.toString())} '
+        '${packageNameStyle(pendingPackageUpdates.length.toString())} '
         'packages will be updated:\n',
       ),
     );
@@ -704,7 +704,6 @@ mixin _VersionMixin on _RunMixin {
             workspace,
             changelogConfig,
             pendingPackageUpdates,
-            updateDependentsVersions: updateDependentsVersions,
           );
         }),
       );
@@ -714,9 +713,8 @@ mixin _VersionMixin on _RunMixin {
   Future<void> _writeAggregateChangelog(
     MelosWorkspace workspace,
     AggregateChangelogConfig config,
-    List<MelosPendingPackageUpdate> pendingPackageUpdates, {
-    required bool updateDependentsVersions,
-  }) async {
+    List<MelosPendingPackageUpdate> pendingPackageUpdates,
+  ) async {
     final today = DateTime.now();
     final dateSlug = [
       today.year.toString(),
@@ -738,7 +736,6 @@ mixin _VersionMixin on _RunMixin {
       pendingPackageUpdates,
       logger,
       config.path,
-      updateDependentsVersions: updateDependentsVersions,
     );
 
     await changelog.write();

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -309,10 +309,15 @@ mixin _VersionMixin on _RunMixin {
       return;
     }
 
+    final pendingPackageUpdatesCount = updateDependentsVersions
+        ? pendingPackageUpdates.length
+        : pendingPackageUpdates
+            .where((update) => update.reason != PackageUpdateReason.dependency)
+            .length;
     logger.log(
       AnsiStyles.magentaBright(
         'The following '
-        '${packageNameStyle(pendingPackageUpdates.length.toString())} '
+        '${packageNameStyle(pendingPackageUpdatesCount.toString())} '
         'packages will be updated:\n',
       ),
     );
@@ -699,6 +704,7 @@ mixin _VersionMixin on _RunMixin {
             workspace,
             changelogConfig,
             pendingPackageUpdates,
+            updateDependentsVersions: updateDependentsVersions,
           );
         }),
       );
@@ -708,8 +714,9 @@ mixin _VersionMixin on _RunMixin {
   Future<void> _writeAggregateChangelog(
     MelosWorkspace workspace,
     AggregateChangelogConfig config,
-    List<MelosPendingPackageUpdate> pendingPackageUpdates,
-  ) async {
+    List<MelosPendingPackageUpdate> pendingPackageUpdates, {
+    required bool updateDependentsVersions,
+  }) async {
     final today = DateTime.now();
     final dateSlug = [
       today.year.toString(),
@@ -731,6 +738,7 @@ mixin _VersionMixin on _RunMixin {
       pendingPackageUpdates,
       logger,
       config.path,
+      updateDependentsVersions: updateDependentsVersions,
     );
 
     await changelog.write();

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -267,7 +267,7 @@ mixin _VersionMixin on _RunMixin {
     for (final package in dependentPackagesToVersion) {
       // If updateDependentsVersions is set to false, we do not perform updates.
       if (!updateDependentsVersions) {
-        continue;
+        break;
       }
 
       final packageHasPendingUpdate = pendingPackageUpdates.any(

--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -14,9 +14,8 @@ class AggregateChangelog {
     this.newEntryTitle,
     this.pendingPackageUpdates,
     this.logger,
-    this.path, {
-    required this.updateDependentsVersions,
-  });
+    this.path,
+  );
 
   final MelosWorkspace workspace;
   final String? description;
@@ -24,7 +23,6 @@ class AggregateChangelog {
   final MelosLogger logger;
   final List<MelosPendingPackageUpdate> pendingPackageUpdates;
   final String path;
-  final bool updateDependentsVersions;
 
   String get _changelogFileHeader => '''
 # Change Log
@@ -46,21 +44,14 @@ ${description?.withoutTrailing('\n') ?? ''}
 
   String get markdown {
     final body = StringBuffer();
-    final dependencyOnlyPackages = updateDependentsVersions
-        ? pendingPackageUpdates
-            .where((update) => update.reason == PackageUpdateReason.dependency)
-        : <MelosPendingPackageUpdate>[];
+    final dependencyOnlyPackages = pendingPackageUpdates
+        .where((update) => update.reason == PackageUpdateReason.dependency);
     final graduatedPackages = pendingPackageUpdates
         .where((update) => update.reason == PackageUpdateReason.graduate);
     final packagesWithBreakingChanges =
         pendingPackageUpdates.where((update) => update.hasBreakingChanges);
-    final packagesWithOtherChanges = pendingPackageUpdates.where((update) {
-      if (update.reason == PackageUpdateReason.dependency &&
-          !updateDependentsVersions) {
-        return false;
-      }
-      return !update.hasBreakingChanges;
-    });
+    final packagesWithOtherChanges =
+        pendingPackageUpdates.where((update) => !update.hasBreakingChanges);
 
     body.writeln(_changelogFileHeader);
     body.writeln('## $newEntryTitle');

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:ansi_styles/ansi_styles.dart';
+import 'package:melos/melos.dart';
+import 'package:melos/src/command_configs/command_configs.dart';
+import 'package:melos/src/common/glob.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec/pubspec.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  late TestLogger logger;
+
+  setUp(() async {
+    logger = TestLogger();
+  });
+
+  group('version', () {
+    // Regression test for: https://github.com/invertase/melos/issues/531
+    test('--no-dependent-versions does not modify workspace changelog',
+        () async {
+      MelosWorkspaceConfig workspaceConfig(String path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              version: VersionCommandConfigs(
+                fetchTags: false,
+              ),
+            ),
+          );
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: workspaceConfig,
+      );
+      await createProject(
+        workspaceDir,
+        PubSpec(name: 'a', version: Version(0, 0, 1)),
+      );
+      await createProject(
+        workspaceDir,
+        PubSpec(
+          name: 'b',
+          version: Version(0, 0, 1),
+          dependencies: {
+            'a': HostedReference(VersionConstraint.any),
+          },
+        ),
+      );
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(config: config, logger: logger);
+
+      await melos.bootstrap();
+      await melos.version(
+        updateDependentsConstraints: false,
+        updateDependentsVersions: false,
+        versionPrivatePackages: true,
+        gitCommit: false,
+        gitTag: false,
+        force: true,
+        manualVersions: {
+          'a': ManualVersionChange(Version(0, 1, 0)),
+        },
+      );
+
+      final workspaceChangelogContent = File(
+        p.join(workspaceDir.path, 'CHANGELOG.md'),
+      ).readAsStringSync();
+
+      final loggerOutput = logger.output;
+      expect(
+        loggerOutput,
+        contains(
+          AnsiStyles.strip('''
+The following 1 packages will be updated:
+'''),
+        ),
+      );
+
+      expect(
+        workspaceChangelogContent,
+        isNot(
+          contains(
+            AnsiStyles.strip('''
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `b` - `v0.0.1+1`
+'''),
+          ),
+        ),
+      );
+      expect(
+        workspaceChangelogContent,
+        contains(
+          AnsiStyles.strip('''
+#### `a` - `v0.1.0`
+
+ - Bump "a" to `0.1.0`.
+'''),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Bug description: We bumped into this while having automated release to private hosting. Consider package B has dependency on A. If A was updated and we do not want do update constraint in B nor its version (we don't want due excessive publishing because we have fully automated release process), it was still mentioned in `melos version` log that B is getting bumped and also in the workspace changelog.

Fixes #531 - But I think it should check `updateDependentsVersions` and not `updateDependentsConstraints` like in the issue. Because if we update constraint it should not reflect to changelog, right ?

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
