### PR TITLE
feat(scripts): add stdio: inherit for interactive scripts

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -57,6 +57,32 @@ A short description, shown when using `melos run` with no argument.
 
 The command to execute.
 
+## stdio
+
+Controls how the script's process is connected to Melos's own input and output
+streams. Accepts one of:
+
+- `pipe` (default) — Melos captures the script's `stdout` and `stderr` so it can
+  prefix the output with the script name. The script's `stdin` is not connected.
+- `inherit` — the script inherits Melos's `stdin`, `stdout`, and `stderr`
+  directly, giving it a real terminal (TTY). Use this for interactive commands
+  that need a controlling terminal, such as `tmux attach`, `vim`, `less`, or the
+  hot-reload key handlers in `flutter run` / `dart_frog dev`. In this mode Melos
+  does not prefix the script's output.
+
+```yaml
+scripts:
+  attach:
+    run: tmux attach -t my_session
+    stdio: inherit
+```
+
+`stdio: inherit` runs a single foreground process attached to your terminal, so
+it cannot be combined with [`exec`](/configuration/scripts#exec) (which runs the
+script across multiple packages) or [`steps`](/configuration/scripts#steps)
+(which run inside a shared shell). Set `stdio: inherit` on the individual
+scripts referenced from `steps` instead.
+
 ## steps
 
 Steps enables the combination of multiple scripts within a single script

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -29,7 +29,7 @@ export 'src/package.dart'
         PackageFilters,
         PackageMap,
         PackageType;
-export 'src/scripts.dart' show ExecOptions, Script, Scripts;
+export 'src/scripts.dart' show ExecOptions, ProcessStdio, Script, Scripts;
 export 'src/workspace.dart' show IdeWorkspace, MelosWorkspace;
 export 'src/workspace_config.dart'
     show IDEConfigs, IntelliJConfig, MelosWorkspaceConfig;

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -91,7 +91,6 @@ class MelosCommandRunner extends CommandRunner<void> {
   }
 }
 
-@override
 FutureOr<void> melosEntryPoint(
   List<String> arguments,
   LaunchContext context,

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -316,6 +316,7 @@ mixin _RunMixin on _Melos {
       logger: logger,
       environment: environment,
       workingDirectory: config.path,
+      inheritStdio: script.stdio == ProcessStdio.inherit,
     );
   }
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -426,6 +426,7 @@ Future<Process> startCommandRaw(
   String? workingDirectory,
   Map<String, String> environment = const {},
   bool includeParentEnvironment = true,
+  ProcessStartMode mode = ProcessStartMode.normal,
 }) {
   final executable = currentPlatform.isWindows ? 'cmd.exe' : '/bin/sh';
   workingDirectory ??= Directory.current.path;
@@ -442,6 +443,7 @@ Future<Process> startCommandRaw(
       EnvironmentVariableKey.melosScript: command.join(' '),
     },
     includeParentEnvironment: includeParentEnvironment,
+    mode: mode,
   );
 }
 
@@ -459,6 +461,7 @@ Future<int> startCommand(
   bool includeParentEnvironment = true,
   String? group,
   ProcessOutputCancelToken? cancelToken,
+  bool inheritStdio = false,
 }) async {
   final processedCommand = command
       // Remove empty arguments.
@@ -471,9 +474,22 @@ Future<int> startCommand(
     workingDirectory: workingDirectory,
     environment: environment,
     includeParentEnvironment: includeParentEnvironment,
+    mode: inheritStdio
+        ? ProcessStartMode.inheritStdio
+        : ProcessStartMode.normal,
   );
 
   _runningPids.add(process.pid);
+
+  if (inheritStdio) {
+    // When stdio is inherited, the child writes directly to our terminal —
+    // its stdout/stderr streams are not available on the [Process] object,
+    // and there is nothing for melos to subscribe to. Just wait for it to
+    // finish.
+    final exitCode = await process.exitCode;
+    _runningPids.remove(process.pid);
+    return exitCode;
+  }
 
   var stdoutStream = process.stdout;
   var stderrStream = process.stderr;

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -102,35 +102,28 @@ enum ProcessStdio {
   /// Child stdout and stderr are piped through melos so it can prefix output
   /// with the script's indent. Child stdin is not connected. This is the
   /// default and is what every script gets without an explicit `stdio` key.
-  pipe('pipe'),
+  pipe,
 
   /// Child stdin, stdout, and stderr are inherited from melos's own terminal,
   /// giving the script a real TTY. Required for any program that needs an
   /// attached terminal — `tmux attach`, `vim`, `less`, `flutter run` /
   /// `dart_frog dev` hot-reload keys. Melos drops its indented output prefix
   /// for the duration of the script in exchange for the TTY.
-  inherit('inherit')
-  ;
-
-  const ProcessStdio(this.yamlValue);
-
-  /// The string used to select this mode in melos config (e.g.
-  /// `stdio: inherit`).
-  final String yamlValue;
+  inherit;
 
   /// Parses the value of a script's `stdio:` config key.
   ///
   /// Throws [MelosConfigException] if [value] is not a recognised mode.
-  static ProcessStdio fromYaml(
+  static ProcessStdio fromString(
     String value, {
     required String scriptName,
   }) {
     for (final mode in ProcessStdio.values) {
-      if (mode.yamlValue == value) {
+      if (mode.name == value) {
         return mode;
       }
     }
-    final allowed = ProcessStdio.values.map((m) => m.yamlValue).join(', ');
+    final allowed = ProcessStdio.values.map((m) => m.name).join(', ');
     throw MelosConfigException(
       'Invalid value "$value" for "stdio" on script $scriptName. '
       'Expected one of: $allowed.',
@@ -295,16 +288,14 @@ class Script {
           )
         : [];
 
-    final stdioYaml = yaml['stdio'];
-    final ProcessStdio stdio;
-    if (stdioYaml == null) {
-      stdio = ProcessStdio.pipe;
-    } else {
-      stdio = ProcessStdio.fromYaml(
-        assertIsA<String>(value: stdioYaml, key: 'stdio', path: scriptPath),
-        scriptName: name,
-      );
-    }
+    final stdioValue = assertKeyIsA<String?>(
+      key: 'stdio',
+      map: yaml,
+      path: scriptPath,
+    );
+    final stdio = stdioValue != null
+        ? ProcessStdio.fromString(stdioValue, scriptName: name)
+        : ProcessStdio.pipe;
 
     return Script(
       name: name,
@@ -480,7 +471,7 @@ class Script {
       if (exec != null) 'exec': exec!.toJson(),
       'private': isPrivate,
       if (groups != null) 'groups': groups,
-      if (stdio != ProcessStdio.pipe) 'stdio': stdio.yamlValue,
+      if (stdio != ProcessStdio.pipe) 'stdio': stdio.name,
     };
   }
 
@@ -526,7 +517,7 @@ Script(
   exec: ${exec.toString().indent('  ')},
   private: $isPrivate,
   groups: $groups,
-  stdio: ${stdio.yamlValue}
+  stdio: ${stdio.name}
 )''';
   }
 }

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -96,6 +96,48 @@ ExecOptions(
 )''';
 }
 
+/// Controls how the standard streams of a script's child process are wired
+/// to melos's own process.
+enum ProcessStdio {
+  /// Child stdout and stderr are piped through melos so it can prefix output
+  /// with the script's indent. Child stdin is not connected. This is the
+  /// default and is what every script gets without an explicit `stdio` key.
+  pipe('pipe'),
+
+  /// Child stdin, stdout, and stderr are inherited from melos's own terminal,
+  /// giving the script a real TTY. Required for any program that needs an
+  /// attached terminal — `tmux attach`, `vim`, `less`, `flutter run` /
+  /// `dart_frog dev` hot-reload keys. Melos drops its indented output prefix
+  /// for the duration of the script in exchange for the TTY.
+  inherit('inherit')
+  ;
+
+  const ProcessStdio(this.yamlValue);
+
+  /// The string used to select this mode in melos config (e.g.
+  /// `stdio: inherit`).
+  final String yamlValue;
+
+  /// Parses the value of a script's `stdio:` config key.
+  ///
+  /// Throws [MelosConfigException] if [value] is not a recognised mode.
+  static ProcessStdio fromYaml(
+    String value, {
+    required String scriptName,
+  }) {
+    for (final mode in ProcessStdio.values) {
+      if (mode.yamlValue == value) {
+        return mode;
+      }
+    }
+    final allowed = ProcessStdio.values.map((m) => m.yamlValue).join(', ');
+    throw MelosConfigException(
+      'Invalid value "$value" for "stdio" on script $scriptName. '
+      'Expected one of: $allowed.',
+    );
+  }
+}
+
 @immutable
 class Script {
   const Script({
@@ -108,6 +150,7 @@ class Script {
     this.steps = const [],
     this.isPrivate = false,
     this.groups = const [],
+    this.stdio = ProcessStdio.pipe,
   });
 
   factory Script.fromYaml(
@@ -252,6 +295,17 @@ class Script {
           )
         : [];
 
+    final stdioYaml = yaml['stdio'];
+    final ProcessStdio stdio;
+    if (stdioYaml == null) {
+      stdio = ProcessStdio.pipe;
+    } else {
+      stdio = ProcessStdio.fromYaml(
+        assertIsA<String>(value: stdioYaml, key: 'stdio', path: scriptPath),
+        scriptName: name,
+      );
+    }
+
     return Script(
       name: name,
       run: run,
@@ -262,6 +316,7 @@ class Script {
       exec: exec,
       isPrivate: isPrivate ?? false,
       groups: groups,
+      stdio: stdio,
     );
   }
 
@@ -343,6 +398,11 @@ class Script {
   // The groups the script is belonging to
   final List<String>? groups;
 
+  /// How the script's child process should connect its standard streams to
+  /// melos. Defaults to [ProcessStdio.pipe]; set to [ProcessStdio.inherit] for
+  /// interactive commands that need a real terminal.
+  final ProcessStdio stdio;
+
   /// Returns the full command to run when executing this script.
   List<String> command([List<String>? extraArgs]) {
     String quoteScript(String script) => '"${script.replaceAll('"', r'\"')}"';
@@ -391,6 +451,22 @@ class Script {
         '    run: $run',
       );
     }
+    if (stdio == ProcessStdio.inherit && exec != null) {
+      throw MelosConfigException(
+        'The script "$name" has both "stdio: inherit" and "exec", which are '
+        'not compatible. "stdio: inherit" attaches a single child process to '
+        'the parent terminal; "exec" runs the script across multiple '
+        'packages.',
+      );
+    }
+    if (stdio == ProcessStdio.inherit && (steps != null && steps!.isNotEmpty)) {
+      throw MelosConfigException(
+        'The script "$name" has both "stdio: inherit" and "steps", which are '
+        'not compatible. "stdio: inherit" applies to a single process. Put '
+        'the inherit flag on the individual scripts referenced from "steps" '
+        'instead.',
+      );
+    }
   }
 
   Map<Object?, Object?> toJson() {
@@ -404,6 +480,7 @@ class Script {
       if (exec != null) 'exec': exec!.toJson(),
       'private': isPrivate,
       if (groups != null) 'groups': groups,
+      if (stdio != ProcessStdio.pipe) 'stdio': stdio.yamlValue,
     };
   }
 
@@ -419,7 +496,8 @@ class Script {
       other.steps == steps &&
       other.isPrivate == isPrivate &&
       other.groups == groups &&
-      other.exec == exec;
+      other.exec == exec &&
+      other.stdio == stdio;
 
   @override
   int get hashCode =>
@@ -432,7 +510,8 @@ class Script {
       steps.hashCode ^
       exec.hashCode ^
       isPrivate.hashCode ^
-      groups.hashCode;
+      groups.hashCode ^
+      stdio.hashCode;
 
   @override
   String toString() {
@@ -446,7 +525,8 @@ Script(
   steps: $steps,
   exec: ${exec.toString().indent('  ')},
   private: $isPrivate,
-  groups: $groups
+  groups: $groups,
+  stdio: ${stdio.yamlValue}
 )''';
   }
 }

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -531,6 +531,79 @@ void main() {
         );
       });
     });
+
+    group('stdio', () {
+      test('defaults to ProcessStdio.pipe when the key is omitted', () {
+        final scripts = Scripts.fromYaml(
+          createYamlMap({
+            'a': {
+              'run': 'b',
+            },
+          }),
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.stdio, ProcessStdio.pipe);
+      });
+
+      test('parses "stdio: inherit"', () {
+        final scripts = Scripts.fromYaml(
+          createYamlMap({
+            'a': {
+              'run': 'b',
+              'stdio': 'inherit',
+            },
+          }),
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.stdio, ProcessStdio.inherit);
+      });
+
+      test('throws when "stdio" is set to an unknown value', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'run': 'b',
+                'stdio': 'bogus',
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ),
+          throwsA(isA<MelosConfigException>()),
+        );
+      });
+
+      test('throws when "stdio: inherit" is combined with "exec"', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'run': 'b',
+                'stdio': 'inherit',
+                'exec': <String, Object?>{},
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ).validate(),
+          throwsA(isA<MelosConfigException>()),
+        );
+      });
+
+      test('throws when "stdio: inherit" is combined with "steps"', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'stdio': 'inherit',
+                'steps': ['echo hi'],
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ).validate(),
+          throwsA(isA<MelosConfigException>()),
+        );
+      });
+    });
   });
 
   group('MelosWorkspaceConfig', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Melos pipes a script's stdout/stderr by default so it can prefix child output. As a side effect, the child process has no controlling terminal (its stdin is also unconnected), which breaks any program that requires a real TTY: `tmux attach`, `vim`, `less`, hot-reload key handling in `flutter run` / `dart_frog dev`, etc. They fail with errors like `open terminal failed: not a terminal`.

This adds an opt-in `stdio: inherit` field on script definitions:

    scripts:
      attach:
        run: tmux attach -t my-session
        stdio: inherit

When set, melos uses `ProcessStartMode.inheritStdio` so the child's stdin/stdout/stderr are wired directly to melos's parent terminal. The trade-off is documented on the enum: melos drops its indented output prefix for the duration of that script in exchange for the TTY.

The default remains `pipe`; existing scripts are unaffected.

Validation rejects two combinations that cannot work:
  - `stdio: inherit` + `exec` (cannot multiplex one TTY across N parallel package children)
  - `stdio: inherit` + `steps` (`steps` run inside a persistent shell; put the inherit flag on the individual scripts referenced from `steps` instead)

Changes:
  - scripts.dart: new ProcessStdio enum, Script.stdio field, YAML parser, validation, equality/hashCode/toString/toJson coverage.
  - common/utils.dart: startCommandRaw accepts `mode`; startCommand accepts `inheritStdio` and branches before subscribing to process.stdout/stderr (those streams are unavailable in inheritStdio mode and would throw a StateError if listened to).
  - commands/run.dart: passes `script.stdio == ProcessStdio.inherit` through to startCommand.
  - melos.dart: exports the new ProcessStdio enum.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
