### PR TITLE
fix: Fixed output tests that failed on some terminals

### DIFF
--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/io.dart';
+import 'package:melos/src/common/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -64,12 +65,12 @@ void main() {
       expect(
         logger.output.normalizeNewLines(),
         ignoringAnsii(
-          r'''
-$ melos analyze
+          '''
+\$ melos analyze
   └> dart analyze --fatal-infos
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -77,19 +78,19 @@ Analyzing a...
    info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
 2 issues found.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --fatal-infos
      └> FAILED (in 1 packages)
         └> a (with exit code 1)
@@ -114,12 +115,12 @@ $ melos analyze
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(r'''
-$ melos analyze
+        ignoringAnsii('''
+\$ melos analyze
   └> dart analyze --fatal-warnings
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -133,19 +134,19 @@ warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try
    info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
 8 issues found.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --fatal-warnings
      └> FAILED (in 1 packages)
         └> a (with exit code 2)
@@ -169,12 +170,12 @@ $ melos analyze
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(r'''
-$ melos analyze
+        ignoringAnsii('''
+\$ melos analyze
   └> dart analyze --no-fatal-warnings
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -189,19 +190,19 @@ warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try
 
 8 issues found.
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --no-fatal-warnings
      └> SUCCESS
 '''),
@@ -225,12 +226,12 @@ $ melos analyze
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(r'''
-$ melos analyze
+        ignoringAnsii('''
+\$ melos analyze
   └> dart analyze --fatal-infos --fatal-warnings
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -244,19 +245,19 @@ warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try
    info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
 8 issues found.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --fatal-infos --fatal-warnings
      └> FAILED (in 1 packages)
         └> a (with exit code 2)
@@ -378,29 +379,29 @@ $ melos analyze
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(r'''
-$ melos analyze
+        ignoringAnsii('''
+\$ melos analyze
   └> dart analyze --concurrency 2
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 No issues found!
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --concurrency 2
      └> SUCCESS
 '''),
@@ -424,12 +425,12 @@ $ melos analyze
 
       expect(
         logger.output.normalizeNewLines(),
-        ignoringAnsii(r'''
-$ melos analyze
+        ignoringAnsii('''
+\$ melos analyze
   └> dart analyze --fatal-infos --concurrency 2
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -437,19 +438,19 @@ Analyzing a...
    info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
 2 issues found.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos analyze
+\$ melos analyze
   └> dart analyze --fatal-infos --concurrency 2
      └> FAILED (in 1 packages)
         └> a (with exit code 1)

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -6,6 +6,7 @@ import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/command_configs/format.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
+import 'package:melos/src/common/utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -59,37 +60,37 @@ void main() {
       expect(
         logger.output.normalizeNewLines(),
         ignoringAnsii(
-          r'''
-$ melos format
+          matches(
+            RegExp(
+              RegExp.escape('''
+\$ melos format
   └> dart format .
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
-Formatted no files in 0.01 seconds.
+Formatted no files in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
-Formatted no files in 0.01 seconds.
+Formatted no files in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
-Formatted no files in 0.01 seconds.
+Formatted no files in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos format
+\$ melos format
   └> dart format .
      └> SUCCESS
-''',
+'''),
+            ),
+          ),
         ),
-        // Skip this test if it fails due to a difference in the execution time
-        // reported for formatting files.
-        // The execution time, such as "0.01 seconds" in the line "Formatted 1
-        // file (1 changed) in 0.01 seconds.",
-        // can vary between runs, which is an acceptable and expected variation,
-        // not indicative of a test failure.
-        skip: ' Differ at offset 182',
       );
     });
 
@@ -128,42 +129,42 @@ $ melos format
       expect(
         logger.output.normalizeNewLines(),
         ignoringAnsii(
-          r'''
-$ melos format
+          matches(
+            RegExp(
+              RegExp.escape('''
+\$ melos format
   └> dart format --output show .
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 void main() {
   for (var i = 0; i < 10; i++) {
-    print('hello ${i + 1}');
+    print('hello \${i + 1}');
   }
 }
-Formatted 1 file (1 changed) in 0.07 seconds.
+Formatted 1 file (1 changed) in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
-Formatted no files in 0.00 seconds.
+Formatted no files in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
-Formatted no files in 0.00 seconds.
+Formatted no files in 0.''') + r'\d{2}' + RegExp.escape('''
+ seconds.
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos format
+\$ melos format
   └> dart format --output show .
      └> SUCCESS
-''',
+'''),
+            ),
+          ),
         ),
-        // Skip this test if it fails due to a difference in the execution time
-        // reported for formatting files.
-        // The execution time, such as "0.07 seconds" in the line "Formatted 1
-        // file (1 changed) in 0.07 seconds.",
-        // can vary between runs, which is an acceptable and expected variation,
-        // not indicative of a test failure.
-        skip: 'Differ at offset 293',
       );
     });
 
@@ -189,7 +190,7 @@ $ melos format
       expect(result.exitCode, equals(1));
       expect(
         result.stdout,
-        ignoringAnsii(r'''
+        ignoringDependencyMessages('''
 Resolving dependencies...
 + ansi_styles 0.3.2+1
 + args 2.4.2
@@ -234,25 +235,25 @@ Resolving dependencies...
 Changed 40 dependencies!
 2 packages have newer versions incompatible with dependency constraints.
 Try `dart pub outdated` for more information.
-$ melos format
+\$ melos format
   └> dart format --set-exit-if-changed --output none .
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Changed main.dart
 Formatted 1 file (1 changed) in 0.09 seconds.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Formatted no files in 0.00 seconds.
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Formatted no files in 0.00 seconds.
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos format
+\$ melos format
   └> dart format --set-exit-if-changed --output none .
      └> FAILED (in 1 packages)
         └> a (with exit code 1)
@@ -263,6 +264,8 @@ $ melos format
         // file (1 changed) in 0.09 seconds.",
         // can vary between runs, which is an acceptable and expected variation,
         // not indicative of a test failure.
+        // Addendum: This test case should be rewritten to not be sensitive to
+        // version updates to the dependencies.
         skip: 'Differ at offset 1261',
       );
     });

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -273,22 +273,22 @@ melos run hello
       expect(
         logger.output.normalizeNewLines(),
         ignoringDependencyMessages(
-          r'''
+          '''
 melos run hello
   └> melos exec -- "echo foo bar baz"
      └> RUNNING
 
-$ melos exec
+\$ melos exec
   └> echo foo bar baz
      └> RUNNING (in 1 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 foo bar baz
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
-$ melos exec
+\$ melos exec
   └> echo foo bar baz
      └> SUCCESS
 
@@ -721,7 +721,7 @@ melos run hello_script
   └> dart analyze 
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -730,17 +730,17 @@ Analyzing a...
 
 2 issues found.
 a: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
 \$ melos analyze
   └> dart analyze 
@@ -895,7 +895,7 @@ melos run hello_script
   └> dart analyze --fatal-infos
      └> RUNNING (in 3 packages)
 
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 a:
 Analyzing a...
 
@@ -903,17 +903,17 @@ Analyzing a...
    info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
 
 2 issues found.
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 b:
 Analyzing b...
 No issues found!
 b: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 c:
 Analyzing c...
 No issues found!
 c: SUCCESS
---------------------------------------------------------------------------------
+${'-' * terminalWidth}
 
 \$ melos analyze
   └> dart analyze --fatal-infos


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Several of the existing test cases failed locally due to inconsistent terminal width logic. This problem surfaced when run on a Mac, using iTerm2 and Bash 5, with a terminal width greater than 80. Some tests, but not all, were hardcoded with output that was 80 wide.

This change makes all the tests consistently use dynamic terminal width in output comparison.

It might be argued that Melos shouldn't write dashed lines longer than 80 anyway, but that's an output design question and beyond the scope of this narrow fix.

Also reinstated two output-checking tests that were skipped since they were sensitive to processing time differences. This was done by simply using regexps for the varying time.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
