### PR TITLE
chore: Downgrade min sdk to 3.8

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 3.9.0 # Update when min sdk supported version of `melos` package changes.
+          sdk: 3.8.0 # Update when min sdk supported version of `melos` package changes.
       - name: Run Melos
         run: ./.github/workflows/scripts/install-tools.sh
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -80,7 +80,7 @@ now:
 name: my_project
 publish_to: none
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 workspace:
   - packages/helper
   - packages/client_package
@@ -146,7 +146,7 @@ For single package setup, just add `useRootAsPackage: true` to your
 name: my_single_package
 publish_to: none
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 
 dev_dependencies:
   melos: ^7.0.0

--- a/docs/guides/migrations.mdx
+++ b/docs/guides/migrations.mdx
@@ -23,7 +23,7 @@ After the migration your root `pubspec.yaml` file would now look something like 
 name: my_workspace
 publish_to: none
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 workspace:
   - packages/helper
   - packages/client_package
@@ -41,7 +41,7 @@ And this is what the `pubspec.yaml` file of a package would look like:
 ```yaml
 name: my_package
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 resolution: workspace
 ```
 
@@ -75,7 +75,7 @@ Add the `useRootAsPackage` option to maintain existing behavior:
 name: my_workspace
 publish_to: none
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 workspace:
   - packages/helper
   - packages/client_package

--- a/packages/conventional_commit/pubspec.yaml
+++ b/packages/conventional_commit/pubspec.yaml
@@ -1,13 +1,12 @@
 name: conventional_commit
-description:
-  Parse a git commit message using the Conventional Commits specification.
+description: Parse a git commit message using the Conventional Commits specification.
 version: 0.6.1+1
 repository: https://github.com/invertase/melos/tree/main/packages/conventional_commit
 issue_tracker: https://github.com/invertase/melos/issues
 resolution: workspace
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 
 dev_dependencies:
   test: any

--- a/packages/melos/README.md
+++ b/packages/melos/README.md
@@ -72,7 +72,7 @@ like this:
 name: my_workspace
 publish_to: none
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 workspace:
   - packages/helper
   - packages/client_package
@@ -90,7 +90,7 @@ And this is what the `pubspec.yaml` file of a package would look like:
 ```yaml
 name: my_package
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 resolution: workspace
 ```
 

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -17,7 +17,7 @@ topics:
   - lerna
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 
 executables:
   melos:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ workspace:
   - packages/melos
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.8.0
 
 # This allows us to use melos on itself during development.
 executables:
@@ -27,7 +27,7 @@ melos:
   command:
     bootstrap:
       environment:
-        sdk: ^3.9.0
+        sdk: ^3.8.0
       dependencies:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
@@ -86,8 +86,7 @@ melos:
 
     activate:
       description: Activate the local version of melos for development.
-      run:
-        dart pub global activate --source="path" . --executable="melos"
+      run: dart pub global activate --source="path" . --executable="melos"
         --overwrite
 
     activate:pub:


### PR DESCRIPTION
## Description

This PR downgrades the sdk requirement to 3.8.0 to allow more projects to use melos ^7.0.0. This addresses #978.
It is understood that this will not make it to `main`, as there are good reasons to require Dart ^3.9.0 in the general case.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
