### PR TITLE
docs: Add note about globs support from Dart 3.11

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -87,8 +87,9 @@ workspace:
   - packages/server_package
 ```
 
-> [!NOTE]
-> Starting from Dart v3.11.0, the workspace definition will support globs.
+<Info>
+Starting from Dart v3.11.0, the workspace definition will support globs.
+</Info>
 
 Where `packages/helper`, `packages/client_package` and `packages/server_package`
 are the paths to the packages in your workspace.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -87,6 +87,9 @@ workspace:
   - packages/server_package
 ```
 
+> [!NOTE]
+> Starting from Dart v3.11.0, the workspace definition will support globs.
+
 Where `packages/helper`, `packages/client_package` and `packages/server_package`
 are the paths to the packages in your workspace.
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Globs in the workspace definition will be supported from Dart 3.11, so a note regarding that is added.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
