### PR TITLE
fix: Avoid duplicated "Change Log" file header on Windows due to CRLF (closes #710)

### DIFF
--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -157,7 +157,9 @@ ${description?.withoutTrailing('\n') ?? ''}
   Future<String> read() async {
     if (fileExists(absolutePath)) {
       final contents = await readTextFileAsync(absolutePath);
-      return contents.replaceFirst(_changelogFileHeader, '');
+      return contents
+          .replaceAll('\r\n', '\n')
+          .replaceFirst(_changelogFileHeader, '');
     }
     return '';
   }


### PR DESCRIPTION
Closes #710

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
