### PR TITLE
🐛 Use `/` in relative path for Windows

### DIFF
--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -284,12 +284,15 @@ class IntellijProject {
     await Future.forEach(_workspace.filteredPackages.values, (package) async {
       if (!package.isFlutterApp) return;
 
-      final generatedRunConfiguration =
-          injectTemplateVariables(flutterTestTemplate, {
-        'flutterRunName': "Flutter Run -&gt; '${package.name}'",
-        'flutterRunMainDartPathRelative':
-            p.join(package.pathRelativeToWorkspace, 'lib', 'main.dart'),
-      });
+      final generatedRunConfiguration = injectTemplateVariables(
+        flutterTestTemplate,
+        {
+          'flutterRunName': "Flutter Run -&gt; '${package.name}'",
+          'flutterRunMainDartPathRelative': p
+              .join(package.pathRelativeToWorkspace, 'lib', 'main.dart')
+              .replaceAll(r'\', '/'),
+        },
+      );
       final outputFile = p.join(
         pathDotIdea,
         'runConfigurations',

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -313,14 +313,8 @@ String pubspecPathForDirectory(String directory) =>
 String pubspecOverridesPathForDirectory(String directory) =>
     p.join(directory, 'pubspec_overrides.yaml');
 
-String relativePath(String path, String from) {
-  if (currentPlatform.isWindows) {
-    return p.windows
-        .normalize(p.relative(path, from: from))
-        .replaceAll(r'\', r'\\');
-  }
-  return p.normalize(p.relative(path, from: from));
-}
+String relativePath(String path, String from) =>
+    p.normalize(p.relative(path, from: from)).replaceAll(r'\', '/');
 
 String listAsPaddedTable(List<List<String>> table, {int paddingSize = 1}) {
   final output = <String>[];


### PR DESCRIPTION
## Description

As we all know, Windows uses `\` as a path separator, so it is reasonable to generate configs that use the same separator for Windows. But for *Run Configurations* and *Pubspec Dependencies*, `/` works on all platforms. Using `/` will significantly reduce the pain when those configurations are checked out to their code version control.

This is first implemented by https://github.com/invertase/melos/commit/86a87a66253808c138e32e5df95d4a9a61f58145.

### Diff on Windows

Before:

```xml
<component name="ProjectRunConfigurationManager">
  <configuration default="false" name="Flutter Run -&gt; 'app'" type="FlutterRunConfigurationType" factoryName="Flutter">
    <option name="filePath" value="$PROJECT_DIR$/app\lib\main.dart" />
    <method v="2" />
  </configuration>
</component>
```

```yaml
dependency_overrides:
  package_a:
    path: ..\\package_a
```

After:

```xml
<component name="ProjectRunConfigurationManager">
  <configuration default="false" name="Flutter Run -&gt; 'app'" type="FlutterRunConfigurationType" factoryName="Flutter">
    <option name="filePath" value="$PROJECT_DIR$/app/lib/main.dart" />
    <method v="2" />
  </configuration>
</component>
```

```yaml
dependency_overrides:
  package_a:
    path: ../package_a
```

## Type of Change

- [x] 🗑️ `chore` -- Chore