### PR TITLE
docs: page for `analyze` was removed but not from side bar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -21,7 +21,6 @@
     [
       "Commands",
       [
-        ["analyze", "/commands/analyze"],
         ["bootstrap", "/commands/bootstrap"],
         ["clean", "/commands/clean"],
         ["format", "/commands/format"],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Since I was reading https://melos.invertase.dev/ ,
I noticed that access to `analyze` from side bar is 404.

![Screenshot 2025-04-08 at 11 22 35](https://github.com/user-attachments/assets/3ef4bfb8-8815-460f-b161-708378f7d0a5)

From some research around why, 
I found that `docs/commands/analyze.mdx` has been deleted in #832 but forgot to remove from side bar.

This commit will remove it from side bar as well.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
