### PR TITLE
feat: Allow overriding `enforceLockfile` with `--no-enforce-lockfile`

### DIFF
--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -86,15 +86,18 @@ melos bootstrap --diff="main"
 
 ## Bootstrap flags
 
-- The `--no-example` flag is used to exclude flutter package's example's dependencies (https://github.com/dart-lang/pub/pull/3856)
+- The `--no-example` flag is used to exclude flutter package's example's dependencies
+  (https://github.com/dart-lang/pub/pull/3856)
     - This will run `pub get` with the `--no-example` flag.
 - The `--enforce-lockfile` flag is used to enforce versions from `.lock` files.
     - Ensure .lock files exist, as failure may occur if they're not checked in.
+- The `--no-enforce-lockfile` flag is used to disregard versions from `.lock` files if
+  `enforce-lockfile` is configured in the `melos.yaml` file.
 - The `--skip-linking` flag is used to skip the local linking of workspace packages.
 
 
-In addition to the above flags, the `melos bootstrap` command supports a few different flags that can be defined in
- your `melos.yaml` file.
+In addition to the above flags, the `melos bootstrap` command supports a few different flags that
+can be defined in your `melos.yaml` file.
 
 
 ### Shared dependencies

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -195,11 +195,16 @@ The default is `false`.
 
 ### enforceLockfile
 
-Whether to run `pub get` with the `--enforce-lockfile` option or not, to force getting the versions specified in the `pubspec.lock` file.
+Whether to run `pub get` with the `--enforce-lockfile` option or not, to force getting the versions
+specified in the `pubspec.lock` file.
 
-This is useful in CI environments or when you want to ensure that all environments/machines are using the same package versions.
+This is useful in CI environments or when you want to ensure that all environments/machines are
+using the same package versions.
 
 The default is `false`.
+
+To temporarily override this `melos bootstrap --no-enforce-lockfile / --enforce-lockfile` can be
+used.
 
 ## command/version
 

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -13,9 +13,10 @@ class BootstrapCommand extends MelosCommand {
     );
     argParser.addFlag(
       'enforce-lockfile',
-      negatable: false,
-      help: 'Run pub get with --enforce-lockfile to enforce versions from .lock'
-          ' files, ensure .lockfile exist for all packages.',
+      help: 'Run pub get with --enforce-lockfile to enforce versions from '
+          '.lock files, ensure .lockfile exist for all packages.\n'
+          '--no-enforce-lockfile can be used to temporarily disregard the '
+          'lockfile versions.',
     );
     argParser.addFlag(
       'skip-linking',
@@ -41,7 +42,7 @@ class BootstrapCommand extends MelosCommand {
     return melos.bootstrap(
       global: global,
       packageFilters: parsePackageFilters(config.path),
-      enforceLockfile: argResults?['enforce-lockfile'] as bool? ?? false,
+      enforceLockfile: argResults?['enforce-lockfile'] as bool?,
       noExample: argResults?['no-example'] as bool,
       skipLinking: argResults?['skip-linking'] as bool,
     );

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -5,7 +5,7 @@ mixin _BootstrapMixin on _CleanMixin {
     GlobalOptions? global,
     PackageFilters? packageFilters,
     bool noExample = false,
-    bool enforceLockfile = false,
+    bool? enforceLockfile,
     bool skipLinking = false,
   }) async {
     final workspace =
@@ -21,7 +21,7 @@ mixin _BootstrapMixin on _CleanMixin {
         final enforceLockfileConfigValue =
             workspace.config.commands.bootstrap.enforceLockfile;
         final shouldEnforceLockfile =
-            (enforceLockfileConfigValue || enforceLockfile) && hasLockFile;
+            (enforceLockfile ?? enforceLockfileConfigValue) && hasLockFile;
 
         final pubCommandForLogging = [
           ...pubCommandExecArgs(
@@ -74,7 +74,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
             await _linkPackagesWithPubspecOverrides(
               workspace,
-              enforceLockfile: enforceLockfile,
+              enforceLockfile: shouldEnforceLockfile,
               noExample: noExample,
             );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds the possibility to run `--no-enforce-lockfile` in a command to override the melos.yaml settings.

Fixes: #734 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
