### PR TITLE
fix: Don't deadlock on cycle exec with order dependents

### DIFF
--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -93,8 +93,20 @@ mixin _ExecMixin on _Melos {
     required bool orderDependents,
     Map<String, String> additionalEnvironment = const {},
   }) async {
+    final sortedPackages = packages.toList(growable: false);
+    var hasImpactfulCycles = false;
+
+    if (orderDependents) {
+      // TODO: This is not really the right way to do this. Cyclic dependencies
+      // are handled in a way that is specific for publishing.
+      sortPackagesForPublishing(sortedPackages);
+      hasImpactfulCycles =
+          findCyclicDependenciesInWorkspace(sortedPackages).isNotEmpty;
+    }
+
+    final calculatedConcurrency = hasImpactfulCycles ? 1 : concurrency;
     final failures = <String, int?>{};
-    final pool = Pool(concurrency);
+    final pool = Pool(calculatedConcurrency);
     final execArgsString = execArgs.join(' ');
     final prefixLogs = concurrency != 1 && packages.length != 1;
 
@@ -107,14 +119,6 @@ mixin _ExecMixin on _Melos {
       logger.horizontalLine();
     }
 
-    final sortedPackages = packages.toList(growable: false);
-
-    if (orderDependents) {
-      // TODO: This is not really the right way to do this. Cyclic dependencies
-      // are handled in a way that is specific for publishing.
-      sortPackagesForPublishing(sortedPackages);
-    }
-
     final packageResults = Map.fromEntries(
       packages.map((package) => MapEntry(package.name, Completer<int?>())),
     );
@@ -125,7 +129,7 @@ mixin _ExecMixin on _Melos {
       pool.forEach<Package, void>(sortedPackages, (package) async {
         assert(!(failFast && failures.isNotEmpty));
 
-        if (orderDependents) {
+        if (orderDependents && !hasImpactfulCycles) {
           final dependenciesResults = await Future.wait(
             package.allDependenciesInWorkspace.values
                 .map((package) => packageResults[package.name]?.future)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This change sets the concurrency to 1 when there are cyclic dependencies and you are running `exec` with `--order-dependents`.

Fixes: #610 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
