### PR TITLE
fix: Run `flutter analyze` for flutter packages

### DIFF
--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -110,7 +110,10 @@ mixin _AnalyzeMixin on _Melos {
   }) {
     final options = _getOptionsArgs(fatalInfos, fatalWarnings, concurrency);
     return <String>[
-      workspace.sdkTool('dart'),
+      if (workspace.isFlutterWorkspace)
+        workspace.sdkTool('flutter')
+      else
+        workspace.sdkTool('dart'),
       'analyze',
       options,
     ];

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -277,6 +277,34 @@ $ melos analyze
       expect(regex.hasMatch(logger.output.normalizeNewLines()), isTrue);
     });
 
+    test('should run analysis with using flutter', () async {
+      final workspaceDir = await createTemporaryWorkspace();
+
+      await createProject(
+        workspaceDir,
+        PubSpec(
+          name: 'a',
+          dependencies: {
+            'c': HostedReference(VersionConstraint.any),
+            'flutter': const SdkReference('flutter'),
+          },
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+      await melos.analyze(concurrency: 2);
+
+      final regex =
+          RegExp(r'\$ melos analyze\s+└> flutter analyze --concurrency 2');
+
+      expect(regex.hasMatch(logger.output.normalizeNewLines()), isTrue);
+    });
+
     test('should run analysis with --concurrency 2 flag', () async {
       await melos.analyze(concurrency: 2);
 

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -350,7 +350,6 @@ $ melos analyze
 
     test('should run analysis using dart', () async {
       final workspaceDir = await createTemporaryWorkspace();
-
       await createProject(
         workspaceDir,
         const PubSpec(


### PR DESCRIPTION

## Description
Current `melos analyze` command is running `dart analyze` instead of `flutter analyze` on flutter projects
https://github.com/invertase/melos/issues/792

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
