### PR TITLE
fix: Fix externally hosted versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 2025-01-24
-
-### Changes
-
----
-
-Packages with breaking changes:
-
- - There are no breaking changes in this release.
-
-Packages with other changes:
-
- - [`melos` - `v7.0.0-dev.5`](#melos---v700-dev5)
-
----
-
-#### `melos` - `v7.0.0-dev.5`
-
- - **FEAT**: Rollback on failed shared dependency resolution ([#848](https://github.com/invertase/melos/issues/848)). ([949c2f6c](https://github.com/invertase/melos/commit/949c2f6c77b6bae92e29a03fc452417b558010f0))
- - **DOCS**: Rearrange repos using melos ([#845](https://github.com/invertase/melos/issues/845)). ([f744da86](https://github.com/invertase/melos/commit/f744da860c5fde166f16c624f5cf5058c62d4370))
-
-
 ## 2025-01-19
 
 ### Changes

--- a/packages/melos/CHANGELOG.md
+++ b/packages/melos/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 7.0.0-dev.5
-
- - **FEAT**: Rollback on failed shared dependency resolution ([#848](https://github.com/invertase/melos/issues/848)). ([949c2f6c](https://github.com/invertase/melos/commit/949c2f6c77b6bae92e29a03fc452417b558010f0))
- - **DOCS**: Rearrange repos using melos ([#845](https://github.com/invertase/melos/issues/845)). ([f744da86](https://github.com/invertase/melos/commit/f744da860c5fde166f16c624f5cf5058c62d4370))
-
 ## 7.0.0-dev.4
 
  - **FIX**: Version package correctly ([#842](https://github.com/invertase/melos/issues/842)). ([a9fde62b](https://github.com/invertase/melos/commit/a9fde62bb2ae5a8599b72a7d792170995db9d64c))

--- a/packages/melos/lib/version.g.dart
+++ b/packages/melos/lib/version.g.dart
@@ -1,2 +1,2 @@
 // This file is generated. Do not manually edit.
-String melosVersion = '7.0.0-dev.5';
+String melosVersion = '7.0.0-dev.4';

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   A tool for managing Dart & Flutter repositories with multiple packages
   (monorepo). Supports automated versioning via Conventional Commits. Inspired
   by JavaScripts Lerna package.
-version: 7.0.0-dev.5
+version: 7.0.0-dev.4
 homepage: https://melos.invertase.dev/~melos-latest
 repository: https://github.com/invertase/melos/tree/main/packages/melos
 issue_tracker: https://github.com/invertase/melos/issues


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When we swapped to `pubspec_parse` the logic for versioning externally hosted packages was overlooked.

Fixes: #851 

This also reverts the recent versioning of Melos so that it can be included in the new version.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
