### PR TITLE
feat: 'auto' option for runPubGetInParallel

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -183,7 +183,7 @@ dependencyOverridePaths:
 
 Whether to run `pub get` in parallel during bootstrapping.
 
-The default is `true`.
+The default is `auto`, which fallbacks to `false` if the machine is a CI instance.
 
 ### runPubGetOffline
 

--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -259,7 +259,7 @@ enum ParallelPubGetMode {
       default:
         throw ArgumentError.value(
           value,
-          'name',
+          'value',
           'Invalid value for ParallelPubGetMode',
         );
     }

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -109,6 +109,16 @@ mixin _BootstrapMixin on _CleanMixin {
     required bool noExample,
   }) async {
     final filteredPackages = workspace.filteredPackages.values;
+    final isCI = utils.isCI;
+
+    bool parallelism;
+    if (workspace.config.commands.bootstrap.parallelPubGetMode ==
+        ParallelPubGetMode.auto) {
+      parallelism = !isCI;
+    } else {
+      parallelism = workspace.config.commands.bootstrap.parallelPubGetMode ==
+          ParallelPubGetMode.enabled;
+    }
 
     await Stream.fromIterable(filteredPackages).parallel(
       (package) async {
@@ -143,8 +153,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
         bootstrappedPackages.forEach(_logBootstrapSuccess);
       },
-      parallelism:
-          workspace.config.commands.bootstrap.runPubGetInParallel ? null : 1,
+      parallelism: parallelism ? null : 1,
     ).drain<void>();
   }
 

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -112,12 +112,13 @@ mixin _BootstrapMixin on _CleanMixin {
     final isCI = utils.isCI;
 
     bool parallelism;
-    if (workspace.config.commands.bootstrap.parallelPubGetMode ==
-        ParallelPubGetMode.auto) {
-      parallelism = !isCI;
-    } else {
-      parallelism = workspace.config.commands.bootstrap.parallelPubGetMode ==
-          ParallelPubGetMode.enabled;
+    switch (workspace.config.commands.bootstrap.parallelPubGetMode) {
+      case ParallelPubGetMode.auto:
+        parallelism = !isCI;
+      case ParallelPubGetMode.enabled:
+        parallelism = true;
+      case ParallelPubGetMode.disabled:
+        parallelism = false;
     }
 
     await Stream.fromIterable(filteredPackages).parallel(

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -14,7 +14,7 @@ void main() {
       // ignore: use_named_constants
       const value = BootstrapCommandConfigs();
 
-      expect(value.runPubGetInParallel, true);
+      expect(value.parallelPubGetMode, ParallelPubGetMode.auto);
     });
 
     group('fromYaml', () {
@@ -49,7 +49,7 @@ void main() {
             workspacePath: '.',
           ),
           BootstrapCommandConfigs(
-            runPubGetInParallel: false,
+            parallelPubGetMode: ParallelPubGetMode.disabled,
             runPubGetOffline: true,
             enforceLockfile: true,
             dependencyOverridePaths: [
@@ -243,7 +243,7 @@ void main() {
             // ignore: avoid_redundant_argument_values, use_named_constants
             bootstrap: BootstrapCommandConfigs(
               // ignore: avoid_redundant_argument_values
-              runPubGetInParallel: true,
+              parallelPubGetMode: ParallelPubGetMode.enabled,
             ),
           ),
         );


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds the new value of 'auto' to `runPubGetInParallel`, which is now default and will only run pub get sequentially if it's being run on a CI instance.

Since the current variable type is of `bool` for this variable, I had to add some code to handle both the old and new possible data types for parsing. Any alternative ideas for this are more than welcome.

PS: thanks for making such an awesome tool!

Closes #546 

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
