### PR TITLE
feat: Add support for executeInTerminal for IntelliJ run configs

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -119,6 +119,19 @@ collisions with other IntelliJ modules you may already have in place.
 
 The default is 'melos\_'.
 
+### executeInTerminal
+
+Whether to execute the script in a terminal.
+
+The default is `true`.
+
+```yaml
+melos:
+  ide:
+    intellij:
+      executeInTerminal: false
+```
+
 ## scripts
 
 Define custom scripts that can be executed in the workspace via the

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -143,8 +143,8 @@ class IntellijProject {
         'fileurl="file://\$PROJECT_DIR\$/$imlPath" '
         'filepath="\$PROJECT_DIR\$/$imlPath" '
         '/>';
-    // Pad to preserve formatting on generated file. Indent x6.
-    return '      $module';
+    // Pad to preserve formatting on generated file.
+    return module.padLeft(6);
   }
 
   Future<void> forceWriteToFile(String filePath, String fileContents) async {
@@ -265,6 +265,8 @@ class IntellijProject {
         'scriptName': scriptName,
         'scriptArgs': scriptArgs,
         'scriptPath': getMelosBinForIde(),
+        'executeInTerminal':
+            _workspace.config.ide.intelliJ.executeInTerminal.toString(),
       });
 
       final outputFile = p.join(

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -105,7 +105,7 @@ class IntelliJConfig {
   static const empty = IntelliJConfig();
   static const _defaultModuleNamePrefix = 'melos_';
   static const _defaultEnabled = true;
-  static const _defaultExecuteInTerminal = true;
+  static const _defaultExecuteInTerminal = false;
 
   final bool enabled;
 

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -65,6 +65,7 @@ class IntelliJConfig {
   const IntelliJConfig({
     this.enabled = _defaultEnabled,
     this.moduleNamePrefix = _defaultModuleNamePrefix,
+    this.executeInTerminal = _defaultExecuteInTerminal,
   });
 
   factory IntelliJConfig.fromYaml(Object? yaml) {
@@ -79,9 +80,17 @@ class IntelliJConfig {
       final enabled = yaml.containsKey('enabled')
           ? assertKeyIsA<bool>(key: 'enabled', map: yaml, path: 'ide/intellij')
           : _defaultEnabled;
+      final executeInTerminal = yaml.containsKey('executeInTerminal')
+          ? assertKeyIsA<bool>(
+              key: 'executeInTerminal',
+              map: yaml,
+              path: 'ide/intellij',
+            )
+          : _defaultExecuteInTerminal;
       return IntelliJConfig(
         enabled: enabled,
         moduleNamePrefix: moduleNamePrefix,
+        executeInTerminal: executeInTerminal,
       );
     } else {
       final enabled = assertIsA<bool>(
@@ -96,15 +105,19 @@ class IntelliJConfig {
   static const empty = IntelliJConfig();
   static const _defaultModuleNamePrefix = 'melos_';
   static const _defaultEnabled = true;
+  static const _defaultExecuteInTerminal = true;
 
   final bool enabled;
 
   final String moduleNamePrefix;
 
+  final bool executeInTerminal;
+
   Object? toJson() {
     return {
       'enabled': enabled,
       'moduleNamePrefix': moduleNamePrefix,
+      'executeInTerminal': executeInTerminal,
     };
   }
 
@@ -113,11 +126,15 @@ class IntelliJConfig {
       other is IntelliJConfig &&
       runtimeType == other.runtimeType &&
       other.enabled == enabled &&
-      other.moduleNamePrefix == moduleNamePrefix;
+      other.moduleNamePrefix == moduleNamePrefix &&
+      other.executeInTerminal == executeInTerminal;
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^ enabled.hashCode ^ moduleNamePrefix.hashCode;
+      runtimeType.hashCode ^
+      enabled.hashCode ^
+      moduleNamePrefix.hashCode ^
+      executeInTerminal.hashCode;
 
   @override
   String toString() {
@@ -125,6 +142,7 @@ class IntelliJConfig {
 IntelliJConfig(
   enabled: $enabled,
   moduleNamePrefix: $moduleNamePrefix,
+  executeInTerminal: $executeInTerminal,
 )
 ''';
   }

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -105,7 +105,7 @@ class IntelliJConfig {
   static const empty = IntelliJConfig();
   static const _defaultModuleNamePrefix = 'melos_';
   static const _defaultEnabled = true;
-  static const _defaultExecuteInTerminal = false;
+  static const _defaultExecuteInTerminal = true;
 
   final bool enabled;
 

--- a/packages/melos/templates/intellij/runConfigurations/shell_script.xml.tmpl
+++ b/packages/melos/templates/intellij/runConfigurations/shell_script.xml.tmpl
@@ -6,6 +6,7 @@
     <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="false" />
     <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="SCRIPT_TEXT" value="melos {{#scriptArgs}}" />
+    <option name="EXECUTE_IN_TERMINAL" value="{{#executeInTerminal}}"/>
     <method v="2" />
   </configuration>
 </component>

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -337,12 +337,24 @@ void main() {
       );
     });
 
+    test('executeInTerminal is false by default', () {
+      expect(
+        IDEConfigs.empty.intelliJ.executeInTerminal,
+        false,
+      );
+    });
+
     group('fromYaml', () {
       test('supports empty map', () {
         expect(
           IDEConfigs.fromYaml(const {}),
           isA<IDEConfigs>()
-              .having((e) => e.intelliJ.enabled, 'intelliJ.enabled', true),
+              .having((e) => e.intelliJ.enabled, 'intelliJ.enabled', true)
+              .having(
+                (e) => e.intelliJ.executeInTerminal,
+                'intelliJ.executeInTerminal',
+                false,
+              ),
         );
       });
 

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -337,10 +337,10 @@ void main() {
       );
     });
 
-    test('executeInTerminal is false by default', () {
+    test('executeInTerminal is true by default', () {
       expect(
         IDEConfigs.empty.intelliJ.executeInTerminal,
-        false,
+        true,
       );
     });
 
@@ -353,7 +353,7 @@ void main() {
               .having(
                 (e) => e.intelliJ.executeInTerminal,
                 'intelliJ.executeInTerminal',
-                false,
+                true,
               ),
         );
       });


### PR DESCRIPTION
## Description

This PR aims to add support for `executeInTerminal` for IntelliJ run configurations allowing scripts to be ran in the "Run" panel instead of the terminal

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
