### PR TITLE
feat: add functionality to keep custom intellij modules

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   string_scanner: ^1.4.1
   yaml: ^3.1.3
   yaml_edit: ^2.2.2
+  xml: ^6.6.1
 
 dev_dependencies:
   mockito: ^5.5.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

As described in #589 intellij modules are overwritten at each `melos bootstrap`. The reason for this is that the whole modules.xml file isrecreated at every bootstrap.

## Description

- Added xml dependency to read and parse the xml content of the modules.xml properly
- Added a function to compare the modules inside the current modules.xml with the melos modules. Then merge them before recreating the modules.xml.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
