### PR TITLE
chore: Add the `steps` property

### DIFF
--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -421,6 +421,26 @@
               }
             }
           ]
+        },
+        {
+          "type": "object",
+          "required": ["steps"],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "A unique identifier for the script."
+            },
+            "description": {
+              "type": "string",
+              "description": "A short description, shown when using `melos run` with no argument."
+            },
+            "steps": {
+              "type": "array",
+              "description": "A list of commands to execute sequentially, enabling complex workflows.",
+              "items": { "type": "string" }
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This pull request addresses an issue in the official Melos schema configuration for the `melos.yaml` file. Specifically, it adds the missing schema definition for the `steps` field.

### Problem

The current official schema lacks the definition for the `steps` field in `melos.yaml`. This omission causes validation errors when users attempt to use the `steps` field in their `melos.yaml` files.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/5ffb6dcb-208e-4fa1-ad26-6af5ddac9338">

### Solution

Add the `steps` property to the `script` definition in the `$defs.script` section of `melos.yaml.schema.json`.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/e807ff26-1b2e-49a8-8062-e46bf24acb79">

### Validation

The changes have been validated in the repository at https://github.com/blendthink/melos-yaml-scheme.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
