### PR TITLE
fix(bootstrap): apply `dependencyOverridePaths` to workspace pubspec_overrides.yaml

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -311,17 +311,35 @@ Configuration for the `bootstrap` command.
 
 ### dependencyOverridePaths
 
-A list of paths to local packages relative to the workspace directory that
-should be added to each workspace package's dependency overrides. Each entry can
-be a specific path or a [glob] pattern.
+A list of paths to local packages that should be linked into the workspace as
+`dependency_overrides`. Paths are resolved relative to the workspace directory
+and each entry can be a specific path or a [glob] pattern.
+
+During `melos bootstrap`, every matched package is written as a path-based
+`dependency_overrides` entry into the workspace root `pubspec_overrides.yaml`.
+The managed entries are tagged with a `melos_managed_dependency_overrides`
+marker comment so any user-defined entries in the same file are preserved
+across bootstraps:
+
+```yaml
+# melos_managed_dependency_overrides: my_pkg
+dependency_overrides:
+  my_pkg:
+    path: ../external_project/packages/my_pkg
+```
+
+Entries no longer matched by `dependencyOverridePaths` are removed on the next
+bootstrap. Entries without the marker comment are left untouched.
 
 **Tip:** External local packages can be referenced using paths relative to the
 workspace root.
 
 ```yaml
 melos:
-  dependencyOverridePaths:
-    - '../external_project/packages/**'
+  command:
+    bootstrap:
+      dependencyOverridePaths:
+        - '../external_project/packages/**'
 ```
 
 ### runPubGetInParallel

--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -145,8 +145,14 @@ class BootstrapCommandConfigs {
   /// Dev dependencies to be synced between all packages.
   final Map<String, Dependency>? devDependencies;
 
-  /// A list of [Glob]s for paths that contain packages to be used as dependency
-  /// overrides for all packages managed in the Melos workspace.
+  /// A list of [Glob]s for paths that contain packages to be used as
+  /// dependency overrides for the Melos workspace.
+  ///
+  /// During `melos bootstrap`, each matched package is added as a path-based
+  /// `dependency_overrides` entry in the workspace root
+  /// `pubspec_overrides.yaml` file, and tagged with a
+  /// `melos_managed_dependency_overrides` marker comment so user-defined
+  /// overrides in the same file are preserved.
   final List<Glob> dependencyOverridePaths;
 
   /// Lifecycle hooks for this command.

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -43,6 +43,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
         final filteredPackages = workspace.filteredPackages.values;
         final rollbackPubspecContent = <String, String>{};
+        _PubspecOverridesRollback? overridesRollback;
 
         try {
           if (bootstrapCommandConfig.environment != null ||
@@ -67,6 +68,10 @@ mixin _BootstrapMixin on _CleanMixin {
               );
             }).drain<void>();
           }
+
+          overridesRollback = await _writeWorkspaceDependencyOverrides(
+            workspace,
+          );
 
           logger.log(
             'Running "$pubCommandForLogging" in workspace...',
@@ -95,6 +100,10 @@ mixin _BootstrapMixin on _CleanMixin {
             ) async {
               await writeTextFileAsync(entry.key, entry.value);
             }).drain<void>();
+          }
+
+          if (overridesRollback != null) {
+            await overridesRollback.restore();
           }
 
           _logBootstrapException(exception, workspace);
@@ -204,6 +213,62 @@ mixin _BootstrapMixin on _CleanMixin {
       if (enforceLockfile) '--enforce-lockfile',
       ...pubGetArgs,
     ];
+  }
+
+  /// Writes path-based dependency overrides for the packages matched by
+  /// [BootstrapCommandConfigs.dependencyOverridePaths] to the workspace root
+  /// `pubspec_overrides.yaml`.
+  ///
+  /// The managed entries are tagged with a `melos_managed_dependency_overrides`
+  /// marker comment so user-defined overrides in the same file are preserved.
+  ///
+  /// Returns a rollback handle that restores the file to its previous state, or
+  /// `null` if no changes were made.
+  Future<_PubspecOverridesRollback?> _writeWorkspaceDependencyOverrides(
+    MelosWorkspace workspace,
+  ) async {
+    final overridesPath = utils.pubspecOverridesPathForDirectory(
+      workspace.path,
+    );
+    final originalContent = fileExists(overridesPath)
+        ? await readTextFileAsync(overridesPath)
+        : null;
+
+    final melosDependencyOverrides = <String, Dependency>{
+      for (final package in workspace.dependencyOverridePackages.values)
+        package.name: PathDependency(
+          relativePath(package.path, workspace.path),
+        ),
+    };
+
+    final updatedContent = _mergeMelosPubspecOverrides(
+      melosDependencyOverrides,
+      originalContent,
+    );
+
+    if (updatedContent == null) {
+      return null;
+    }
+
+    if (updatedContent.isEmpty) {
+      deleteEntry(overridesPath);
+    } else {
+      await writeTextFileAsync(overridesPath, updatedContent);
+    }
+
+    final relativeOverridesPath = relativePath(overridesPath, workspace.path);
+    final message = melosDependencyOverrides.isEmpty
+        ? 'Removed obsolete melos-managed dependency_overrides'
+        : 'Linked ${melosDependencyOverrides.length} '
+              'melos-managed dependency_overrides';
+    logger
+        .child(targetStyle(relativeOverridesPath), prefix: '$checkLabel ')
+        .child(message);
+
+    return _PubspecOverridesRollback(
+      path: overridesPath,
+      originalContent: originalContent,
+    );
   }
 
   Future<void> _setSharedDependenciesForPackage(
@@ -403,6 +468,28 @@ mixin _BootstrapMixin on _CleanMixin {
     }
     if (processStdErrString != null) {
       logger.stderr(processStdErrString);
+    }
+  }
+}
+
+/// Rollback handle for changes made to a `pubspec_overrides.yaml` file during
+/// bootstrap.
+class _PubspecOverridesRollback {
+  _PubspecOverridesRollback({
+    required this.path,
+    required this.originalContent,
+  });
+
+  final String path;
+  final String? originalContent;
+
+  Future<void> restore() async {
+    if (originalContent == null) {
+      if (fileExists(path)) {
+        deleteEntry(path);
+      }
+    } else {
+      await writeTextFileAsync(path, originalContent!);
     }
   }
 }

--- a/packages/melos/lib/src/commands/clean.dart
+++ b/packages/melos/lib/src/commands/clean.dart
@@ -18,6 +18,10 @@ mixin _CleanMixin on _Melos {
 
         await Future.wait(workspace.filteredPackages.values.map(_cleanPackage));
 
+        await _cleanMelosManagedOverrides(
+          utils.pubspecOverridesPathForDirectory(workspace.path),
+        );
+
         await cleanIntelliJ(workspace);
 
         logger
@@ -44,20 +48,31 @@ mixin _CleanMixin on _Melos {
       }
     }
 
-    // Remove any old Melos generated dependency overrides from
-    // `pubspec_overrides.yaml`. This can be removed after a few versions when
-    // everyone has migrated to Melos ^7.0.0.
-    final pubspecOverridesFile = p.join(package.path, 'pubspec_overrides.yaml');
-    if (fileExists(pubspecOverridesFile)) {
-      final contents = await readTextFileAsync(pubspecOverridesFile);
-      final updatedContents = _mergeMelosPubspecOverrides({}, contents);
-      if (updatedContents != null) {
-        if (updatedContents.isEmpty) {
-          deleteEntry(pubspecOverridesFile);
-        } else {
-          await writeTextFileAsync(pubspecOverridesFile, updatedContents);
-        }
-      }
+    // Strip any Melos-managed dependency overrides from per-package
+    // `pubspec_overrides.yaml` files. These were written by older versions of
+    // Melos (pre pub-workspaces); current versions write to the workspace
+    // root file instead, but cleaning these keeps legacy workspaces tidy.
+    await _cleanMelosManagedOverrides(
+      p.join(package.path, 'pubspec_overrides.yaml'),
+    );
+  }
+
+  /// Removes melos-managed `dependency_overrides` from the
+  /// `pubspec_overrides.yaml` at [path], preserving any user-defined entries.
+  /// Deletes the file if no overrides remain.
+  Future<void> _cleanMelosManagedOverrides(String path) async {
+    if (!fileExists(path)) {
+      return;
+    }
+    final contents = await readTextFileAsync(path);
+    final updatedContents = _mergeMelosPubspecOverrides({}, contents);
+    if (updatedContents == null) {
+      return;
+    }
+    if (updatedContents.isEmpty) {
+      deleteEntry(path);
+    } else {
+      await writeTextFileAsync(path, updatedContents);
     }
   }
 

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -401,6 +401,203 @@ Generating IntelliJ IDE files...
       );
     });
 
+    test(
+      'writes dependencyOverridePaths to workspace pubspec_overrides.yaml '
+      'with melos-managed marker',
+      () async {
+        final overrideDir = createTestTempDir();
+        final overrideProject = await createProject(
+          overrideDir,
+          Pubspec('override_pkg'),
+          path: '',
+        );
+
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+          configBuilder: (path) => MelosWorkspaceConfig(
+            name: 'workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(
+              bootstrap: BootstrapCommandConfigs(
+                dependencyOverridePaths: [
+                  createGlob(overrideProject.path, currentDirectoryPath: path),
+                ],
+              ),
+            ),
+            path: path,
+          ),
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'override_pkg': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await runMelosBootstrap(melos, logger);
+
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        expect(File(overridesPath).existsSync(), isTrue);
+
+        final overridesContent = readTextFile(overridesPath);
+        expect(
+          overridesContent,
+          contains('# melos_managed_dependency_overrides: override_pkg'),
+        );
+
+        final parsedOverrides = loadYaml(overridesContent) as YamlMap;
+        final dependencyOverrides =
+            parsedOverrides['dependency_overrides'] as YamlMap;
+        expect(
+          (dependencyOverrides['override_pkg'] as YamlMap)['path'],
+          relativePath(overrideProject.path, workspaceDir.path),
+        );
+
+        final aConfig = packageConfigForPackageAt(workspaceDir);
+        expect(
+          p.canonicalize(
+            p.join(
+              p.dirname(packageConfigPath(workspaceDir.path)),
+              p.prettyUri(
+                aConfig.packages
+                    .firstWhere((p) => p.name == 'override_pkg')
+                    .rootUri,
+              ),
+            ),
+          ),
+          p.canonicalize(overrideProject.path),
+        );
+      },
+    );
+
+    test(
+      'preserves user-defined dependency_overrides alongside melos-managed '
+      'ones',
+      () async {
+        final overrideDir = createTestTempDir();
+        final overrideProject = await createProject(
+          overrideDir,
+          Pubspec('override_pkg'),
+          path: '',
+        );
+
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+          configBuilder: (path) => MelosWorkspaceConfig(
+            name: 'workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(
+              bootstrap: BootstrapCommandConfigs(
+                dependencyOverridePaths: [
+                  createGlob(overrideProject.path, currentDirectoryPath: path),
+                ],
+              ),
+            ),
+            path: path,
+          ),
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'override_pkg': HostedDependency(version: VersionConstraint.any),
+              'meta': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+
+        // Pre-existing pubspec_overrides.yaml with a user-defined override.
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        writeTextFile(
+          overridesPath,
+          '''
+dependency_overrides:
+  meta:
+    hosted: https://pub.dev
+    version: ^1.0.0
+''',
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await runMelosBootstrap(melos, logger);
+
+        final overridesContent = readTextFile(overridesPath);
+        expect(
+          overridesContent,
+          contains('# melos_managed_dependency_overrides: override_pkg'),
+        );
+
+        final parsed = loadYaml(overridesContent) as YamlMap;
+        final overrides = parsed['dependency_overrides'] as YamlMap;
+        // User-defined entry preserved.
+        expect(overrides.containsKey('meta'), isTrue);
+        // Melos-managed entry written.
+        expect(
+          (overrides['override_pkg'] as YamlMap)['path'],
+          relativePath(overrideProject.path, workspaceDir.path),
+        );
+      },
+    );
+
+    test(
+      'removes obsolete melos-managed dependency_overrides on bootstrap',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a'),
+        );
+
+        // Simulate state left by a previous bootstrap that had a
+        // dependencyOverridePaths entry which is no longer configured.
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        writeTextFile(
+          overridesPath,
+          '''
+# melos_managed_dependency_overrides: stale_pkg
+dependency_overrides:
+  stale_pkg:
+    path: ../stale_pkg
+''',
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        await runMelosBootstrap(Melos(logger: logger, config: config), logger);
+
+        // The stale managed override and marker comment should be gone.
+        expect(File(overridesPath).existsSync(), isFalse);
+      },
+    );
+
     test('bootstrap flutter example packages', () async {
       final workspaceDir = await createTemporaryWorkspace(
         workspacePackages: ['a'],

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -561,6 +561,85 @@ dependency_overrides:
     );
 
     test(
+      'expands glob patterns in dependencyOverridePaths to multiple packages',
+      () async {
+        final overridesRoot = createTestTempDir();
+        final overrideOne = await createProject(
+          overridesRoot,
+          Pubspec('override_one'),
+          path: 'one',
+          inWorkspace: false,
+        );
+        final overrideTwo = await createProject(
+          overridesRoot,
+          Pubspec('override_two'),
+          path: 'two',
+          inWorkspace: false,
+        );
+
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+          configBuilder: (path) => MelosWorkspaceConfig(
+            name: 'workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(
+              bootstrap: BootstrapCommandConfigs(
+                dependencyOverridePaths: [
+                  createGlob(
+                    p.join(overridesRoot.path, '*'),
+                    currentDirectoryPath: path,
+                  ),
+                ],
+              ),
+            ),
+            path: path,
+          ),
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'override_one': HostedDependency(version: VersionConstraint.any),
+              'override_two': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        await runMelosBootstrap(Melos(logger: logger, config: config), logger);
+
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        final overridesContent = readTextFile(overridesPath);
+        expect(
+          overridesContent,
+          contains(
+            '# melos_managed_dependency_overrides: '
+            'override_one,override_two',
+          ),
+        );
+
+        final overrides =
+            (loadYaml(overridesContent) as YamlMap)['dependency_overrides']
+                as YamlMap;
+        expect(
+          (overrides['override_one'] as YamlMap)['path'],
+          relativePath(overrideOne.path, workspaceDir.path),
+        );
+        expect(
+          (overrides['override_two'] as YamlMap)['path'],
+          relativePath(overrideTwo.path, workspaceDir.path),
+        );
+      },
+    );
+
+    test(
       'removes obsolete melos-managed dependency_overrides on bootstrap',
       () async {
         final workspaceDir = await createTemporaryWorkspace(

--- a/packages/melos/test/commands/clean_test.dart
+++ b/packages/melos/test/commands/clean_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:melos/src/common/utils.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  group('clean', () {
+    test(
+      'strips melos-managed dependency_overrides from workspace root '
+      'pubspec_overrides.yaml while preserving user-defined entries',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a'),
+        );
+
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        writeTextFile(
+          overridesPath,
+          '''
+# melos_managed_dependency_overrides: managed_pkg
+dependency_overrides:
+  managed_pkg:
+    path: ../managed_pkg
+  user_pkg:
+    path: ../user_pkg
+''',
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        await Melos(logger: logger, config: config).clean();
+
+        expect(File(overridesPath).existsSync(), isTrue);
+        final after = readTextFile(overridesPath);
+        expect(
+          after,
+          isNot(contains('melos_managed_dependency_overrides')),
+        );
+        expect(after, isNot(contains('managed_pkg')));
+        expect(after, contains('user_pkg'));
+      },
+    );
+
+    test(
+      'deletes workspace pubspec_overrides.yaml when only melos-managed '
+      'entries remain',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a'),
+        );
+
+        final overridesPath = pubspecOverridesPathForDirectory(
+          workspaceDir.path,
+        );
+        writeTextFile(
+          overridesPath,
+          '''
+# melos_managed_dependency_overrides: managed_pkg
+dependency_overrides:
+  managed_pkg:
+    path: ../managed_pkg
+''',
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        await Melos(logger: logger, config: config).clean();
+
+        expect(File(overridesPath).existsSync(), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`command/bootstrap/dependencyOverridePaths` was parsed and resolved into `MelosWorkspace.dependencyOverridePackages`, but the migration to Pub workspaces (#816) removed the per-package `pubspec_overrides.yaml` writing path without rewiring it to the workspace root, the option has been effectively dead since 7.0.0.

`melos bootstrap` now writes each matched package as a path-based `dependency_overrides` entry into the workspace root `pubspec_overrides.yaml`, tagged with a `melos_managed_dependency_overrides` marker comment so any user-defined entries in the same file are preserved across bootstraps:

```yaml
# melos_managed_dependency_overrides: my_pkg
dependency_overrides:
  my_pkg:
    path: ../external_project/packages/my_pkg
```

- Obsolete managed entries are pruned on subsequent bootstraps and by `melos clean`.
- Entries without the marker comment are left untouched.
- The file write is rolled back if `pub get` fails (matches the existing `pubspec.yaml` rollback behavior).

Also fixes the `dependencyOverridePaths` docs, which had the option nested at the wrong level (`melos.dependencyOverridePaths` instead of `melos.command.bootstrap.dependencyOverridePaths`).

## Test plan

- [x] `dart analyze` clean
- [x] New tests in `bootstrap_test.dart`:
  - writes overrides + marker comment to the root `pubspec_overrides.yaml` and pub resolves to the local path
  - preserves user-defined `dependency_overrides` entries
  - removes obsolete melos-managed entries on bootstrap when no longer configured
- [x] New `clean_test.dart`:
  - strips melos-managed entries while preserving user-defined ones
  - deletes the file when only melos-managed entries remained
- [x] Full `bootstrap_test.dart` + `workspace_test.dart` + `workspace_config_test.dart` suites pass (86 tests)