### PR TITLE
fix: replace deprecated applicationConfigHome with BaseDirectories

### DIFF
--- a/packages/melos/lib/src/common/pub_credential.dart
+++ b/packages/melos/lib/src/common/pub_credential.dart
@@ -21,7 +21,7 @@ class PubCredentialStore {
   PubCredentialStore(this.credentials);
 
   factory PubCredentialStore.fromConfigFile({String? configDir}) {
-    configDir ??= applicationConfigHome('dart');
+    configDir ??= BaseDirectories('dart').configHome;
     final tokenFilePath = path.join(configDir, _pubTokenFileName);
 
     if (!fileExists(tokenFilePath)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ melos:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
         cli_launcher: ^0.3.3
-        cli_util: ^0.4.2
+        cli_util: ^0.5.0
         collection: ^1.19.0
         file: ^7.0.1
         glob: ^2.1.3


### PR DESCRIPTION
## Summary

- Replaces the deprecated `applicationConfigHome('dart')` call in `PubCredentialStore.fromConfigFile` with the new `BaseDirectories('dart').configHome` API from `cli_util` 0.5.x
- Fixes the `deprecated_member_use` warning reported by `flutter analyze`

## Test plan

- [x] `flutter analyze` reports no issues