### PR TITLE
fix: Propagate error code when fail fast is enabled

### DIFF
--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -229,7 +229,7 @@ mixin _ExecMixin on _Melos {
         }
       }
 
-      exitCode = 1;
+      exitCode = failFast ? failures[failures.keys.first]! : 1;
     } else {
       resultLogger.child(successLabel);
     }

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -215,20 +215,20 @@ ${'-' * terminalWidth}
     });
 
     group('fail fast', () {
-      test('propagate error code when fail fast is enabled', () async {
+      test('print error codes correctly', () async {
         final workspaceDir = await createTemporaryWorkspace();
 
-        final a = await createProject(
+        await createProject(
           workspaceDir,
           const PubSpec(name: 'a'),
         );
 
-        final b = await createProject(
+        await createProject(
           workspaceDir,
           const PubSpec(name: 'b'),
         );
 
-        final c = await createProject(
+        await createProject(
           workspaceDir,
           const PubSpec(name: 'c'),
         );
@@ -256,7 +256,7 @@ ${'-' * terminalWidth}
      └> RUNNING (in 3 packages)
 
 ${'-' * terminalWidth}
-e-ERROR: [a]: ls: cannot access \'i_do_surely_not_exist\': No such file or directory
+e-ERROR: [a]: ls: cannot access 'i_do_surely_not_exist': No such file or directory
 e-
 ${'-' * terminalWidth}
 
@@ -270,6 +270,34 @@ ${'-' * terminalWidth}
 ''',
           ),
         );
+      });
+
+      test('propagate error code when fail fast is enabled', () async {
+        final workspaceDir = await createTemporaryWorkspace();
+
+        await createProject(
+          workspaceDir,
+          const PubSpec(name: 'a'),
+        );
+
+        await createProject(
+          workspaceDir,
+          const PubSpec(name: 'b'),
+        );
+
+        await createProject(
+          workspaceDir,
+          const PubSpec(name: 'c'),
+        );
+
+        final result = await Process.run(
+          'melos',
+          ['exec', '--fail-fast', 'ls', 'i_do_surely_not_exist'],
+          workingDirectory: workspaceDir.path,
+          runInShell: true,
+        );
+
+        expect(result.exitCode, equals(2));
       });
     });
 

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -243,7 +243,7 @@ ${'-' * terminalWidth}
         );
 
         await melos.exec(
-          ['ls', 'i_do_surely_not_exist'],
+          ['exit', '2'],
           failFast: true,
         );
 
@@ -252,16 +252,14 @@ ${'-' * terminalWidth}
           ignoringAnsii(
             '''
 \$ melos exec
-  └> ls i_do_surely_not_exist
+  └> exit 2
      └> RUNNING (in 3 packages)
 
 ${'-' * terminalWidth}
-e-ERROR: [a]: ls: cannot access 'i_do_surely_not_exist': No such file or directory
-e-
 ${'-' * terminalWidth}
 
 \$ melos exec
-  └> ls i_do_surely_not_exist
+  └> exit 2
      └> FAILED (in 1 packages)
         └> a (with exit code 2)
      └> CANCELED (in 2 packages)
@@ -292,9 +290,9 @@ ${'-' * terminalWidth}
 
         final result = await Process.run(
           'melos',
-          ['exec', '--fail-fast', 'ls', 'i_do_surely_not_exist'],
+          ['exec', '--fail-fast', 'exit', '2'],
           workingDirectory: workspaceDir.path,
-          runInShell: true,
+          runInShell: Platform.isWindows,
         );
 
         expect(result.exitCode, equals(2));


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When `--fail-fast` is enabled we should propagate the error code.
Fixes: #527 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
