### PR TITLE
feat: hooks for predefined command

### DIFF
--- a/packages/melos/lib/src/command_configs/analyze.dart
+++ b/packages/melos/lib/src/command_configs/analyze.dart
@@ -1,0 +1,58 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+import '../lifecycle_hooks/lifecycle_hooks.dart';
+
+/// Configurations for `melos format`.
+@immutable
+class AnalyzeCommandConfigs {
+  const AnalyzeCommandConfigs({
+    this.hooks = LifecycleHooks.empty,
+  });
+
+  factory AnalyzeCommandConfigs.fromYaml(
+    Map<Object?, Object?> yaml, {
+    required String workspacePath,
+  }) {
+    final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'hooks',
+      map: yaml,
+      path: 'command/analyze',
+    );
+    final hooks = hooksMap != null
+        ? LifecycleHooks.fromYaml(hooksMap, workspacePath: workspacePath)
+        : LifecycleHooks.empty;
+
+    return AnalyzeCommandConfigs(
+      hooks: hooks,
+    );
+  }
+
+  static const AnalyzeCommandConfigs empty = AnalyzeCommandConfigs();
+
+  /// Lifecycle hooks for this command.
+  final LifecycleHooks hooks;
+
+  Map<String, Object?> toJson() {
+    return {
+      'hooks': hooks.toJson(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnalyzeCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.hooks == hooks;
+
+  @override
+  int get hashCode => runtimeType.hashCode ^ hooks.hashCode;
+
+  @override
+  String toString() {
+    return '''
+AnalyzeCommandConfigs(
+  hooks: $hooks,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/command_configs.dart
+++ b/packages/melos/lib/src/command_configs/command_configs.dart
@@ -77,7 +77,10 @@ class CommandConfigs {
         workspacePath: workspacePath,
         repositoryIsConfigured: repositoryIsConfigured,
       ),
-      format: FormatCommandConfigs.fromYaml(formatMap ?? const {}),
+      format: FormatCommandConfigs.fromYaml(
+        formatMap ?? const {},
+        workspacePath: workspacePath,
+      ),
     );
   }
 

--- a/packages/melos/lib/src/command_configs/command_configs.dart
+++ b/packages/melos/lib/src/command_configs/command_configs.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/utils.dart';
 import '../common/validation.dart';
+import 'analyze.dart';
 import 'bootstrap.dart';
 import 'clean.dart';
 import 'format.dart';
@@ -21,6 +22,7 @@ class CommandConfigs {
     this.version = VersionCommandConfigs.empty,
     this.publish = PublishCommandConfigs.empty,
     this.format = FormatCommandConfigs.empty,
+    this.analyze = AnalyzeCommandConfigs.empty,
   });
 
   factory CommandConfigs.fromYaml(
@@ -58,6 +60,12 @@ class CommandConfigs {
       path: 'command',
     );
 
+    final analyzeMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'analyze',
+      map: yaml,
+      path: 'command',
+    );
+
     return CommandConfigs(
       bootstrap: BootstrapCommandConfigs.fromYaml(
         bootstrapMap ?? const {},
@@ -81,6 +89,10 @@ class CommandConfigs {
         formatMap ?? const {},
         workspacePath: workspacePath,
       ),
+      analyze: AnalyzeCommandConfigs.fromYaml(
+        analyzeMap ?? const {},
+        workspacePath: workspacePath,
+      ),
     );
   }
 
@@ -91,6 +103,7 @@ class CommandConfigs {
   final VersionCommandConfigs version;
   final PublishCommandConfigs publish;
   final FormatCommandConfigs format;
+  final AnalyzeCommandConfigs analyze;
 
   Map<String, Object?> toJson() {
     return {
@@ -99,6 +112,7 @@ class CommandConfigs {
       'version': version.toJson(),
       'publish': publish.toJson(),
       'format': format.toJson(),
+      'analyze': analyze.toJson(),
     };
   }
 
@@ -110,7 +124,8 @@ class CommandConfigs {
       other.clean == clean &&
       other.version == version &&
       other.publish == publish &&
-      other.format == format;
+      other.format == format &&
+      other.analyze == analyze;
 
   @override
   int get hashCode => Object.hash(
@@ -120,6 +135,7 @@ class CommandConfigs {
         version,
         publish,
         format,
+        analyze,
       );
 
   @override
@@ -131,6 +147,7 @@ CommandConfigs(
   version: ${version.toString().indent('  ')},
   publish: ${publish.toString().indent('  ')},
   format: ${format.toString().indent('  ')},
+  analyze: ${analyze.toString().indent('  ')},
 )
 ''';
   }

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -12,12 +12,18 @@ mixin _AnalyzeMixin on _Melos {
         await createWorkspace(global: global, packageFilters: packageFilters);
     final packages = workspace.filteredPackages.values;
 
-    await _analyzeForAllPackages(
+    return _runLifecycle(
       workspace,
-      packages,
-      fatalInfos: fatalInfos,
-      fatalWarnings: fatalWarnings,
-      concurrency: concurrency,
+      CommandWithLifecycle.analyze,
+      () async {
+        await _analyzeForAllPackages(
+          workspace,
+          packages,
+          fatalInfos: fatalInfos,
+          fatalWarnings: fatalWarnings,
+          concurrency: concurrency,
+        );
+      },
     );
   }
 

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -13,13 +13,19 @@ mixin _FormatMixin on _Melos {
         await createWorkspace(global: global, packageFilters: packageFilters);
     final packages = workspace.filteredPackages.values;
 
-    await _formatForAllPackages(
+    return _runLifecycle(
       workspace,
-      packages,
-      concurrency: concurrency,
-      setExitIfChanged: setExitIfChanged,
-      output: output,
-      lineLength: lineLength,
+      CommandWithLifecycle.format,
+      () async {
+        await _formatForAllPackages(
+          workspace,
+          packages,
+          concurrency: concurrency,
+          setExitIfChanged: setExitIfChanged,
+          output: output,
+          lineLength: lineLength,
+        );
+      },
     );
   }
 

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -58,6 +58,7 @@ enum CommandWithLifecycle {
   version,
   publish,
   format,
+  analyze,
 }
 
 class Melos extends _Melos
@@ -185,6 +186,8 @@ extension _ResolveLifecycleHooks on CommandConfigs {
         return publish.hooks;
       case CommandWithLifecycle.format:
         return format.hooks;
+      case CommandWithLifecycle.analyze:
+        return analyze.hooks;
     }
   }
 }

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -42,21 +42,22 @@ import '../scripts.dart';
 import '../workspace.dart';
 import '../workspace_configs.dart';
 
+part 'analyze.dart';
 part 'bootstrap.dart';
 part 'clean.dart';
 part 'exec.dart';
+part 'format.dart';
 part 'list.dart';
 part 'publish.dart';
 part 'run.dart';
 part 'version.dart';
-part 'analyze.dart';
-part 'format.dart';
 
 enum CommandWithLifecycle {
   bootstrap,
   clean,
   version,
   publish,
+  format,
 }
 
 class Melos extends _Melos
@@ -83,6 +84,7 @@ class Melos extends _Melos
 
 abstract class _Melos {
   MelosLogger get logger;
+
   MelosWorkspaceConfig get config;
 
   Future<MelosWorkspace> createWorkspace({
@@ -181,6 +183,8 @@ extension _ResolveLifecycleHooks on CommandConfigs {
         return version.hooks;
       case CommandWithLifecycle.publish:
         return publish.hooks;
+      case CommandWithLifecycle.format:
+        return format.hooks;
     }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Melos versions 5.0.0 and 5.1.0 introduced built-in commands (format and analyze). While I appreciate the efficiency of these new commands, as noted in [this comment](https://github.com/invertase/melos/issues/661#issuecomment-1997126247), remembering them can be challenging. Therefore, I propose adding a hooks feature that allows users to automatically trigger custom commands alongside the built-in format and analyze commands.

Closes #661

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
