### PR TITLE
feat: Support tag_pattern based versioning in git dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-  "dart.runPubGetOnPubspecChanges": "always"
+  "dart.runPubGetOnPubspecChanges": "always",
+  "[dart]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "never",
+      "source.organizeImports": "never",
+      "source.sortMembers": "never"
+    },
+    "editor.defaultFormatter": "Dart-Code.dart-code",
+    "editor.formatOnSave": false,
+    "editor.formatOnType": false,
+  },
 }

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -29,6 +29,7 @@ import '../common/extensions/environment.dart';
 import '../common/git.dart';
 import '../common/git_commit.dart';
 import '../common/git_repository.dart';
+import '../common/git_tag_pattern_dependency.dart';
 import '../common/glob.dart';
 import '../common/intellij_project.dart';
 import '../common/io.dart';

--- a/packages/melos/lib/src/common/git_tag_pattern_dependency.dart
+++ b/packages/melos/lib/src/common/git_tag_pattern_dependency.dart
@@ -1,0 +1,95 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:yaml/yaml.dart';
+
+// TODO: Remove this class once pubspec_parse supports tag_pattern dependencies.
+/// Represents a Git dependency that uses tag patterns for versioning.
+///
+/// Instead of using pubspec_parse for parsing this dependency, we
+/// manually parse the pubspec string to extract the necessary fields.
+/// Though the tag_pattern feature is officially supported by dart since
+/// SDK version 3.9.0, the pubspec_parse package does not yet support it.
+/// See: [Dart SDK issue](https://github.com/dart-lang/tools/issues/2155)
+class GitTagPatternDependency extends GitDependency {
+  GitTagPatternDependency({
+    required this.name,
+    required this.tagPattern,
+    required this.version,
+    required Uri url,
+    String? path,
+  }) : super(url, path: path);
+  final String name;
+  final String tagPattern;
+  final Version version;
+
+  /// Searches for a git dependency with a tag_pattern in the pubspec string.
+  ///
+  /// Looks for the dependency by [name] in dependencies, dev_dependencies,
+  /// and dependency_overrides sections.
+  /// Returns a [GitTagPatternDependency] instance
+  /// if found, otherwise returns null.
+  static GitTagPatternDependency? fromRawCommit({
+    required String pubspec,
+    required String name,
+  }) {
+    final yaml = loadYaml(pubspec) as Map<Object?, Object?>?;
+    if (yaml == null) {
+      return null;
+    }
+    // Search in all dependency sections
+    for (final section in [
+      'dependencies',
+      'dev_dependencies',
+      'dependency_overrides',
+    ]) {
+      final dependencies = yaml[section] as Map<Object?, Object?>?;
+      if (dependencies == null) {
+        continue;
+      }
+
+      final dependency = dependencies[name];
+      if (dependency == null || dependency is! Map<Object?, Object?>) {
+        continue;
+      }
+
+      // Check if this is a git dependency with tag_pattern
+      final git = dependency['git'];
+      if (git == null || git is! Map<Object?, Object?>) {
+        continue;
+      }
+
+      final tagPattern = git['tag_pattern'];
+      if (tagPattern == null || tagPattern is! String) {
+        continue;
+      }
+
+      // Extract required fields
+      final url = git['url'];
+      if (url == null || url is! String) {
+        continue;
+      }
+
+      final path = git['path'] as String?;
+
+      final versionString = dependency['version'];
+      if (versionString == null || versionString is! String) {
+        continue;
+      }
+
+      final version = VersionConstraint.parse(versionString);
+      if (version is! VersionRange || version.min == null) {
+        continue;
+      }
+
+      return GitTagPatternDependency(
+        name: name,
+        url: Uri.parse(url),
+        path: path,
+        tagPattern: tagPattern,
+        version: version.min!,
+      );
+    }
+
+    return null;
+  }
+}

--- a/packages/melos/test/utils.dart
+++ b/packages/melos/test/utils.dart
@@ -162,12 +162,19 @@ Future<Directory> createTemporaryWorkspace({
   return Directory(workspacePath);
 }
 
+/// Creates a new project in the given [workspace] directory.
+///
+/// If you pass a [rawPubspecContent], it will be used as the content of the
+/// `pubspec.yaml` file instead of generating one from the [partialPubspec].
+/// This helps testing edge cases that are not supported by
+/// the pubspec_parse package.
 Future<Directory> createProject(
   Directory workspace,
   Pubspec partialPubspec, {
   String? path,
   bool createLockfile = false,
   bool inWorkspace = true,
+  String? rawPubspecContent,
 }) async {
   final pubspec = partialPubspec.copyWith(
     environment: partialPubspec.environment.isEmpty
@@ -194,7 +201,12 @@ Future<Directory> createProject(
 
   ensureDir(projectDirectory.path);
 
-  await pubspec.save(projectDirectory);
+  if (rawPubspecContent != null) {
+    final pubspecFile = File(p.join(projectDirectory.path, 'pubspec.yaml'));
+    await pubspecFile.writeAsString(rawPubspecContent);
+  } else {
+    await pubspec.save(projectDirectory);
+  }
 
   if (createLockfile) {
     final lockfile = p.join(projectDirectory.path, 'pubspec.lock');
@@ -468,7 +480,7 @@ class VirtualWorkspaceBuilder {
 }
 
 final defaultTestEnvironment = {
-  'sdk': VersionConstraint.parse('^3.6.0'),
+  'sdk': VersionConstraint.parse('^3.10.0'),
 };
 
 class _VirtualPackage {

--- a/scripts/generate_version.dart
+++ b/scripts/generate_version.dart
@@ -10,8 +10,12 @@ Future<void> main() async {
     [Directory.current.path, 'packages', 'melos', 'lib', 'version.g.dart'],
   );
   print('Updating generated file $outputPath');
-  final melosPubspecPath =
-      p.joinAll([Directory.current.path, 'packages', 'melos', 'pubspec.yaml']);
+  final melosPubspecPath = p.joinAll([
+    Directory.current.path,
+    'packages',
+    'melos',
+    'pubspec.yaml',
+  ]);
   final yamlMap =
       loadYaml(File(melosPubspecPath).readAsStringSync()) as YamlMap;
   final currentVersion = yamlMap['version'] as String;


### PR DESCRIPTION
## Description

This PR implements a temporary workaround to version git dependencies that are using the `tag_pattern` based versioning introduced in the Dart SDK 3.9.0. See #933.

Melos is using the [pubspec_parse](https://pub.dev/packages/pubspec_parse) package to handle dependency versioning. Unfortunately `pubspec_parse` does not support he `tag_pattern` in git dependencies and will probably not do so in the near future as a [PR](https://github.com/dart-lang/tools/pull/2159) dealing with this problem has been closed unmerged.

Once the [dart-lang issue #2155](https://github.com/dart-lang/tools/issues/2155) has been closed, this workaround can be removed.

## Implementation

This workaround reads the pubspec as unparsed string and searches for dependencies using `tag_pattern`. If found, they are parsed to a new `GitTagPatternDependency` which extends the `GitDependency` from the `pubspec_parse` package. This adds another dependency case to the versioning. Tests have been added.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore

## Fixes issue

- fix #933 