### PR TITLE
feat: add `pubGetArgs` to `BootstrapCommandConfigs`

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -351,6 +351,23 @@ The default is `false`.
 To temporarily override this `melos bootstrap --no-enforce-lockfile / --enforce-lockfile` can be
 used.
 
+### pubGetArgs
+
+A list of additional arguments to pass to `pub get` during bootstrapping.
+
+This is useful when you want to pass custom flags to `pub get` for all runs of
+`melos bootstrap` without having to specify them every time.
+
+The default is an empty list.
+
+```yaml
+melos:
+  command:
+    bootstrap:
+      pubGetArgs:
+        - --no-precompile
+```
+
 ## command/version
 
 Configuration for the `version` command.

--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -17,6 +17,7 @@ class BootstrapCommandConfigs {
     this.runPubGetInParallel = true,
     this.runPubGetOffline = false,
     this.enforceLockfile = false,
+    this.pubGetArgs = const [],
     this.environment,
     this.dependencies,
     this.devDependencies,
@@ -70,6 +71,17 @@ class BootstrapCommandConfigs {
       ),
     );
 
+    final pubGetArgs = assertListIsA<String>(
+      key: 'pubGetArgs',
+      map: yaml,
+      isRequired: false,
+      assertItemIsA: (index, value) => assertIsA<String>(
+        value: value,
+        index: index,
+        path: 'command/bootstrap/pubGetArgs',
+      ),
+    );
+
     final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'hooks',
       map: yaml,
@@ -87,6 +99,7 @@ class BootstrapCommandConfigs {
       runPubGetInParallel: runPubGetInParallel,
       runPubGetOffline: runPubGetOffline,
       enforceLockfile: enforceLockfile,
+      pubGetArgs: pubGetArgs,
       environment: environment.isEmpty ? null : environment,
       dependencies: dependencies.isEmpty ? null : dependencies,
       devDependencies: devDependencies.isEmpty ? null : devDependencies,
@@ -120,6 +133,9 @@ class BootstrapCommandConfigs {
   /// The default is `false`.
   final bool enforceLockfile;
 
+  /// Additional arguments to pass to `pub get` during bootstrapping.
+  final List<String> pubGetArgs;
+
   /// Environment configuration to be synced between all packages.
   final Environment? environment;
 
@@ -141,6 +157,7 @@ class BootstrapCommandConfigs {
       'runPubGetInParallel': runPubGetInParallel,
       'runPubGetOffline': runPubGetOffline,
       'enforceLockfile': enforceLockfile,
+      if (pubGetArgs.isNotEmpty) 'pubGetArgs': pubGetArgs,
       if (environment != null) 'environment': environment!.toJson(),
       if (dependencies != null) 'dependencies': dependencies!.toJson(),
       if (devDependencies != null)
@@ -160,6 +177,7 @@ class BootstrapCommandConfigs {
       other.runPubGetInParallel == runPubGetInParallel &&
       other.runPubGetOffline == runPubGetOffline &&
       other.enforceLockfile == enforceLockfile &&
+      const ListEquality<String>().equals(other.pubGetArgs, pubGetArgs) &&
       // Extracting equality from environment here as it does not implement ==
       other.environment.sdkConstraint == environment.sdkConstraint &&
       const DeepCollectionEquality().equals(other.environment, environment) &&
@@ -179,6 +197,7 @@ class BootstrapCommandConfigs {
       runPubGetInParallel.hashCode ^
       runPubGetOffline.hashCode ^
       enforceLockfile.hashCode ^
+      const ListEquality<String>().hash(pubGetArgs) ^
       // Extracting hashCode from environment here as it does not implement
       // hashCode
       environment.sdkConstraint.hashCode ^
@@ -197,6 +216,7 @@ BootstrapCommandConfigs(
   runPubGetInParallel: $runPubGetInParallel,
   runPubGetOffline: $runPubGetOffline,
   enforceLockfile: $enforceLockfile,
+  pubGetArgs: $pubGetArgs,
   environment: $environment,
   dependencies: $dependencies,
   devDependencies: $devDependencies,

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -26,12 +26,14 @@ mixin _BootstrapMixin on _CleanMixin {
             workspace.config.commands.bootstrap.enforceLockfile;
         final shouldEnforceLockfile =
             (enforceLockfile ?? enforceLockfileConfigValue) && hasLockFile;
+        final pubGetArgs = bootstrapCommandConfig.pubGetArgs;
 
         final pubCommandForLogging = _buildPubGetCommand(
           workspace: workspace,
           noExample: noExample,
           runOffline: runOffline,
           enforceLockfile: shouldEnforceLockfile,
+          pubGetArgs: pubGetArgs,
         ).join(' ');
 
         logger
@@ -75,6 +77,7 @@ mixin _BootstrapMixin on _CleanMixin {
             noExample: noExample,
             runOffline: runOffline,
             enforceLockfile: shouldEnforceLockfile,
+            pubGetArgs: pubGetArgs,
           );
 
           logger
@@ -122,6 +125,7 @@ mixin _BootstrapMixin on _CleanMixin {
     required bool noExample,
     required bool runOffline,
     required bool enforceLockfile,
+    List<String> pubGetArgs = const [],
   }) async {
     await runPubGetForPackage(
       workspace,
@@ -129,6 +133,7 @@ mixin _BootstrapMixin on _CleanMixin {
       noExample: noExample,
       runOffline: runOffline,
       enforceLockfile: enforceLockfile,
+      pubGetArgs: pubGetArgs,
     );
   }
 
@@ -139,12 +144,14 @@ mixin _BootstrapMixin on _CleanMixin {
     required bool noExample,
     required bool runOffline,
     required bool enforceLockfile,
+    List<String> pubGetArgs = const [],
   }) async {
     final command = _buildPubGetCommand(
       workspace: workspace,
       noExample: noExample,
       runOffline: runOffline,
       enforceLockfile: enforceLockfile,
+      pubGetArgs: pubGetArgs,
     );
     final process = await startCommandRaw(
       command,
@@ -184,6 +191,7 @@ mixin _BootstrapMixin on _CleanMixin {
     required bool noExample,
     required bool runOffline,
     required bool enforceLockfile,
+    List<String> pubGetArgs = const [],
   }) {
     return [
       ...pubCommandExecArgs(
@@ -194,6 +202,7 @@ mixin _BootstrapMixin on _CleanMixin {
       if (noExample) '--no-example',
       if (runOffline) '--offline',
       if (enforceLockfile) '--enforce-lockfile',
+      ...pubGetArgs,
     ];
   }
 

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -738,6 +738,112 @@ Generating IntelliJ IDE files...
       );
     });
 
+    test('can run pub get with extra pubGetArgs from config', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: [],
+        configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+          createYamlMap(
+            {
+              'melos': {
+                'command': {
+                  'bootstrap': {
+                    'pubGetArgs': ['--no-precompile'],
+                  },
+                },
+              },
+            },
+            defaults: configMapDefaults,
+          ),
+          path: path,
+        ),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
+        logger: logger.toMelosLogger(),
+      );
+      final melos = Melos(logger: logger, config: config);
+      final pubExecArgs = pubCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
+      );
+
+      await runMelosBootstrap(melos, logger);
+
+      expect(
+        logger.output,
+        ignoringAnsii(
+          '''
+melos bootstrap
+  └> ${workspaceDir.path}
+
+Running "${pubExecArgs.join(' ')} get --no-precompile" in workspace...
+  > SUCCESS
+
+Generating IntelliJ IDE files...
+  > SUCCESS
+
+ -> 0 packages bootstrapped
+''',
+        ),
+      );
+    });
+
+    test('can run pub get with multiple pubGetArgs from config', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: [],
+        configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+          createYamlMap(
+            {
+              'melos': {
+                'command': {
+                  'bootstrap': {
+                    'pubGetArgs': ['--no-precompile', '--no-example'],
+                  },
+                },
+              },
+            },
+            defaults: configMapDefaults,
+          ),
+          path: path,
+        ),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
+        logger: logger.toMelosLogger(),
+      );
+      final melos = Melos(logger: logger, config: config);
+      final pubExecArgs = pubCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
+      );
+
+      await runMelosBootstrap(melos, logger);
+
+      expect(
+        logger.output,
+        ignoringAnsii(
+          '''
+melos bootstrap
+  └> ${workspaceDir.path}
+
+Running "${pubExecArgs.join(' ')} get --no-precompile --no-example" in workspace...
+  > SUCCESS
+
+Generating IntelliJ IDE files...
+  > SUCCESS
+
+ -> 0 packages bootstrapped
+''',
+        ),
+      );
+    });
+
     test(
       'applies shared dependencies from melos config',
       () async {


### PR DESCRIPTION
## Description

Closes #988

Adds a `pubGetArgs` field to `BootstrapCommandConfigs` that allows users to 
configure default arguments passed to `pub get` during `melos bootstrap` via 
`melos.yaml`, without having to specify them every time.

The arguments are appended to the `pub get` command after the existing flags 
(`--offline`, `--enforce-lockfile`, etc.).

### Example usage

```yaml
melos:
  command:
    bootstrap:
      pubGetArgs:
        - --no-precompile
```

### Changes
- `command_configs/bootstrap.dart` — added `pubGetArgs` field, YAML parsing, `toJson`, `==`, `hashCode`, `toString`
- `commands/bootstrap.dart` — threaded `pubGetArgs` through `_buildPubGetCommand`, `_runPubGetForWorkspace`, `runPubGetForPackage`
- `test/commands/bootstrap_test.dart` — added 2 tests covering single and multiple args
- `docs/configuration/overview.mdx` — documented the new field under `command/bootstrap`

## Type of Change
- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 📝 `docs` -- Documentation
