### PR TITLE
fix: too many open files while creating a workspace

### DIFF
--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -531,15 +531,14 @@ class PackageMap {
 
     final packageMap = <String, Package>{};
 
-    await Future.wait<void>(
-      pubspecFiles.map((pubspecFile) async {
-        final pubspecDirPath = pubspecFile.parent.path;
-        final pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
-        final name = pubspec.name;
+    await Stream.fromIterable(pubspecFiles).parallel((pubspecFile) async {
+      final pubspecDirPath = pubspecFile.parent.path;
+      final pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
+      final name = pubspec.name;
 
-        if (packageMap.containsKey(name)) {
-          throw MelosConfigException(
-            '''
+      if (packageMap.containsKey(name)) {
+        throw MelosConfigException(
+          '''
 Multiple packages with the name `$name` found in the workspace, which is unsupported.
 To fix this problem, consider renaming your packages to have a unique name.
 
@@ -547,38 +546,37 @@ The packages that caused the problem are:
 - $name at ${printablePath(relativePath(pubspecDirPath, workspacePath))}
 - $name at ${printablePath(relativePath(packageMap[name]!.path, workspacePath))}
 ''',
-          );
-        }
-
-        final filteredCategories = <String>[];
-
-        categories.forEach((key, value) {
-          final isCategoryMatching = value.any(
-            (category) => category.matches(
-              relativePath(pubspecDirPath, workspacePath),
-            ),
-          );
-
-          if (isCategoryMatching) {
-            filteredCategories.add(key);
-          }
-        });
-
-        packageMap[name] = Package(
-          name: name,
-          path: pubspecDirPath,
-          pathRelativeToWorkspace: relativePath(pubspecDirPath, workspacePath),
-          version: pubspec.version ?? Version.none,
-          publishTo: pubspec.publishTo.let(Uri.parse),
-          packageMap: packageMap,
-          dependencies: pubspec.dependencies.keys.toList(),
-          devDependencies: pubspec.devDependencies.keys.toList(),
-          dependencyOverrides: pubspec.dependencyOverrides.keys.toList(),
-          pubspec: pubspec,
-          categories: filteredCategories,
         );
-      }),
-    );
+      }
+
+      final filteredCategories = <String>[];
+
+      categories.forEach((key, value) {
+        final isCategoryMatching = value.any(
+          (category) => category.matches(
+            relativePath(pubspecDirPath, workspacePath),
+          ),
+        );
+
+        if (isCategoryMatching) {
+          filteredCategories.add(key);
+        }
+      });
+
+      packageMap[name] = Package(
+        name: name,
+        path: pubspecDirPath,
+        pathRelativeToWorkspace: relativePath(pubspecDirPath, workspacePath),
+        version: pubspec.version ?? Version.none,
+        publishTo: pubspec.publishTo.let(Uri.parse),
+        packageMap: packageMap,
+        dependencies: pubspec.dependencies.keys.toList(),
+        devDependencies: pubspec.devDependencies.keys.toList(),
+        dependencyOverrides: pubspec.dependencyOverrides.keys.toList(),
+        pubspec: pubspec,
+        categories: filteredCategories,
+      );
+    }).drain<void>();
 
     return PackageMap(packageMap, logger);
   }

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -531,7 +531,7 @@ class PackageMap {
 
     final packageMap = <String, Package>{};
 
-    await Stream.fromIterable(pubspecFiles).parallel((pubspecFile) async {
+    for (final pubspecFile in pubspecFiles) {
       final pubspecDirPath = pubspecFile.parent.path;
       final pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
       final name = pubspec.name;
@@ -576,7 +576,7 @@ The packages that caused the problem are:
         pubspec: pubspec,
         categories: filteredCategories,
       );
-    }).drain<void>();
+    }
 
     return PackageMap(packageMap, logger);
   }

--- a/packages/melos/test/matchers.dart
+++ b/packages/melos/test/matchers.dart
@@ -24,6 +24,7 @@ Matcher ignoringDependencyMessages(String expected) {
                 !line.startsWith('Got dependencies!') &&
                 // Removes lines like "  pub_updater 0.4.0 (0.5.0 available)"
                 !(line.startsWith('  ') && line.contains(' available)')) &&
+                !line.startsWith('No dependencies would change in') &&
                 !line.contains(
                   'newer versions incompatible with dependency constraints',
                 ) &&

--- a/packages/melos/test/matchers.dart
+++ b/packages/melos/test/matchers.dart
@@ -25,6 +25,7 @@ Matcher ignoringDependencyMessages(String expected) {
                 // Removes lines like "  pub_updater 0.4.0 (0.5.0 available)"
                 !(line.startsWith('  ') && line.contains(' available)')) &&
                 !line.startsWith('No dependencies would change in') &&
+                !line.startsWith('Would change') &&
                 !line.contains(
                   'newer versions incompatible with dependency constraints',
                 ) &&


### PR DESCRIPTION
## Description

Fixing https://github.com/invertase/melos/issues/803

I was thinking of creating a new Future extension to handle parallelism, but then I discovered that Stream.parallel already does the job by using the number of processors for concurrency. It turned out to be a perfect fit for what I needed 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
