### PR TITLE
fix: Prints local development when `-h`

### DIFF
--- a/bin/melos_dev.dart
+++ b/bin/melos_dev.dart
@@ -3,7 +3,7 @@ import '../packages/melos/bin/melos.dart' as melos;
 // A copy of packages/melos/bin/melos.dart
 // This allows us to use melos on itself during development.
 void main(List<String> arguments) async {
-  if (arguments.contains('--help')) {
+  if (arguments.contains('-h') || arguments.contains('--help')) {
     // ignore_for_file: avoid_print
     print('---------------------------------------------------------');
     print('| You are running a local development version of melos. |');


### PR DESCRIPTION
## Description

The tip is being printed only with `--help`, it should be available with `-h` too.

## Type of Change

- [x] 🗑️ `chore` -- Chore
