### PR TITLE
feat(scripts): allow overriding default scripts with custom ones

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -45,23 +45,6 @@ scripts:
   prepare: melos bootstrap && melos run build
 ```
 
-## Overriding built-in commands
-
-Custom scripts can override Melos built-in commands. When a custom script has
-the same name as a built-in command, the custom script takes precedence. This
-allows you to customize the behavior of built-in commands to match your
-workspace needs.
-
-For example, you can override the built-in `format` command:
-
-```yaml
-scripts:
-  format: dart run custom_formatter
-```
-
-With this configuration, both `melos format` and `melos run format` will execute
-your custom format script instead of the built-in format command.
-
 ## name
 
 A unique identifier for the script.
@@ -203,3 +186,20 @@ Currently, the following Melos commands support hooks:
 - [`clean`](/commands/clean)
 - [`version`](/commands/version)
 - [`publish`](/commands/publish)
+
+## Overriding built-in commands
+
+Custom scripts can override Melos built-in commands. When a custom script has
+the same name as a built-in command, the custom script takes precedence. This
+allows you to customize the behavior of built-in commands to match your
+workspace needs.
+
+For example, you can override the built-in `format` command:
+
+```yaml
+scripts:
+  format: dart run custom_formatter
+```
+
+With this configuration, both `melos format` and `melos run format` will execute
+your custom format script instead of the built-in format command.

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -45,6 +45,23 @@ scripts:
   prepare: melos bootstrap && melos run build
 ```
 
+## Overriding built-in commands
+
+Custom scripts can override Melos built-in commands. When a custom script has
+the same name as a built-in command, the custom script takes precedence. This
+allows you to customize the behavior of built-in commands to match your
+workspace needs.
+
+For example, you can override the built-in `format` command:
+
+```yaml
+scripts:
+  format: dart run custom_formatter
+```
+
+With this configuration, both `melos format` and `melos run format` will execute
+your custom format script instead of the built-in format command.
+
 ## name
 
 A unique identifier for the script.

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -64,18 +64,25 @@ class MelosCommandRunner extends CommandRunner<void> {
       addCommand(script);
     }
 
-    bool canAddCommand(String name) => !scriptNames.contains(name);
+    // Create built-in commands
+    final builtInCommands = [
+      InitCommand(config),
+      ExecCommand(config),
+      BootstrapCommand(config),
+      CleanCommand(config),
+      RunCommand(config),
+      ListCommand(config),
+      PublishCommand(config),
+      VersionCommand(config),
+      FormatCommand(config),
+    ];
 
     // Add built-in commands only if they don't conflict with custom scripts
-    if (canAddCommand('init')) addCommand(InitCommand(config));
-    if (canAddCommand('exec')) addCommand(ExecCommand(config));
-    if (canAddCommand('bootstrap')) addCommand(BootstrapCommand(config));
-    if (canAddCommand('clean')) addCommand(CleanCommand(config));
-    if (canAddCommand('run')) addCommand(RunCommand(config));
-    if (canAddCommand('list')) addCommand(ListCommand(config));
-    if (canAddCommand('publish')) addCommand(PublishCommand(config));
-    if (canAddCommand('version')) addCommand(VersionCommand(config));
-    if (canAddCommand('format')) addCommand(FormatCommand(config));
+    for (final command in builtInCommands) {
+      if (!scriptNames.contains(command.name)) {
+        addCommand(command);
+      }
+    }
   }
 
   @override

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -57,21 +57,25 @@ class MelosCommandRunner extends CommandRunner<void> {
           'the special value "auto".',
     );
 
-    addCommand(InitCommand(config));
-    addCommand(ExecCommand(config));
-    addCommand(BootstrapCommand(config));
-    addCommand(CleanCommand(config));
-    addCommand(RunCommand(config));
-    addCommand(ListCommand(config));
-    addCommand(PublishCommand(config));
-    addCommand(VersionCommand(config));
-    addCommand(FormatCommand(config));
-
-    // Keep this last to exclude all built-in commands listed above
-    final script = ScriptCommand.fromConfig(config, exclude: commands.keys);
+    // Register custom scripts first so they can override built-in commands
+    final script = ScriptCommand.fromConfig(config);
+    final scriptNames = script?.scripts ?? <String>{};
     if (script != null) {
       addCommand(script);
     }
+
+    bool canAddCommand(String name) => !scriptNames.contains(name);
+
+    // Add built-in commands only if they don't conflict with custom scripts
+    if (canAddCommand('init')) addCommand(InitCommand(config));
+    if (canAddCommand('exec')) addCommand(ExecCommand(config));
+    if (canAddCommand('bootstrap')) addCommand(BootstrapCommand(config));
+    if (canAddCommand('clean')) addCommand(CleanCommand(config));
+    if (canAddCommand('run')) addCommand(RunCommand(config));
+    if (canAddCommand('list')) addCommand(ListCommand(config));
+    if (canAddCommand('publish')) addCommand(PublishCommand(config));
+    if (canAddCommand('version')) addCommand(VersionCommand(config));
+    if (canAddCommand('format')) addCommand(FormatCommand(config));
   }
 
   @override

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -36,7 +36,7 @@ void main() {
       expect(command!.hidden, isTrue);
     });
 
-    test('excludes conflicting script commands', () async {
+    test('custom scripts override built-in commands', () async {
       final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
           path: path,
@@ -45,7 +45,7 @@ void main() {
             createGlob('packages/**', currentDirectoryPath: path),
           ],
           scripts: const Scripts({
-            'run': Script(name: 'run', run: ''),
+            'format': Script(name: 'format', run: 'echo "custom format"'),
           }),
         ),
         workspacePackages: [],
@@ -54,9 +54,10 @@ void main() {
       final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
       final runner = MelosCommandRunner(config);
 
-      final command = runner.commands['run'];
+      final command = runner.commands['format'];
       expect(command, isNotNull);
-      expect(command!.hidden, isFalse);
+      // The command should be hidden (custom script behavior)
+      expect(command!.hidden, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/invertase/melos/issues/874.

This PR makes it so that if you have a custom script defined in `pubspec.yaml` that has the same name as a built-in command (e.g. `format`), that script will be run when you invoke _either_ `melos <script>` or `melos run <script>`. Before this change, your script would NOT be run if you ran `melos <script>`, the built-in command would be run, which is not expected.

**One important behavioral quirk I noticed when making this change:** Custom scripts are not included in `--help` invocation. This is because:
- An empty workspace is used when `--help` is passed.
- Custom scripts are hidden via `ScriptCommand` having `hidden` set to `true`

I found this behavior to be unexpected. I was able to make custom scripts show up in `--help` by changing the above conditions, but I did _not_ commit that change as I suspect there are historical reasons this behavior exists (e.g. I noticed that when we _don't_ use an empty workspace during `--help` invocations, information on `init` shows up which is weird if you've already run `init`).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
