### PR TITLE
Add --list flag to run command

### DIFF
--- a/packages/melos/lib/src/command_runner/run.dart
+++ b/packages/melos/lib/src/command_runner/run.dart
@@ -11,6 +11,11 @@ class RunCommand extends MelosCommand {
           """configuration). Filters defined in the script's "packageFilters" """
           'options will however still be applied.',
     );
+    argParser.addFlag(
+      'list',
+      negatable: false,
+      help: 'Lists all scripts defined in the melos.yaml config file.',
+    );
   }
 
   @override
@@ -32,6 +37,7 @@ class RunCommand extends MelosCommand {
     final extraArgs = scriptName != null
         ? argResults!.rest.skip(1).toList()
         : <String>[];
+    final listScripts = argResults!['list'] as bool;
 
     try {
       return await melos.run(
@@ -39,6 +45,7 @@ class RunCommand extends MelosCommand {
         scriptName: scriptName,
         noSelect: noSelect,
         extraArgs: extraArgs,
+        listScripts: listScripts,
       );
     } on NoPackageFoundScriptException catch (err) {
       logger.warning(err.toString(), label: false);

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -6,8 +6,15 @@ mixin _RunMixin on _Melos {
     GlobalOptions? global,
     String? scriptName,
     bool noSelect = false,
+    bool listScripts = false,
     List<String> extraArgs = const [],
   }) async {
+    if (listScripts && scriptName == null) {
+      logger.command('melos run --list');
+      logger.newLine();
+      config.scripts.forEach((_, script) => logger.log(script.name));
+      return;
+    }
     if (config.scripts.keys.isEmpty) {
       throw NoScriptException._();
     }

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -904,4 +904,69 @@ SUCCESS
       );
     });
   });
+
+  group('flags', () {
+    test(
+      'verifies that the --list flag lists all scripts in the config',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_package',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            scripts: const Scripts({
+              'test_script_1': Script(
+                name: 'test_script',
+                steps: [
+                  'absolute_bogus_command',
+                  'echo "test_script_2"',
+                ],
+              ),
+              'test_script_2': Script(
+                name: 'test_script',
+                steps: [
+                  'absolute_bogus_command',
+                  'echo "test_script_2"',
+                ],
+              ),
+              'test_script_3': Script(
+                name: 'test_script',
+                steps: [
+                  'absolute_bogus_command',
+                  'echo "test_script_2"',
+                ],
+              ),
+            }),
+          ),
+          workspacePackages: ['a'],
+        );
+
+        await createProject(workspaceDir, Pubspec('a'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(
+          logger: logger,
+          config: config,
+        );
+
+        await melos.run(listScripts: true);
+
+        expect(
+          logger.output.normalizeLines().split('\n'),
+          containsAllInOrder([
+            'melos run --list',
+            '',
+            'test_script_1',
+            'test_script_2',
+            'test_script_3',
+          ]),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->
As requested in issue #895 I added a --list flag to the run command to simply list all scripts defined in the melos config


## Description

<!--- Describe your changes in detail -->
- Added a flag to run to list all scripts in the melos configuration
- This flag only works if no script is defined, if so the list flag is ignored
- Added tests for the new flag

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
