### PR TITLE
fix: failing tests due to Flutter upgrade to version 3.27.

### DIFF
--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -76,7 +76,8 @@ class BootstrapCommandConfigs {
         ? LifecycleHooks.fromYaml(hooksMap, workspacePath: workspacePath)
         : LifecycleHooks.empty;
 
-    final environment = bootstrapConstraints.environment;
+    // ignore: dead_null_aware_expression
+    final environment = bootstrapConstraints.environment ?? {};
     final dependencies = bootstrapConstraints.dependencies;
     final devDependencies = bootstrapConstraints.devDependencies;
 

--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -76,7 +76,7 @@ class BootstrapCommandConfigs {
         ? LifecycleHooks.fromYaml(hooksMap, workspacePath: workspacePath)
         : LifecycleHooks.empty;
 
-    final environment = bootstrapConstraints.environment ?? {};
+    final environment = bootstrapConstraints.environment;
     final dependencies = bootstrapConstraints.dependencies;
     final devDependencies = bootstrapConstraints.devDependencies;
 

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -858,7 +858,7 @@ Generating IntelliJ IDE files...
           equals(defaultTestEnvironment),
         );
         expect(
-          pubspecA.environment?['sdk'],
+          pubspecA.environment['sdk'],
           equals(VersionConstraint.parse('>=2.18.0 <3.0.0')),
         );
         expect(
@@ -883,11 +883,11 @@ Generating IntelliJ IDE files...
         );
 
         expect(
-          pubspecBPreBootstrap.environment?['flutter'],
+          pubspecBPreBootstrap.environment['flutter'],
           equals(VersionConstraint.parse('>=2.12.0 <3.0.0')),
         );
         expect(
-          pubspecB.environment?['flutter'],
+          pubspecB.environment['flutter'],
           equals(VersionConstraint.parse('>=2.18.0 <3.0.0')),
         );
         expect(

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -401,9 +401,9 @@ dependency_overrides:
           updatedPubspecOverrides: '''
 # melos_managed_dependency_overrides: a
 dependency_overrides:
+  x: any
   a:
     path: ../a
-  x: any
 ''',
         );
       });

--- a/packages/melos/test/matchers.dart
+++ b/packages/melos/test/matchers.dart
@@ -24,6 +24,8 @@ Matcher ignoringDependencyMessages(String expected) {
                 !line.startsWith('Got dependencies!') &&
                 // Removes lines like "  pub_updater 0.4.0 (0.5.0 available)"
                 !(line.startsWith('  ') && line.contains(' available)')) &&
+                !line.startsWith('No dependencies would change in') &&
+                !line.startsWith('Would change') &&
                 !line.contains(
                   'newer versions incompatible with dependency constraints',
                 ) &&

--- a/packages/melos/test/pubspec_extension.dart
+++ b/packages/melos/test/pubspec_extension.dart
@@ -74,7 +74,7 @@ extension PubspecExtension on Pubspec {
           screenshots?.map((screenshot) => screenshot.toJson()).toList(),
       'documentation': documentation,
       'environment':
-          environment?.map((key, value) => MapEntry(key, value?.toString())),
+          environment.map((key, value) => MapEntry(key, value?.toString())),
       'dependencies':
           dependencies.map((key, value) => MapEntry(key, value.toJson())),
       'dev_dependencies':

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -152,8 +152,7 @@ Future<Directory> createProject(
   String? path,
   bool createLockfile = false,
 }) async {
-  final pubspec = partialPubspec.environment != null &&
-          partialPubspec.environment!.isNotEmpty
+  final pubspec = partialPubspec.environment.isNotEmpty
       ? partialPubspec
       : partialPubspec.copyWith(
           environment: {


### PR DESCRIPTION
## Description
Fix failing tests due to Flutter upgrade to version 3.27.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
