### PR TITLE
feat: Changed from topological sort to layered topologic sort for orderDependents

### DIFF
--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -377,16 +377,10 @@ mixin _ListMixin on _Melos {
     final cycles = findCyclicDependenciesInWorkspace(
       workspace.filteredPackages.values.toList(),
     );
-
     if (cycles.isEmpty) {
       logger.stdout('🎉 No cycles in dependencies found.');
     } else {
-      logger.stdout('🚨 ${cycles.length} cycles in dependencies found:');
-      for (final cycle in cycles) {
-        logger.stdout(
-          '[ ${cycle.map((package) => package.name).join(' -> ')} ]',
-        );
-      }
+      printCyclesInDependencies(cycles, logger);
       exitCode = 1;
     }
   }

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -192,8 +192,8 @@ mixin _PublishMixin on _ExecMixin {
 
     await _execForAllPackages(
       workspace,
-      unpublishedPackages,
       execArgs,
+      executablePackages: unpublishedPackages,
       concurrency: 1,
       failFast: true,
       orderDependents: false,

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -36,6 +36,7 @@ import '../common/pending_package_update.dart';
 import '../common/persistent_shell.dart';
 import '../common/platform.dart';
 import '../common/pubspec_overrides.dart';
+import '../common/topology.dart';
 import '../common/utils.dart' as utils;
 import '../common/utils.dart';
 import '../common/versioning.dart' as versioning;

--- a/packages/melos/lib/src/common/topology.dart
+++ b/packages/melos/lib/src/common/topology.dart
@@ -1,0 +1,106 @@
+import 'package:cli_util/cli_logging.dart';
+import 'package:collection/collection.dart' hide stronglyConnectedComponents;
+import 'package:graphs/graphs.dart';
+
+import '../package.dart';
+
+/// Sorts [packages] in topological order so they can be published without
+/// errors.
+///
+/// Packages with inter-dependencies cannot be topologically sorted and will
+/// be sorted by name length. This is a heuristic to better handle cyclic
+/// dependencies in federated plugins.
+void sortPackagesForPublishing(List<Package> packages) {
+  final packageNames = packages.map((package) => package.name).toList();
+  final graph = <String, Iterable<String>>{
+    for (final package in packages)
+      package.name: [
+        ...package.dependencies.where(packageNames.contains),
+        ...package.devDependencies.where(packageNames.contains),
+      ],
+  };
+  final ordered =
+      stronglyConnectedComponents(graph.keys, (package) => graph[package]!)
+          .expand(
+            (component) => component.sortedByCompare(
+              (package) => package.length,
+              (a, b) => b - a,
+            ),
+          )
+          .toList();
+
+  packages.sort((a, b) {
+    return ordered.indexOf(a.name).compareTo(ordered.indexOf(b.name));
+  });
+}
+
+/// Sorts [packages] in layered topological order so on each layer packages
+/// are not dependent from each other.
+/// Check against cyclic dependencies should be done separately.
+List<List<Package>> sortPackagesForExecution(List<Package> packages) {
+  final packageNames = packages.map((package) => package.name).toList();
+  final packageMap = {for (final package in packages) package.name: package};
+  final graph = <String, Iterable<String>>{
+    for (final package in packages)
+      package.name: [
+        ...package.dependencies.where(packageNames.contains),
+        ...package.devDependencies.where(packageNames.contains),
+      ],
+  };
+  return stronglyConnectedComponents(graph.keys, (package) => graph[package]!)
+      .map(
+        (sortedPackageNames) =>
+            sortedPackageNames.map((e) => packageMap[e]!).toList(),
+      )
+      .toList();
+}
+
+/// Filters [packageLayers] to contain only [executablePackages].
+/// Empty layers are dropped.
+List<List<Package>> whereOnlyExecutablePackages(
+  List<List<Package>> packageLayers,
+  List<Package> executablePackages,
+) {
+  final executablePackageNames = executablePackages.map(
+    (package) => package.name,
+  );
+  return packageLayers
+      .map(
+        (packageLayer) => packageLayer
+            .where((package) => executablePackageNames.contains(package.name))
+            .toList(growable: false),
+      )
+      .where((layer) => layer.isNotEmpty)
+      .toList(growable: false);
+}
+
+/// Returns a list of dependency cycles between [packages], taking into
+/// account only workspace dependencies.
+///
+/// All dependencies between packages in the workspace are considered, including
+/// `dev_dependencies` and `dependency_overrides`.
+List<List<Package>> findCyclicDependenciesInWorkspace(List<Package> packages) {
+  return stronglyConnectedComponents(
+    packages,
+    (package) => package.allDependenciesInWorkspace.values,
+  ).where((component) => component.length > 1).map((component) {
+    try {
+      topologicalSort(
+        component,
+        (package) => package.allDependenciesInWorkspace.values,
+      );
+    } on CycleException<Package> catch (error) {
+      return error.cycle;
+    }
+    throw StateError('Expected a cycle to be found.');
+  }).toList();
+}
+
+void printCyclesInDependencies(List<List<Package>> cycles, Logger logger) {
+  logger.stdout('🚨 ${cycles.length} cycles in dependencies found:');
+  for (final cycle in cycles) {
+    logger.stdout(
+      '[ ${cycle.map((package) => package.name).join(' -> ')} ]',
+    );
+  }
+}

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -2,7 +2,7 @@ import 'package:melos/melos.dart';
 import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/command_configs/publish.dart';
 import 'package:melos/src/common/glob.dart';
-import 'package:melos/src/common/utils.dart';
+import 'package:melos/src/common/topology.dart';
 import 'package:melos/src/lifecycle_hooks/publish.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';

--- a/packages/melos/test/git_test.dart
+++ b/packages/melos/test/git_test.dart
@@ -17,6 +17,9 @@ void main() {
       expect(branchName, isNotEmpty);
     });
 
+    // If you forked repo and test fails:
+    // 1. git remote add "upstream" https://github.com/invertase/melos.git — add original repo as upstream
+    // 2. git fetch --tags upstream — fetch tags from original repo
     test('gitTagExists', () async {
       const aTagThatExists = 'melos-v0.4.11';
       const aTagThatDoesNotExist = 'not-melos-v0.4.11';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
<!--- Describe your changes in detail -->

Feature/Fix for https://github.com/invertase/melos/issues/974

1. Refactored `_execForAllPackages` to rely on layered topological sort in case if `orderDependents` is true.
2. Added cyclic dependency check for `exec` in case if `orderDepdents` is true.
3. Removed `dependency failed` checks in case if `failFast: false`
4. Added test for case if `orderDependents: true` with package filter applied.
5. Moved functions that use package `graphs` to `topology.dart` for readability

Generally, this PR is a breaking change, as it changes behaviour of `_execForAllPackages` in case if `orderDependents` is true.
If there are cyclic dependencies — it shouldn't be allowed to run `exec` with `orderDependents`, as in this case we cannot have layers. Thus, with this PR `exec` runs with `orderDependents: true` with cyclic dependencies will not succeed, thus, being a breaking change.
On the other hand, we don't need to maintain `hasImpactfulCycles` failure logic, and we can rely on existing mechanism.
This changes logs behave, so this is another breaking change.

`_PublishMixin` shouldn't be impacted, as check against cyclic dependencies is not needed, due to hard limit of `concurrency: 1` and due to `orderDependents: false`.

On the other hand, there is some topological sort for publish packages.

Breaking changes are visible in changes of test logic.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
