### PR TITLE
fix: Simple hosted dependencies should be inlined

### DIFF
--- a/packages/melos/lib/src/common/extensions/dependency.dart
+++ b/packages/melos/lib/src/common/extensions/dependency.dart
@@ -9,6 +9,18 @@ extension DependencyExtension on Dependency {
     return null;
   }
 
+  /// Whether the json can be inlined with its parent.
+  ///
+  /// For example for [HostedDependency] the version shouldn't be on a separate
+  /// line when only the version is defined.
+  bool get inlineVersion {
+    if (this is HostedDependency) {
+      return (this as HostedDependency).hosted == null &&
+          versionConstraint != null;
+    }
+    return false;
+  }
+
   Object toJson() {
     final self = this;
     if (self is PathDependency) {
@@ -34,15 +46,17 @@ extension PathDependencyExtension on PathDependency {
 }
 
 extension HostedDependencyExtension on HostedDependency {
-  Map<String, dynamic> toJson() {
-    return {
-      'version': version.toString(),
-      if (hosted != null)
-        'hosted': {
-          'name': hosted!.declaredName,
-          'url': hosted!.url?.toString(),
-        },
-    };
+  Object toJson() {
+    return inlineVersion
+        ? version.toString()
+        : {
+            'version': version.toString(),
+            if (hosted != null)
+              'hosted': {
+                'name': hosted!.declaredName,
+                'url': hosted!.url?.toString(),
+              },
+          };
   }
 }
 

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -219,6 +219,10 @@ String packageConfigPath(String packageRoot) {
   );
 }
 
+String pubspecPath(String directory) {
+  return p.join(directory, 'pubspec.yaml');
+}
+
 PackageConfig packageConfigForPackageAt(Directory dir) {
   final source = readTextFile(packageConfigPath(dir.path));
   return PackageConfig.fromJson(json.decode(source) as Map<String, Object?>);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Before this fix (after moving to pubspec_parse), when we updated shared dependencies they would explicitly use the version field.

Example before this PR:
```yaml
dependencies:
  flame:
    version: ^1.21.0
```

After this PR:
```yaml
dependencies:
  flame: ^1.21.0
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
