### PR TITLE
fix: Prevent subsequent packages from executing after failure when failFast is enabled

### DIFF
--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -129,7 +129,11 @@ mixin _ExecMixin on _Melos {
 
     operation = CancelableOperation.fromFuture(
       pool.forEach<Package, void>(sortedPackages, (package) async {
-        assert(!(failFast && failures.isNotEmpty));
+        if (failFast && failures.isNotEmpty) {
+          packageResults[package.name]?.complete();
+          failures[package.name] = null;
+          return;
+        }
 
         if (orderDependents && !hasImpactfulCycles) {
           final dependenciesResults = await Future.wait(


### PR DESCRIPTION
## Description

Fixes an issue where `melos exec` with `--fail-fast` and `-c 1` (sequential execution) would continue executing subsequent packages even after a package fails, instead of immediately stopping execution.

### Problem
https://github.com/invertase/melos/issues/885
When running `melos exec` with `failFast=true` and `concurrency=1`:
- A package fails and triggers `operation.cancel()`
- However, the Pool has already started scheduling the next package
- Due to a race condition, subsequent packages continue to execute despite the failure
- This defeats the purpose of the `--fail-fast` flag

### Root Cause
The `operation.cancel()` call is asynchronous, and the Pool pre-schedules tasks. By the time the cancellation completes, the next package in the queue has already begun execution.

### Solution
Added a check at the beginning of each package execution:
```dart
if (failFast && failures.isNotEmpty) {
  packageResults[package.name]?.complete();
  failures[package.name] = null;
  return;
}
```

This ensures that even if the Pool starts a task, the task immediately checks if any failures have occurred and exits before executing the actual command, properly marking itself as "CANCELED (due to failFast)".

### Testing
I attempted to write an automated test for this scenario, but discovered that the race condition doesn't manifest in the test environment due to the extremely fast execution times (< 1ms per package). The issue only surfaces in real-world scenarios where packages take seconds to execute.

The fix has been manually tested on my own repository with 25 packages where the issue was consistently reproducible. After the fix, execution correctly stops after the first failure.

## Type of Change

- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)