### PR TITLE
fix: Replace `\\` with `/` when generating `pubspec_overrides.yaml` on Windows

### DIFF
--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -163,7 +163,7 @@ mixin _BootstrapMixin on _CleanMixin {
     for (final otherPackage in workspace.allPackages.values) {
       if (allTransitiveDependencies.containsKey(otherPackage.name)) {
         melosDependencyOverrides[otherPackage.name] = PathDependency(
-          utils.relativePath(otherPackage.path, package.path),
+          utils.relativePathForPubspec(otherPackage.path, package.path),
         );
       }
     }
@@ -172,7 +172,7 @@ mixin _BootstrapMixin on _CleanMixin {
     for (final dependencyOverride
         in workspace.dependencyOverridePackages.values) {
       melosDependencyOverrides[dependencyOverride.name] = PathDependency(
-        utils.relativePath(dependencyOverride.path, package.path),
+        utils.relativePathForPubspec(dependencyOverride.path, package.path),
       );
     }
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -322,6 +322,15 @@ String relativePath(String path, String from) {
   return p.normalize(p.relative(path, from: from));
 }
 
+String relativePathForPubspec(String path, String from) {
+  if (currentPlatform.isWindows) {
+    return p.windows
+        .normalize(p.relative(path, from: from))
+        .replaceAll(r'\', '/');
+  }
+  return p.normalize(p.relative(path, from: from));
+}
+
 String listAsPaddedTable(List<List<String>> table, {int paddingSize = 1}) {
   final output = <String>[];
   final maxColumnSizes = <int, int>{};

--- a/packages/melos/test/commands/clean_test.dart
+++ b/packages/melos/test/commands/clean_test.dart
@@ -40,7 +40,10 @@ void main() {
         pubspecOverrides,
         yamlFile({
           'dependency_overrides': {
-            'a': {'path': relativePath(packageADir.path, packageBDir.path)},
+            'a': {
+              'path':
+                  relativePathForPubspec(packageADir.path, packageBDir.path),
+            },
           },
         }),
       );


### PR DESCRIPTION
## Description

Follow-up #788

## Type of Change

- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
