### PR TITLE
fix!: retain and increment build numbers when versioning

### DIFF
--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -77,6 +77,32 @@ the conventional commit type. This is useful since some collaborative version
 control systems use these non-configurable prefixes when they merge pull
 requests.
 
+#### Versions below 1.0.0
+
+Semantic versioning doesn't promise any compatibility between versions prior to
+`1.0.0`, but the Dart community convention is to treat those versions
+semantically as well, with the interpretation of each number shifted down one
+slot:
+
+- a **major** (breaking) bump increments the minor: `0.1.2` → `0.2.0`.
+- a **minor** (feature) bump increments the patch: `0.1.2` → `0.1.3`.
+- a **patch** bump also increments the patch: `0.1.2` → `0.1.3`.
+
+#### Build numbers
+
+A version may carry a build number, the `+N` suffix (e.g. `3.0.0+11`). When a
+package's current version has an integer build number, Melos retains it and
+increments it by one on every version bump, regardless of the bump type:
+
+- `3.0.0+11` with a major bump → `4.0.0+12`
+- `3.0.0+11` with a patch bump → `3.0.1+12`
+
+If the current version has no build number, none is added (e.g. `3.0.0` →
+`3.0.1`). Build metadata that is not a single integer (such as a prerelease-style
+tag, a git hash, or a dot-separated build) is not retained:
+
+- `3.0.0+abc` with a major bump → `4.0.0`
+
 #### Not using Conventional Commits?
 
 If an existing Git project is already established and does not use Conventional

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -57,42 +57,57 @@ Version nextStableVersion(
   Version currentVersion,
   SemverReleaseType releaseType,
 ) {
-  // For simplicity's sake, we avoid using + after the version reaches 1.0.0.
+  final Version bumpedVersion;
   if (currentVersion.major > 0) {
+    // Standard semantic versioning once the version reaches 1.0.0.
     switch (releaseType) {
       case SemverReleaseType.major:
-        return currentVersion.nextBreaking;
+        bumpedVersion = currentVersion.nextBreaking;
       case SemverReleaseType.minor:
-        return currentVersion.nextMinor;
+        bumpedVersion = currentVersion.nextMinor;
       case SemverReleaseType.patch:
-        return currentVersion.nextPatch;
+        bumpedVersion = currentVersion.nextPatch;
+    }
+  } else {
+    // Although semantic versioning doesn't promise any compatibility between
+    // versions prior to 1.0.0, the Dart community convention is to treat those
+    // versions semantically as well. The interpretation of each number is just
+    // shifted down one slot:
+    //   - going from 0.1.2 to 0.2.0 indicates a breaking change
+    //   - going to 0.1.3 indicates a new feature or a change that doesn't
+    //     affect the public API
+    switch (releaseType) {
+      case SemverReleaseType.major:
+        bumpedVersion = currentVersion.nextMinor;
+      case SemverReleaseType.minor:
+      case SemverReleaseType.patch:
+        bumpedVersion = currentVersion.nextPatch;
     }
   }
 
-  // Although semantic versioning doesn't promise any compatibility between
-  // versions prior to 1.0.0, the Dart community convention is to treat those
-  // versions semantically as well. The interpretation of each number is just
-  // shifted down one slot:
-  //   - going from 0.1.2 to 0.2.0 indicates a breaking change
-  //   - going to 0.1.3 indicates a new feature
-  //   - going to 0.1.2+1 indicates a change that doesn't affect the public API
-  switch (releaseType) {
-    case SemverReleaseType.major:
-      return currentVersion.nextMinor;
-    case SemverReleaseType.minor:
-      return currentVersion.nextPatch;
-    case SemverReleaseType.patch:
-      // Bump the build number, or set it if it does not exist.
-      final currentBuild = currentVersion.build.length == 1
-          ? currentVersion.build[0] as int
-          : 0;
-      return Version(
-        currentVersion.major,
-        currentVersion.minor,
-        currentVersion.patch,
-        build: (currentBuild + 1).toString(),
-      );
+  // Retain and increment an integer build number (e.g. `+11` -> `+12`) when the
+  // current version has one. Non-integer or multi-component build metadata
+  // (prerelease-style tags, git hashes, dot-separated builds) is not retained.
+  final currentBuildNumber = _integerBuildNumber(currentVersion);
+  if (currentBuildNumber != null) {
+    return Version(
+      bumpedVersion.major,
+      bumpedVersion.minor,
+      bumpedVersion.patch,
+      build: (currentBuildNumber + 1).toString(),
+    );
   }
+
+  return bumpedVersion;
+}
+
+/// Returns the build number of [version] if its build metadata is a single
+/// integer component (e.g. `+11`), otherwise `null`.
+int? _integerBuildNumber(Version version) {
+  if (version.build.length == 1 && version.build.first is int) {
+    return version.build.first as int;
+  }
+  return null;
 }
 
 Version nextPrereleaseVersion(

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -69,13 +69,10 @@ Version nextStableVersion(
         bumpedVersion = currentVersion.nextPatch;
     }
   } else {
-    // Although semantic versioning doesn't promise any compatibility between
-    // versions prior to 1.0.0, the Dart community convention is to treat those
-    // versions semantically as well. The interpretation of each number is just
-    // shifted down one slot:
-    //   - going from 0.1.2 to 0.2.0 indicates a breaking change
-    //   - going to 0.1.3 indicates a new feature or a change that doesn't
-    //     affect the public API
+    // Below 1.0.0 the interpretation of each number is shifted down one slot:
+    //   - a breaking change bumps the minor: 0.1.2 -> 0.2.0
+    //   - a new feature or a change that doesn't affect the public API bumps
+    //     the patch: 0.1.2 -> 0.1.3
     switch (releaseType) {
       case SemverReleaseType.major:
         bumpedVersion = currentVersion.nextMinor;

--- a/packages/melos/test/changelog_test.dart
+++ b/packages/melos/test/changelog_test.dart
@@ -53,7 +53,7 @@ void main() {
           package,
           testCommit(message: 'Merge foo into bar'),
         ),
-        '## 0.0.0+1\n\n',
+        '## 0.0.1\n\n',
       );
     });
 

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -371,7 +371,7 @@ The following 1 packages will be updated:
               AnsiStyles.strip('''
 > Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
 
- - `b` - `v0.0.1+1`
+ - `b` - `v0.0.2`
 '''),
             ),
           ),
@@ -622,7 +622,7 @@ The following 1 packages will be updated:
           );
           // app directly depends on core, so it should get a dependent bump
           // even though mid is ignored.
-          expect(pubspecApp.version, Version.parse('0.0.1+1'));
+          expect(pubspecApp.version, Version.parse('0.0.2'));
         },
       );
 

--- a/packages/melos/test/common/versioning_test.dart
+++ b/packages/melos/test/common/versioning_test.dart
@@ -219,6 +219,17 @@ const _versioningTestCases = [
   VersioningTestCase('1.1.1', '2.0.0', SemverReleaseType.major),
   VersioningTestCase('1.1.1', '1.2.0', SemverReleaseType.minor),
   VersioningTestCase('1.1.1', '1.1.2', SemverReleaseType.patch),
+
+  // An integer build number (e.g. `+11`) is retained and incremented when
+  // bumping a version, regardless of the release type.
+  VersioningTestCase('3.0.0+11', '4.0.0+12', SemverReleaseType.major),
+  VersioningTestCase('3.0.0+11', '3.1.0+12', SemverReleaseType.minor),
+  VersioningTestCase('3.0.0+11', '3.0.1+12', SemverReleaseType.patch),
+  // No build number is added when the current version doesn't have one.
+  VersioningTestCase('3.0.0', '3.0.1', SemverReleaseType.patch),
+  // Non-integer or multi-component build metadata is not retained.
+  VersioningTestCase('3.0.0+foo', '4.0.0', SemverReleaseType.major),
+  VersioningTestCase('3.0.0+1.2', '4.0.0', SemverReleaseType.major),
   VersioningTestCase(
     '1.0.0',
     '2.0.0-dev.0',
@@ -251,24 +262,27 @@ const _versioningTestCases = [
   // shifted down one slot
   VersioningTestCase('0.1.0', '0.2.0', SemverReleaseType.major),
   VersioningTestCase('0.1.0', '0.1.1', SemverReleaseType.minor),
+  // A patch release below 1.0.0 bumps the patch component rather than creating
+  // a build number.
   VersioningTestCase(
     '0.1.0',
-    '0.1.0+1',
+    '0.1.1',
     SemverReleaseType.patch,
   ),
+  // An existing integer build number is retained and incremented across bumps.
   VersioningTestCase(
     '0.1.1+1',
-    '0.2.0',
+    '0.2.0+2',
     SemverReleaseType.major,
   ),
   VersioningTestCase(
     '0.1.1+1',
-    '0.1.2',
+    '0.1.2+2',
     SemverReleaseType.minor,
   ),
   VersioningTestCase(
     '0.1.1+1',
-    '0.1.1+2',
+    '0.1.2+2',
     SemverReleaseType.patch,
   ),
   VersioningTestCase(
@@ -285,7 +299,7 @@ const _versioningTestCases = [
   ),
   VersioningTestCase(
     '0.1.0',
-    '0.1.0-dev.0+1',
+    '0.1.1-dev.0',
     SemverReleaseType.patch,
     shouldMakePrereleaseVersion: true,
   ),
@@ -364,7 +378,7 @@ const _versioningTestCases = [
   ),
   NullSafetyTestCase(
     '0.1.0+1',
-    '0.2.0-1.0.nullsafety.0',
+    '0.2.0-1.0.nullsafety.0+2',
     SemverReleaseType.patch,
   ),
 


### PR DESCRIPTION
## Description

Fixes #401.

When using `melos version` on application projects (or any package whose version carries a build number / version code, e.g. `3.0.0+11`), Melos previously **dropped the build number** when bumping the version, turning `3.0.0+11` into `4.0.0`.

This PR makes Melos **retain and increment** an integer build number on every version bump, so the version code is no longer lost on release.

### Build numbers (all version ranges)

An integer `+N` is retained and incremented by one on every bump, regardless of the bump type:

| Current | Bump | Before | After |
|---------|------|--------|-------|
| `3.0.0+11` | major | `4.0.0` | `4.0.0+12` |
| `3.0.0+11` | minor | `3.1.0` | `3.1.0+12` |
| `3.0.0+11` | patch | `3.0.1` | `3.0.1+12` |
| `3.0.0` | patch | `3.0.1` | `3.0.1` (no build added) |
| `3.0.0+abc` | major | `4.0.0` | `4.0.0` (non-integer build dropped) |

Build metadata that is **not** a single integer (prerelease-style tags, git hashes, dot-separated builds) is still dropped.

### ⚠️ Breaking change: pre-1.0.0 patch releases

To make the `+N` slot behave purely as a build counter in all ranges, a **patch** release below `1.0.0` now bumps the **patch component** instead of creating a build number:

| Current | Bump | Before | After |
|---------|------|--------|-------|
| `0.1.0` | patch | `0.1.0+1` | `0.1.1` |
| `0.1.1+1` | patch | `0.1.1+2` | `0.1.2+2` |

`major`/`minor` behavior for pre-1.0.0 versions is unchanged (`0.1.2` → `0.2.0` / `0.1.3`), except that an existing integer build number is now retained and incremented (e.g. `0.1.1+1` major → `0.2.0+2`).

**Impact:** projects below `1.0.0` that relied on patch releases producing a `+N` build suffix will now get a patch-component bump instead. Anyone depending on the previous output should review their release flow before upgrading.

## Changes

- `packages/melos/lib/src/common/versioning.dart` — `nextStableVersion` now separates the version-component bump from build-number handling, via a new `_integerBuildNumber` helper. The retention propagates automatically to the prerelease and nullsafety paths.
- `packages/melos/test/**` — added cases for build retention (incl. non-integer/multi-component drop) and updated the pre-1.0.0 expectations (`versioning_test`, `version_test`, `changelog_test`).
- `docs/guides/automated-releases.mdx` — documented build-number handling and the below-1.0.0 convention.

## Testing

- `dart test test/common/versioning_test.dart` — all pass (incl. `3.0.0+11` → `4.0.0+12`).
- `dart test test/changelog_test.dart` — all pass.
- `dart test test/commands/version_test.dart` — matches `main` baseline.
- `dart analyze` — no issues.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [x] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore