### PR TITLE
feat(intellij): add runArguments support for IntelliJ run configurations

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -270,6 +270,34 @@ melos:
       generateAppRunConfigs: false
 ```
 
+### runArguments
+
+Allows specifying additional run arguments per Flutter app package. This
+generates one IntelliJ run configuration per entry instead of the default single
+configuration.
+
+The `name` field sets the display name suffix and output filename. If `name` is
+omitted and `default: true` is set, the entry replaces the default configuration.
+
+```yaml
+melos:
+  ide:
+    intellij:
+      runArguments:
+        my_app:
+          - name: local
+            args: "--flavor local --dart-define-from-file=local.json"
+          - name: prod
+            args: "--flavor prod --dart-define-from-file=prod.json"
+          - default: true
+            args: "--flavor dev"
+```
+
+This generates:
+- `melos_flutter_run_my_app_local.xml`
+- `melos_flutter_run_my_app_prod.xml`
+- `melos_flutter_run_my_app.xml` (the default)
+
 ## scripts
 
 Define custom scripts that can be executed in the workspace via the

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -342,33 +342,93 @@ class IntellijProject {
   }
 
   Future<void> writeFlutterRunScripts() async {
-    final flutterTestTemplate = await readFileTemplate(
+    final flutterRunTemplate = await readFileTemplate(
       'flutter_run.xml',
       templateCategory: 'runConfigurations',
     );
+    final flutterRunWithArgsTemplate = await readFileTemplate(
+      'flutter_run_with_args.xml',
+      templateCategory: 'runConfigurations',
+    );
+
+    final runArguments = _workspace.config.ide.intelliJ.runArguments;
+
+    // Warn about packages in runArguments that don't exist in the workspace.
+    for (final packageName in runArguments.keys) {
+      final exists = _workspace.filteredPackages.values.any(
+        (p) => p.name == packageName,
+      );
+      if (!exists) {
+        _workspace.logger.warning(
+          'runArguments references package "$packageName" '
+          'which was not found in this workspace.',
+        );
+      }
+    }
 
     await Future.forEach(_workspace.filteredPackages.values, (package) async {
       if (!package.isFlutterApp) {
         return;
       }
 
-      final generatedRunConfiguration = injectTemplateVariables(
-        flutterTestTemplate,
-        {
-          'flutterRunName': "Flutter Run -&gt; '${package.name}'",
-          'flutterRunMainDartPathRelative': p
-              .join(package.pathRelativeToWorkspace, 'lib', 'main.dart')
-              .replaceAll(r'\', '/'),
-        },
-      );
-      final outputFile = p.join(
-        pathDotIdea,
-        'runConfigurations',
-        'melos_flutter_run_${package.name}.xml',
-      );
+      final packageRunArgs = runArguments[package.name] ?? [];
+      final mainDartPath = p
+          .join(package.pathRelativeToWorkspace, 'lib', 'main.dart')
+          .replaceAll(r'\', '/');
 
-      await forceWriteToFile(outputFile, generatedRunConfiguration);
+      if (packageRunArgs.isEmpty) {
+        // Original behaviour — one default config, no extra args.
+        final generatedRunConfiguration = injectTemplateVariables(
+          flutterRunTemplate,
+          {
+            'flutterRunName': "Flutter Run -&gt; '${package.name}'",
+            'flutterRunMainDartPathRelative': mainDartPath,
+          },
+        );
+        final outputFile = p.join(
+          pathDotIdea,
+          'runConfigurations',
+          'melos_flutter_run_${package.name}.xml',
+        );
+        await forceWriteToFile(outputFile, generatedRunConfiguration);
+      } else {
+        // One config per runArguments entry.
+        for (final runArg in packageRunArgs) {
+          final isDefault =
+              runArg.isDefault || runArg.name == null || runArg.name!.isEmpty;
+          final configDisplayName = isDefault
+              ? "Flutter Run -&gt; '${package.name}'"
+              : "Flutter Run -&gt; '${package.name}' (${runArg.name})";
+          final fileSuffix = isDefault
+              ? package.name
+              : '${package.name}_${runArg.name}';
+
+          final generatedRunConfiguration = injectTemplateVariables(
+            flutterRunWithArgsTemplate,
+            {
+              'flutterRunName': configDisplayName,
+              'flutterRunMainDartPathRelative': mainDartPath,
+              'flutterRunAdditionalArgs': _escapeXmlAttr(runArg.args),
+            },
+          );
+          final outputFile = p.join(
+            pathDotIdea,
+            'runConfigurations',
+            'melos_flutter_run_$fileSuffix.xml',
+          );
+          await forceWriteToFile(outputFile, generatedRunConfiguration);
+        }
+      }
     });
+  }
+
+  /// Escapes characters that are unsafe inside XML attribute values.
+  String _escapeXmlAttr(String value) {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('"', '&quot;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;');
   }
 
   Future<void> writeFlutterTestScripts() async {

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -774,21 +774,14 @@ class IdeRunConfiguration {
     );
   }
 
-  /// Optional display name, e.g. "local" or "prod".
   final String? name;
-
-  /// If true, args are merged into the default config instead of
-  /// creating a new named configuration.
-  final bool isDefault;
-
-  /// Additional args string, e.g.
-  /// "--flavor local --dart-define-from-file=local.json"
   final String args;
+  final bool isDefault;
 
   Map<String, Object?> toJson() => {
     'name': name,
-    'default': isDefault,
     'args': args,
+    'default': isDefault,
   };
 
   @override
@@ -796,10 +789,10 @@ class IdeRunConfiguration {
       other is IdeRunConfiguration &&
       runtimeType == other.runtimeType &&
       other.name == name &&
-      other.isDefault == isDefault &&
-      other.args == args;
+      other.args == args &&
+      other.isDefault == isDefault;
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^ name.hashCode ^ isDefault.hashCode ^ args.hashCode;
+      runtimeType.hashCode ^ name.hashCode ^ args.hashCode ^ isDefault.hashCode;
 }

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -67,6 +67,7 @@ class IntelliJConfig {
     this.moduleNamePrefix = _defaultModuleNamePrefix,
     this.executeInTerminal = _defaultExecuteInTerminal,
     this.generateAppRunConfigs = _defaultGenerateAppRunConfigs,
+    this.runArguments = const {},
   });
 
   factory IntelliJConfig.fromYaml(Object? yaml) {
@@ -95,11 +96,26 @@ class IntelliJConfig {
               path: 'ide/intellij',
             )
           : _defaultGenerateAppRunConfigs;
+      final rawRunArgsYaml = yaml['runArguments'];
+      final rawRunArgs = (rawRunArgsYaml is Map)
+          ? rawRunArgsYaml.cast<Object?, Object?>()
+          : <Object?, Object?>{};
+      final runArguments = <String, List<IdeRunConfiguration>>{};
+      for (final entry in rawRunArgs.entries) {
+        final pkgName = entry.key! as String;
+        final list = (entry.value! as List)
+            .cast<Map<Object?, Object?>>()
+            .map(IdeRunConfiguration.fromYaml)
+            .toList();
+        runArguments[pkgName] = list;
+      }
+
       return IntelliJConfig(
         enabled: enabled,
         moduleNamePrefix: moduleNamePrefix,
         executeInTerminal: executeInTerminal,
         generateAppRunConfigs: generateAppRunConfigs,
+        runArguments: runArguments,
       );
     } else {
       final enabled = assertIsA<bool>(
@@ -125,12 +141,20 @@ class IntelliJConfig {
 
   final bool generateAppRunConfigs;
 
+  final Map<String, List<IdeRunConfiguration>> runArguments;
+
   Object? toJson() {
     return {
       'enabled': enabled,
       'moduleNamePrefix': moduleNamePrefix,
       'executeInTerminal': executeInTerminal,
       'generateAppRunConfigs': generateAppRunConfigs,
+      'runArguments': runArguments.map(
+        (key, value) => MapEntry(
+          key,
+          value.map((e) => e.toJson()).toList(),
+        ),
+      ),
     };
   }
 
@@ -141,7 +165,11 @@ class IntelliJConfig {
       other.enabled == enabled &&
       other.moduleNamePrefix == moduleNamePrefix &&
       other.executeInTerminal == executeInTerminal &&
-      other.generateAppRunConfigs == generateAppRunConfigs;
+      other.generateAppRunConfigs == generateAppRunConfigs &&
+      const DeepCollectionEquality().equals(
+        other.runArguments,
+        runArguments,
+      );
 
   @override
   int get hashCode =>
@@ -149,7 +177,8 @@ class IntelliJConfig {
       enabled.hashCode ^
       moduleNamePrefix.hashCode ^
       executeInTerminal.hashCode ^
-      generateAppRunConfigs.hashCode;
+      generateAppRunConfigs.hashCode ^
+      const DeepCollectionEquality().hash(runArguments);
 
   @override
   String toString() {
@@ -726,4 +755,51 @@ class UnresolvedWorkspace implements MelosException {
 
   @override
   String toString() => message;
+}
+
+/// A single named run configuration with additional arguments.
+@immutable
+class IdeRunConfiguration {
+  const IdeRunConfiguration({
+    required this.args,
+    this.name,
+    this.isDefault = false,
+  });
+
+  factory IdeRunConfiguration.fromYaml(Map<Object?, Object?> yaml) {
+    return IdeRunConfiguration(
+      name: yaml['name'] as String?,
+      args: yaml['args'] as String? ?? '',
+      isDefault: yaml['default'] as bool? ?? false,
+    );
+  }
+
+  /// Optional display name, e.g. "local" or "prod".
+  final String? name;
+
+  /// If true, args are merged into the default config instead of
+  /// creating a new named configuration.
+  final bool isDefault;
+
+  /// Additional args string, e.g.
+  /// "--flavor local --dart-define-from-file=local.json"
+  final String args;
+
+  Map<String, Object?> toJson() => {
+    'name': name,
+    'default': isDefault,
+    'args': args,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      other is IdeRunConfiguration &&
+      runtimeType == other.runtimeType &&
+      other.name == name &&
+      other.isDefault == isDefault &&
+      other.args == args;
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ name.hashCode ^ isDefault.hashCode ^ args.hashCode;
 }

--- a/packages/melos/templates/intellij/runConfigurations/flutter_run_with_args.xml.tmpl
+++ b/packages/melos/templates/intellij/runConfigurations/flutter_run_with_args.xml.tmpl
@@ -1,4 +1,4 @@
-﻿<component name="ProjectRunConfigurationManager">
+<component name="ProjectRunConfigurationManager">
   <configuration default="false" name="{{#flutterRunName}}" type="FlutterRunConfigurationType" factoryName="Flutter">
     <option name="filePath" value="$PROJECT_DIR$/{{#flutterRunMainDartPathRelative}}" />
     <option name="additionalArgs" value="{{#flutterRunAdditionalArgs}}" />

--- a/packages/melos/templates/intellij/runConfigurations/flutter_run_with_args.xml.tmpl
+++ b/packages/melos/templates/intellij/runConfigurations/flutter_run_with_args.xml.tmpl
@@ -1,0 +1,7 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="{{#flutterRunName}}" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/{{#flutterRunMainDartPathRelative}}" />
+    <option name="additionalArgs" value="{{#flutterRunAdditionalArgs}}" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/packages/melos/test/common/intellij_project_test.dart
+++ b/packages/melos/test/common/intellij_project_test.dart
@@ -104,4 +104,221 @@ void main() {
       );
     },
   );
+
+  // https://github.com/invertase/melos/issues/1004
+  group('runArguments', () {
+    test(
+      'generates single default config when no runArguments specified',
+      () async {
+        final tempDir = createTestTempDir();
+        await createProject(
+          tempDir,
+          Pubspec(
+            'my_app',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+          path: 'packages/my_app',
+        );
+        File(
+          p.join(tempDir.path, 'packages', 'my_app', 'lib', 'main.dart'),
+        ).createSync(recursive: true);
+
+        final workspaceBuilder = VirtualWorkspaceBuilder(
+          path: tempDir.path,
+          '''
+          packages:
+            - packages/my_app
+          ''',
+        );
+        workspaceBuilder.addPackage(
+          File(
+            p.join(tempDir.path, 'packages', 'my_app', 'pubspec.yaml'),
+          ).readAsStringSync(),
+        );
+
+        final workspace = workspaceBuilder.build();
+        final project = IntellijProject.fromWorkspace(workspace);
+        await project.writeFlutterRunScripts();
+
+        final defaultXml = p.join(
+          project.runConfigurationsDir.path,
+          'melos_flutter_run_my_app.xml',
+        );
+        expect(File(defaultXml).existsSync(), isTrue);
+        final content = readTextFile(defaultXml);
+        expect(content, isNot(contains('additionalArgs')));
+      },
+    );
+
+    test(
+      'generates one config per named runArguments entry',
+      () async {
+        final tempDir = createTestTempDir();
+        await createProject(
+          tempDir,
+          Pubspec(
+            'my_app',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+          path: 'packages/my_app',
+        );
+        File(
+          p.join(tempDir.path, 'packages', 'my_app', 'lib', 'main.dart'),
+        ).createSync(recursive: true);
+
+        final workspaceBuilder = VirtualWorkspaceBuilder(
+          path: tempDir.path,
+          '''
+          packages:
+            - packages/my_app
+          ide:
+            intellij:
+              runArguments:
+                my_app:
+                  - name: local
+                    args: "--flavor local --dart-define-from-file=local.json"
+                  - name: prod
+                    args: "--flavor prod --dart-define-from-file=prod.json"
+          ''',
+        );
+        workspaceBuilder.addPackage(
+          File(
+            p.join(tempDir.path, 'packages', 'my_app', 'pubspec.yaml'),
+          ).readAsStringSync(),
+        );
+
+        final workspace = workspaceBuilder.build();
+        final project = IntellijProject.fromWorkspace(workspace);
+        await project.writeFlutterRunScripts();
+
+        final localXml = p.join(
+          project.runConfigurationsDir.path,
+          'melos_flutter_run_my_app_local.xml',
+        );
+        final prodXml = p.join(
+          project.runConfigurationsDir.path,
+          'melos_flutter_run_my_app_prod.xml',
+        );
+
+        expect(File(localXml).existsSync(), isTrue);
+        expect(File(prodXml).existsSync(), isTrue);
+
+        final localContent = readTextFile(localXml);
+        expect(localContent, contains('--flavor local'));
+        expect(localContent, contains('additionalArgs'));
+
+        final prodContent = readTextFile(prodXml);
+        expect(prodContent, contains('--flavor prod'));
+        expect(prodContent, contains('additionalArgs'));
+      },
+    );
+
+    test(
+      'entry with default: true generates config with package name as filename',
+      () async {
+        final tempDir = createTestTempDir();
+        await createProject(
+          tempDir,
+          Pubspec(
+            'my_app',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+          path: 'packages/my_app',
+        );
+        File(
+          p.join(tempDir.path, 'packages', 'my_app', 'lib', 'main.dart'),
+        ).createSync(recursive: true);
+
+        final workspaceBuilder = VirtualWorkspaceBuilder(
+          path: tempDir.path,
+          '''
+          packages:
+            - packages/my_app
+          ide:
+            intellij:
+              runArguments:
+                my_app:
+                  - default: true
+                    args: "--flavor dev"
+          ''',
+        );
+        workspaceBuilder.addPackage(
+          File(
+            p.join(tempDir.path, 'packages', 'my_app', 'pubspec.yaml'),
+          ).readAsStringSync(),
+        );
+
+        final workspace = workspaceBuilder.build();
+        final project = IntellijProject.fromWorkspace(workspace);
+        await project.writeFlutterRunScripts();
+
+        final defaultXml = p.join(
+          project.runConfigurationsDir.path,
+          'melos_flutter_run_my_app.xml',
+        );
+        expect(File(defaultXml).existsSync(), isTrue);
+        final content = readTextFile(defaultXml);
+        expect(content, contains('--flavor dev'));
+        expect(content, contains('additionalArgs'));
+      },
+    );
+
+    test(
+      'escapes XML special characters in args',
+      () async {
+        final tempDir = createTestTempDir();
+        await createProject(
+          tempDir,
+          Pubspec(
+            'my_app',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+          path: 'packages/my_app',
+        );
+        File(
+          p.join(tempDir.path, 'packages', 'my_app', 'lib', 'main.dart'),
+        ).createSync(recursive: true);
+
+        final workspaceBuilder = VirtualWorkspaceBuilder(
+          path: tempDir.path,
+          '''
+          packages:
+            - packages/my_app
+          ide:
+            intellij:
+              runArguments:
+                my_app:
+                  - name: local
+                    args: '--dart-define=KEY="value"'
+          ''',
+        );
+        workspaceBuilder.addPackage(
+          File(
+            p.join(tempDir.path, 'packages', 'my_app', 'pubspec.yaml'),
+          ).readAsStringSync(),
+        );
+
+        final workspace = workspaceBuilder.build();
+        final project = IntellijProject.fromWorkspace(workspace);
+        await project.writeFlutterRunScripts();
+
+        final xmlFile = p.join(
+          project.runConfigurationsDir.path,
+          'melos_flutter_run_my_app_local.xml',
+        );
+        expect(File(xmlFile).existsSync(), isTrue);
+        final content = readTextFile(xmlFile);
+        expect(content, contains('&quot;'));
+        expect(content, isNot(contains('"value"')));
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Description

Closes #1004

Allows users to specify custom run arguments per Flutter app package in `melos.yaml` under `ide.intellij.runArguments`. This enables teams to generate multiple named IntelliJ run configurations with different flavors, dart-defines, or other arguments — without manually creating them per developer.

### Usage

```yaml
melos:
  ide:
    intellij:
      runArguments:
        my_app:
          - name: local
            args: "--flavor local --dart-define-from-file=local.json"
          - name: prod
            args: "--flavor prod --dart-define-from-file=prod.json"
          - default: true
            args: "--flavor dev"
```

This generates:
- `melos_flutter_run_my_app_local.xml`
- `melos_flutter_run_my_app_prod.xml`
- `melos_flutter_run_my_app.xml` (when default: true or name is empty)

### Changes
- Add `IdeRunConfiguration` model with `name`, `args`, and `isDefault` fields
- Add `runArguments` field to `IntelliJConfig` with YAML parsing support
- Update `writeFlutterRunScripts` to generate one config per runArguments entry, falling back to original behaviour when none are specified
- Add `_escapeXmlAttr` helper to safely escape XML attribute values
- Add validation warning when a runArguments package is not found in the workspace
- Add `flutter_run_with_args.xml.tmpl` template with additionalArgs support

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)