### PR TITLE
fix: Melos init adding empty string / list in pubspec.yaml

### DIFF
--- a/packages/melos/lib/src/commands/init.dart
+++ b/packages/melos/lib/src/commands/init.dart
@@ -50,7 +50,12 @@ mixin _InitMixin on _Melos {
     final pubspecFile = File(p.join(dir.absolute.path, 'pubspec.yaml'));
 
     pubspecFile.writeAsStringSync(
-      (YamlEditor('')..update([], pubspecYaml)).toString(),
+      // YamlEditor adds empty strings and empty lists to the pubspec.yaml file
+      // if the value is empty. This is a workaround to remove them.
+      (YamlEditor('')..update([], pubspecYaml))
+          .toString()
+          .replaceFirst('""', '')
+          .replaceFirst('[]', ''),
     );
 
     logger.log(

--- a/packages/melos/lib/src/commands/init.dart
+++ b/packages/melos/lib/src/commands/init.dart
@@ -15,7 +15,7 @@ mixin _InitMixin on _Melos {
     }
 
     final isCurrentDir = directory == '.';
-    final dir = Directory(directory);
+    final dir = isCurrentDir ? Directory.current : Directory(directory);
     if (!isCurrentDir && dir.existsSync()) {
       throw StateError('Directory $directory already exists');
     } else {
@@ -43,7 +43,13 @@ mixin _InitMixin on _Melos {
       'dev_dependencies': {
         'melos': '^$melosVersion',
       },
-      'workspace': packages.values.map((p) => p.path).toList(),
+      'workspace': packages.values
+          .map(
+            (p) => p.path
+                .replaceFirst(dir.absolute.path, '.')
+                .replaceFirst('./', ''),
+          )
+          .toList(),
       'melos': '',
     };
 

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -114,7 +114,7 @@ ${'-' * terminalWidth}
         stderrEncoding: utf8,
       );
 
-      expect(result.exitCode, equals(1));
+      expect(result.exitCode, isNot(0));
     });
 
     test('should run format with --output show flag', () async {

--- a/packages/melos/test/commands/init_test.dart
+++ b/packages/melos/test/commands/init_test.dart
@@ -7,6 +7,24 @@ import 'package:yaml/yaml.dart';
 
 import '../utils.dart';
 
+Future<void> _createPackages(Directory dir) async {
+  final packageDir = Directory(p.join(dir.absolute.path, 'packages'));
+  packageDir.createSync(recursive: true);
+  await Process.run(
+    'dart',
+    ['create', 'test_package'],
+    workingDirectory: packageDir.absolute.path,
+  );
+
+  final appDir = Directory(p.join(dir.absolute.path, 'apps'));
+  appDir.createSync(recursive: true);
+  await Process.run(
+    'dart',
+    ['create', 'test_app'],
+    workingDirectory: appDir.absolute.path,
+  );
+}
+
 void main() {
   group('init', () {
     late TestLogger logger;
@@ -49,7 +67,6 @@ void main() {
         File(p.join(workspaceDir.path, 'pubspec.yaml')).readAsStringSync(),
       ) as YamlMap;
       expect(melosYaml['name'], equals('my_workspace'));
-      // TODO: Create some packages first that we can test against
       expect(melosYaml['workspace'], isNull);
 
       // Verify pubspec.yaml content
@@ -93,8 +110,6 @@ void main() {
       final melosYaml = loadYaml(
         File(p.join(workspaceDir.path, 'pubspec.yaml')).readAsStringSync(),
       ) as YamlMap;
-      // TODO: Create some packages in 'custom/*', 'plugins/**' that we can test
-      // against.
       expect(melosYaml['workspace'], isNull);
     });
 
@@ -109,7 +124,7 @@ void main() {
       final originalDir = Directory.current;
       try {
         Directory.current = tempDir;
-
+        await _createPackages(tempDir);
         await melos.init(
           '.',
           directory: '.',
@@ -180,7 +195,6 @@ void main() {
       final melosYaml = loadYaml(
         File(p.join(workspaceDir.path, 'pubspec.yaml')).readAsStringSync(),
       ) as YamlMap;
-      // TODO: Create some packages first that we can test against
       expect(melosYaml['workspace'], isNull);
     });
   });

--- a/packages/melos/test/commands/init_test.dart
+++ b/packages/melos/test/commands/init_test.dart
@@ -50,7 +50,7 @@ void main() {
       ) as YamlMap;
       expect(melosYaml['name'], equals('my_workspace'));
       // TODO: Create some packages first that we can test against
-      expect(melosYaml['workspace'], equals([]));
+      expect(melosYaml['workspace'], isNull);
 
       // Verify pubspec.yaml content
       final pubspecYaml = loadYaml(
@@ -95,7 +95,7 @@ void main() {
       ) as YamlMap;
       // TODO: Create some packages in 'custom/*', 'plugins/**' that we can test
       // against.
-      expect(melosYaml['workspace'], equals([]));
+      expect(melosYaml['workspace'], isNull);
     });
 
     test('creates workspace in current directory when directory is "."',
@@ -181,7 +181,7 @@ void main() {
         File(p.join(workspaceDir.path, 'pubspec.yaml')).readAsStringSync(),
       ) as YamlMap;
       // TODO: Create some packages first that we can test against
-      expect(melosYaml['workspace'], equals([]));
+      expect(melosYaml['workspace'], isNull);
     });
   });
 }

--- a/packages/melos/test/commands/init_test.dart
+++ b/packages/melos/test/commands/init_test.dart
@@ -140,6 +140,10 @@ void main() {
         final pubspecYaml =
             loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
         expect(pubspecYaml['name'], equals(p.basename(tempDir.path)));
+        expect(
+          pubspecYaml['workspace'],
+          equals(['apps/test_app', 'packages/test_package']),
+        );
       } finally {
         Directory.current = originalDir;
       }


### PR DESCRIPTION
## Description

`melos init` currently adds an empty string to `melos:` and an empty list/array to `workspace:` in pubsspec.yaml when generating it. This is a limitation of the yaml package we're using. A workaround to remove these has been implemented

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
