### PR TITLE
docs: Remove `melos.yaml` and `melos analyze` from v7 docs

### DIFF
--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -87,61 +87,63 @@ melos bootstrap --diff="main"
 - The `--enforce-lockfile` flag is used to enforce versions from `.lock` files.
     - Ensure .lock files exist, as failure may occur if they're not checked in.
 - The `--no-enforce-lockfile` flag is used to disregard versions from `.lock`
-  files if `enforce-lockfile` is configured in the `melos.yaml` file.
+  files if `enforce-lockfile` is configured in the root `pubspec.yaml` file.
 - The `--offline` flag is used to only resolve dependencies from the local
   cache by running `pub get` with the `--offline` flag.
 
 
 In addition to the above flags, the `melos bootstrap` command supports a few
-different configurations that can be defined in your `melos.yaml` file.
+different configurations that can be defined in your root `pubspec.yaml` file.
 
 
 ### Shared dependencies
 
 If you want to share dependency versions between your packages in your Melos
 project, just add the dependencies you wish to share between the packages to
-your bootstrap config in your `melos.yaml` file.
+your bootstrap config in your root `pubspec.yaml` file.
 
 If a dependency from `environment`, `dependencies` or `dev_dependencies` in
-your `melos.yaml` exists in a package, the dependency version in this
+your root `pubspec.yaml` exists in a package, the dependency version in this
 package will be updated to match the version defined in your
 bootstrap config every time `melos bootstrap` is run.
 
 ```yaml
-# melos.yaml
+# root pubspec.yaml
 # ...
-command:
-  bootstrap:
-    environment:
-      sdk: ">=3.0.0 <4.0.0"
-      flutter: ">=3.0.0 <4.0.0"
-    dependencies:
-      collection: ^1.18.0
-      integral_isolates: any
-      uni_links2:
-      uni_links_macos:
-        git: https://github.com/SamJakob/uni_links_macos.git
-    
-    dev_dependencies:
-      build_runner: ^2.3.3
+melos:
+  command:
+    bootstrap:
+      environment:
+        sdk: ">=3.0.0 <4.0.0"
+        flutter: ">=3.0.0 <4.0.0"
+      dependencies:
+        collection: ^1.18.0
+        integral_isolates: any
+        uni_links2:
+        uni_links_macos:
+          git: https://github.com/SamJakob/uni_links_macos.git
+
+      dev_dependencies:
+        build_runner: ^2.3.3
 # ...
 ```
 
 ## Adding a post bootstrap lifecycle script
 
 Melos supports various command [lifecycle hooks](/configuration/scripts#hooks)
-that can be defined in your `melos.yaml`.
+that can be defined in your root `pubspec.yaml`.
 
 For example, if you needed to run something such as a build runner automatically
 after `melos bootstrap` is run, you can add a `post` hook script:
 
 ```yaml
-# melos.yaml
+# root pubspec.yaml
 # ...
-command:
-  bootstrap:
-    hooks:
-      post: dart pub run build_runner build
+melos:
+  command:
+    bootstrap:
+      hooks:
+        post: dart pub run build_runner build
 # ...
 ```
 

--- a/docs/commands/clean.mdx
+++ b/docs/commands/clean.mdx
@@ -44,19 +44,20 @@ melos clean --flutter
 ## Adding a postclean lifecycle script
 
 Melos supports various command lifecycle hooks that can be defined in your
-`melos.yaml`.
+root `pubspec.yaml`.
 
 For example, if you needed to cleanup any generated files, e.g. from a build
 runner, automatically after `melos clean` is ran, you can add a `post` hook
 script.
 
 ```yaml
-# melos.yaml
+# root pubspec.yaml
 # ...
-command:
-  clean:
-    hooks:
-      post: rm packages/foo/lib/src/generated_file.g.dart
+melos:
+  command:
+    clean:
+      hooks:
+        post: rm packages/foo/lib/src/generated_file.g.dart
 # ...
 ```
 

--- a/docs/commands/publish.mdx
+++ b/docs/commands/publish.mdx
@@ -46,21 +46,22 @@ publish of packages.
 ## Hooks
 
 Melos supports various command [lifecycle hooks](/configuration/scripts#hooks)
-that can be defined in your `melos.yaml`.
+that can be defined in your root `pubspec.yaml`.
 
 For example, if you need to run something such as a build runner automatically
 before `melos publish` is run and then remove the generated files after
 publishing is done, you can add `pre` and `post` hook scripts to your
-`melos.yaml` file:
+root `pubspec.yaml` file:
 
 ```yaml
-# melos.yaml
+# root pubspec.yaml
 # ...
-command:
-  publish:
-    hooks:
-      pre: dart pub run build_runner build
-      post: dart pub run build_runner clean
+melos:
+  command:
+    publish:
+      hooks:
+        pre: dart pub run build_runner build
+        post: dart pub run build_runner clean
 # ...
 ```
 

--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -6,7 +6,7 @@ description: Learn more about the `run` command in Melos.
 # Run Command
 
 Run a [script](/configuration/scripts) by name defined in the workspace
-`melos.yaml` config file.
+root `pubspec.yaml` config file.
 
 ```bash
 melos run <name>

--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -94,7 +94,7 @@ Use `--no-release-url` to disable.
 
 The default for this option can be configured in
 [command/version/releaseUrl](/configuration/overview#releaseurl) in your
-`melos.yaml` file.
+root `pubspec.yaml` file.
 
 ## --[no-]dependent-constraints
 

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -59,10 +59,11 @@ The command to execute.
 
 ## steps
 
-Enables the combination of multiple scripts within a single script definition
-for complex workflows. In the example below, the pre-commit script is
+Steps enables the combination of multiple scripts within a single script
+definition for complex workflows. In the example below, the pre-commit script is
 configured to sequentially invoke a simple command echo 'hello world',
-followed by Melos commands: format and analyze, each with specific arguments.
+followed by the Melos command to format your workspace and a command to run
+tests through Dart, each command with their specific arguments.
 
 ```yaml
 scripts:
@@ -71,7 +72,7 @@ scripts:
     steps:
       - echo 'hello world'
       - format --output none --set-exit-if-changed
-      - analyze --fatal-infos
+      - dart test --fail-fast .
 ```
 
 Note: When utilizing the `steps`, it's important to understand that options 

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -75,5 +75,5 @@ for all the filtering options defined in the `packageFilters` section.
 ### `MELOS_SDK_PATH`
 
 The path to the Dart/Flutter SDK to use. This environment variable has
-precedence over the `sdkPath` option in `melos.yaml`, but is overridden by the
-command line option `--sdk-path`.
+precedence over the `sdkPath` option in the root `pubspec.yaml`, but is
+overridden by the command line option `--sdk-path`.

--- a/docs/filters.mdx
+++ b/docs/filters.mdx
@@ -48,7 +48,7 @@ melos exec --ignore="*internal*" -- flutter build ios
 
 ## --category
 
-Filter packages based on categories declared in the `melos.yaml` file.
+Filter packages based on categories declared in the root `pubspec.yaml` file.
 
 ```bash
 # Run `flutter build ios` on all packages in the "examples" category.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -40,13 +40,12 @@ dart pub global activate melos
 
 Melos is designed to work with a workspace. A workspace is a directory which
 contains all the packages that are going to be developed together. Its root
-directory must contain a `melos.yaml` and a `pubspec.yaml` file.
+directory must contain a `pubspec.yaml` file defining the workspace.
 
 ### Recommended directory structure
 
-When using Melos you shouldn't have a project in the root of the workspace,
-since that is where the configuration for the workspace will live and those
-dependencies might clash with your project dependencies.
+When using Melos you shouldn't currently have an app/package in the root of the
+workspace, since that is where the configuration for the workspace will live.
 
 The following is the recommended workspace directory structure:
 
@@ -58,7 +57,6 @@ my_project
 ├── packages
 │   ├── package_1
 │   └── package_2
-├── melos.yaml
 ├── pubspec.yaml
 └── README.md
 ```
@@ -110,23 +108,6 @@ resolution: workspace
 ...
 ```
 
-### Configure the workspace
-
-Next create a `melos.yaml` file at the repository root. Within the `melos.yaml`
-file, add the `name` and `packages` fields:
-
-```yaml
-name: my_project
-
-packages:
-  - apps/**
-  - packages/**
-```
-
-The `packages` list should contain paths to the individual packages within your
-project. Each path can be defined using the
-[glob](https://docs.python.org/3/library/glob.html) pattern expansion format.
-
 ## Bootstrapping
 
 Once installed & setup, Melos needs to be bootstrapped. Bootstrapping has
@@ -153,25 +134,24 @@ packages.
 
 Melos also provides other helpful features such as running scripts across all
 packages. For example, to run dart analyzer in each package, add a new `script`
-item in your `melos.yaml`:
+item in your root `pubspec.yaml`:
 
 ```yaml
-name: my_project
+name: my_workspace
 
-packages:
-  - apps/**
-  - packages/**
+...
 
-scripts:
-  generate:
-    run: melos exec -c 1 --depends-on build_runner -- dart run build_runner build
+melos:
+  scripts:
+    generate:
+      run: melos exec -c 1 --depends-on build_runner -- dart run build_runner build
 ```
 
 Then execute the command by running `melos generate`.
 
 If you're looking for some inspiration as to what scripts can help with, check
 out the
-[FlutterFire repository](https://github.com/firebase/flutterfire/blob/main/melos.yaml)
+[FlutterFire repository](https://github.com/firebase/flutterfire/blob/main/pubspec.yaml)
 or the [Flame repository](https://github.com/flame-engine/flame/blob/main/pubspec.yaml).
 
 If you are using VS Code, there is an [extension](/ide-support#vs-code)

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -144,9 +144,9 @@ This behavior can be disabled by passing `--no-git-tag-version`.
 #### Hook
 
 After updating `pubspec.yaml` files and changelogs but before creating the
-version commit, the `command/version/hooks/preCommit` script in `melos.yaml` is
-executed. This allows you to run custom code before the version commit is
-created.
+version commit, the `command/version/hooks/preCommit` script in root
+`pubspec.yaml` is executed. This allows you to run custom code before the
+version commit is created.
 
 Note that you have to stage changes that you make in the hook and want to have
 included in the version commit yourself.
@@ -200,12 +200,13 @@ melos version --release-url
 melos version -r
 ```
 
-To enable this feature permanently, add the following to your `melos.yaml`:
+To enable this feature permanently, add the following to your root `pubspec.yaml`:
 
 ```yaml
-command:
-  version:
-    releaseUrl: true
+melos:
+  command:
+    version:
+      releaseUrl: true
 ```
 
 ## Git Hosted Packages
@@ -217,7 +218,7 @@ accordingly.
 
 To use this feature enable
 [`command/version/updateGitTagRefs`](/configuration/overview#updategittagrefs)
-in `melos.yaml`
+in your root `pubspec.yaml`
 
 Take the following git dependency:
 

--- a/docs/guides/migrations.mdx
+++ b/docs/guides/migrations.mdx
@@ -50,6 +50,11 @@ resolution: workspace
 > If you are using an older version of the Dart SDK, you can still use Melos
 > with pub workspaces, but then you have to rely on the `7.0.0-dev.x` versions.
 
+### 'melos analyze` no longer exists
+
+Since `flutter/dart analyze` now runs in the full pub workspace, the
+`melos analyze` command has been removed,
+
 ## 3.0.0 to 4.0.0
 
 ### `--no-git-tag-version` behavior change

--- a/docs/ide-support.mdx
+++ b/docs/ide-support.mdx
@@ -21,6 +21,8 @@ workspace, and will create flutter and dart Run configurations for your
 
 ### `melos.yaml`
 
+<Info> This is only supported for Melos v6 and lower</Info>
+
 Autocompletion and validation of `melos.yaml` can be enabled in IntelliJ by
 going to `Settings` > `Languages & Frameworks` > `Schemas and DTDs` >
 `JSON Schema Mappings` and adding the Melos schema:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Some docs were not properly updated for v7, this PR removes the mentions of `melos.yaml` that were left and removes `melos analyze`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
