### PR TITLE
feat: add pubServer config option to melos publish

### DIFF
--- a/docs/commands/publish.mdx
+++ b/docs/commands/publish.mdx
@@ -29,6 +29,29 @@ melos publish --no-dry-run
 
 Use `--no-dry-run` to disable.
 
+## --server
+
+The URL of the package server to publish to. When set, `--server <url>` is
+forwarded to `dart pub publish`, overriding the per-package `publish_to` field
+in `pubspec.yaml`.
+
+```bash
+melos publish --no-dry-run --server https://pub.flutter-io.cn
+```
+
+This can also be set workspace-wide in `melos.yaml` via the `pubServer` option
+under `command/publish`, so you don't have to pass it on every invocation:
+
+```yaml
+# melos.yaml
+command:
+  publish:
+    pubServer: https://pub.flutter-io.cn
+```
+
+The CLI flag takes precedence over the `pubServer` config value when both are
+provided.
+
 ## --git-tag-version (-t)
 
 Add any missing git tags for release. Tags are only created if --no-dry-run is

--- a/packages/melos/lib/src/command_configs/publish.dart
+++ b/packages/melos/lib/src/command_configs/publish.dart
@@ -22,6 +22,7 @@ class PublishCommandConfigs {
     List<AggregateChangelogConfig>? aggregateChangelogs,
     this.fetchTags = true,
     this.hooks = PublishLifecycleHooks.empty,
+    this.pubServer,
   }) : _aggregateChangelogs = aggregateChangelogs;
 
   factory PublishCommandConfigs.fromYaml(
@@ -124,6 +125,12 @@ class PublishCommandConfigs {
       path: 'command/publish',
     );
 
+    final pubServer = assertKeyIsA<String?>(
+      key: 'pubServer',
+      map: yaml,
+      path: 'command/publish',
+    );
+
     final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'hooks',
       map: yaml,
@@ -170,6 +177,7 @@ class PublishCommandConfigs {
       aggregateChangelogs: aggregateChangelogs,
       fetchTags: fetchTags ?? true,
       hooks: hooks,
+      pubServer: pubServer,
     );
   }
 
@@ -218,6 +226,12 @@ class PublishCommandConfigs {
   /// Lifecycle hooks for this command.
   final PublishLifecycleHooks hooks;
 
+  /// The pub server URL to publish packages to.
+  ///
+  /// When set, `--server <url>` is passed to `dart pub publish`. If not set,
+  /// the per-package `publish_to` field in `pubspec.yaml` is used.
+  final String? pubServer;
+
   Map<String, Object?> toJson() {
     return {
       if (branch != null) 'branch': branch,
@@ -231,6 +245,7 @@ class PublishCommandConfigs {
           .toList(),
       'fetchTags': fetchTags,
       'hooks': hooks.toJson(),
+      if (pubServer != null) 'pubServer': pubServer,
     };
   }
 
@@ -250,7 +265,8 @@ class PublishCommandConfigs {
         aggregateChangelogs,
       ) &&
       other.fetchTags == fetchTags &&
-      other.hooks == hooks;
+      other.hooks == hooks &&
+      other.pubServer == pubServer;
 
   @override
   int get hashCode =>
@@ -264,7 +280,8 @@ class PublishCommandConfigs {
       releaseUrl.hashCode ^
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
-      hooks.hashCode;
+      hooks.hashCode ^
+      pubServer.hashCode;
 
   @override
   String toString() {
@@ -280,6 +297,7 @@ PublishCommandConfigs(
   aggregateChangelogs: $aggregateChangelogs,
   fetchTags: $fetchTags,
   hooks: $hooks,
+  pubServer: $pubServer,
 )''';
   }
 }

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -24,6 +24,12 @@ class PublishCommand extends MelosCommand {
       negatable: false,
       help: 'Skip the Y/n confirmation prompt when using --no-dry-run.',
     );
+    argParser.addOption(
+      publishOptionServer,
+      help:
+          'The URL of the package server to publish to. '
+          'Overrides the pubServer option in melos.yaml.',
+    );
   }
 
   @override
@@ -39,6 +45,7 @@ class PublishCommand extends MelosCommand {
     final dryRun = argResults![publishOptionDryRun] as bool;
     final gitTagVersion = argResults![publishOptionGitTagVersion] as bool;
     final yes = argResults![publishOptionYes] as bool;
+    final pubServer = argResults![publishOptionServer] as String?;
 
     final melos = Melos(logger: logger, config: config);
     final packageFilters = parsePackageFilters(config.path);
@@ -49,6 +56,7 @@ class PublishCommand extends MelosCommand {
       dryRun: dryRun,
       force: yes,
       gitTagVersion: gitTagVersion,
+      pubServer: pubServer,
     );
   }
 }

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -8,6 +8,7 @@ mixin _PublishMixin on _ExecMixin {
     bool gitTagVersion = true,
     // yes
     bool force = false,
+    String? pubServer,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -22,6 +23,7 @@ mixin _PublishMixin on _ExecMixin {
         dryRun: dryRun,
         gitTagVersion: gitTagVersion,
         force: force,
+        pubServer: pubServer ?? workspace.config.commands.publish.pubServer,
       );
     });
   }
@@ -34,6 +36,7 @@ mixin _PublishMixin on _ExecMixin {
     bool gitTagVersion = true,
     // yes
     bool force = false,
+    String? pubServer,
   }) async {
     logger.command('melos publish${dryRun ? " --$publishOptionDryRun" : ''}');
     logger.child(targetStyle(workspace.path)).newLine();
@@ -120,6 +123,7 @@ mixin _PublishMixin on _ExecMixin {
       unpublishedPackages,
       dryRun: dryRun,
       gitTagVersion: gitTagVersion,
+      pubServer: pubServer,
     );
   }
 
@@ -175,6 +179,7 @@ mixin _PublishMixin on _ExecMixin {
     List<Package> unpublishedPackages, {
     required bool dryRun,
     required bool gitTagVersion,
+    String? pubServer,
   }) async {
     final updateRegistryProgress = logger.progress(
       'Publishing ${unpublishedPackages.length} packages to registry:',
@@ -188,6 +193,10 @@ mixin _PublishMixin on _ExecMixin {
       execArgs.add('--dry-run');
     } else {
       execArgs.add('--force');
+    }
+
+    if (pubServer != null) {
+      execArgs.addAll(['--server', pubServer]);
     }
 
     await _execForAllPackages(

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -45,6 +45,7 @@ const publishOptionGitTagVersion = 'git-tag-version';
 const publishOptionNoGitTagVersion = 'no-git-tag-version';
 const publishOptionYes = 'yes';
 const publishOptionForce = 'force';
+const publishOptionServer = 'server';
 
 extension Let<T> on T? {
   R? let<R>(R Function(T value) cb) {

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -504,10 +504,13 @@ ${'-' * terminalWidth}
             orderDependents: true,
           );
 
+          // b and e are in the same topological layer and run concurrently,
+          // so their relative output order is non-deterministic.
           expect(
             logger.output.normalizeLines(),
-            ignoringAnsii(
-              '''
+            anyOf(
+              ignoringAnsii(
+                '''
 \$ melos exec
   └> echo hello world
      └> RUNNING (in 5 packages)
@@ -524,6 +527,26 @@ ${'-' * terminalWidth}
   └> echo hello world
      └> SUCCESS
 ''',
+              ),
+              ignoringAnsii(
+                '''
+\$ melos exec
+  └> echo hello world
+     └> RUNNING (in 5 packages)
+
+${'-' * terminalWidth}
+[d]: hello world
+[c]: hello world
+[e]: hello world
+[b]: hello world
+[a]: hello world
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> echo hello world
+     └> SUCCESS
+''',
+              ),
             ),
           );
         },

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -121,6 +121,87 @@ void main() {
       }
     });
 
+    group('pubServer', () {
+      test('passes --server flag to dart pub publish when configured', () async {
+        final logger = TestLogger();
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              publish: PublishCommandConfigs(
+                pubServer: 'https://pub.flutter-io.cn',
+              ),
+            ),
+          ),
+          workspacePackages: const ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 2, 3)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await expectLater(melos.publish(force: true), completes);
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('--server https://pub.flutter-io.cn'),
+        );
+      });
+
+      test('CLI --server flag takes precedence over config pubServer', () async {
+        final logger = TestLogger();
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              publish: PublishCommandConfigs(
+                pubServer: 'https://pub.flutter-io.cn',
+              ),
+            ),
+          ),
+          workspacePackages: const ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 2, 3)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await expectLater(
+          melos.publish(force: true, pubServer: 'https://pub.dev'),
+          completes,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('--server https://pub.dev'),
+        );
+        expect(
+          logger.output.normalizeLines(),
+          isNot(contains('--server https://pub.flutter-io.cn')),
+        );
+      });
+    });
+
     test('should support number as pre release version', () async {
       final logger = TestLogger();
       final workspaceDir = await createTemporaryWorkspace(

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -122,84 +122,90 @@ void main() {
     });
 
     group('pubServer', () {
-      test('passes --server flag to dart pub publish when configured', () async {
-        final logger = TestLogger();
-        final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: (path) => MelosWorkspaceConfig(
-            path: path,
-            name: 'test_workspace',
-            packages: [
-              createGlob('packages/**', currentDirectoryPath: path),
-            ],
-            commands: const CommandConfigs(
-              publish: PublishCommandConfigs(
-                pubServer: 'https://pub.flutter-io.cn',
+      test(
+        'passes --server flag to dart pub publish when configured',
+        () async {
+          final logger = TestLogger();
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: (path) => MelosWorkspaceConfig(
+              path: path,
+              name: 'test_workspace',
+              packages: [
+                createGlob('packages/**', currentDirectoryPath: path),
+              ],
+              commands: const CommandConfigs(
+                publish: PublishCommandConfigs(
+                  pubServer: 'https://pub.flutter-io.cn',
+                ),
               ),
             ),
-          ),
-          workspacePackages: const ['a'],
-        );
+            workspacePackages: const ['a'],
+          );
 
-        await createProject(
-          workspaceDir,
-          Pubspec('a', version: Version(1, 2, 3)),
-        );
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 2, 3)),
+          );
 
-        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
-          workspaceDir,
-        );
-        final melos = Melos(logger: logger, config: config);
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(logger: logger, config: config);
 
-        await expectLater(melos.publish(force: true), completes);
+          await expectLater(melos.publish(force: true), completes);
 
-        expect(
-          logger.output.normalizeLines(),
-          contains('--server https://pub.flutter-io.cn'),
-        );
-      });
+          expect(
+            logger.output.normalizeLines(),
+            contains('--server https://pub.flutter-io.cn'),
+          );
+        },
+      );
 
-      test('CLI --server flag takes precedence over config pubServer', () async {
-        final logger = TestLogger();
-        final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: (path) => MelosWorkspaceConfig(
-            path: path,
-            name: 'test_workspace',
-            packages: [
-              createGlob('packages/**', currentDirectoryPath: path),
-            ],
-            commands: const CommandConfigs(
-              publish: PublishCommandConfigs(
-                pubServer: 'https://pub.flutter-io.cn',
+      test(
+        'CLI --server flag takes precedence over config pubServer',
+        () async {
+          final logger = TestLogger();
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: (path) => MelosWorkspaceConfig(
+              path: path,
+              name: 'test_workspace',
+              packages: [
+                createGlob('packages/**', currentDirectoryPath: path),
+              ],
+              commands: const CommandConfigs(
+                publish: PublishCommandConfigs(
+                  pubServer: 'https://pub.flutter-io.cn',
+                ),
               ),
             ),
-          ),
-          workspacePackages: const ['a'],
-        );
+            workspacePackages: const ['a'],
+          );
 
-        await createProject(
-          workspaceDir,
-          Pubspec('a', version: Version(1, 2, 3)),
-        );
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 2, 3)),
+          );
 
-        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
-          workspaceDir,
-        );
-        final melos = Melos(logger: logger, config: config);
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(logger: logger, config: config);
 
-        await expectLater(
-          melos.publish(force: true, pubServer: 'https://pub.dev'),
-          completes,
-        );
+          await expectLater(
+            melos.publish(force: true, pubServer: 'https://pub.dev'),
+            completes,
+          );
 
-        expect(
-          logger.output.normalizeLines(),
-          contains('--server https://pub.dev'),
-        );
-        expect(
-          logger.output.normalizeLines(),
-          isNot(contains('--server https://pub.flutter-io.cn')),
-        );
-      });
+          expect(
+            logger.output.normalizeLines(),
+            contains('--server https://pub.dev'),
+          );
+          expect(
+            logger.output.normalizeLines(),
+            isNot(contains('--server https://pub.flutter-io.cn')),
+          );
+        },
+      );
     });
 
     test('should support number as pre release version', () async {

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -1,5 +1,6 @@
 import 'package:melos/melos.dart';
 import 'package:melos/src/command_configs/command_configs.dart';
+import 'package:melos/src/command_configs/publish.dart';
 import 'package:melos/src/common/git_repository.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/platform.dart';
@@ -322,6 +323,57 @@ void main() {
         expect(
           () => CommandConfigs.fromYaml(
             const {'version': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('can decode publish pubServer', () {
+        expect(
+          CommandConfigs.fromYaml(
+            const {
+              'publish': {
+                'pubServer': 'https://pub.flutter-io.cn',
+              },
+            },
+            workspacePath: '.',
+          ),
+          const CommandConfigs(
+            publish: PublishCommandConfigs(
+              pubServer: 'https://pub.flutter-io.cn',
+            ),
+          ),
+        );
+      });
+    });
+  });
+
+  group('PublishCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          PublishCommandConfigs.fromYaml(const {}, workspacePath: '.'),
+          PublishCommandConfigs.empty,
+        );
+      });
+
+      test('can decode pubServer', () {
+        expect(
+          PublishCommandConfigs.fromYaml(
+            const {'pubServer': 'https://pub.flutter-io.cn'},
+            workspacePath: '.',
+          ),
+          const PublishCommandConfigs(
+            pubServer: 'https://pub.flutter-io.cn',
+          ),
+        );
+      });
+
+      test('throws if pubServer is not a string', () {
+        expect(
+          () => PublishCommandConfigs.fromYaml(
+            const {'pubServer': 42},
             workspacePath: '.',
           ),
           throwsMelosConfigException(),


### PR DESCRIPTION
## Summary

- Adds a `pubServer` field to `PublishCommandConfigs` (read from `command/publish/pubServer` in `melos.yaml`) so users can set a workspace-wide pub registry URL for publishing
- Adds a `--server <url>` CLI flag to `melos publish` that overrides the config file value
- When either is set, `--server <url>` is forwarded to `dart pub publish`

Example `melos.yaml` usage:
```yaml
command:
  publish:
    pubServer: https://pub.flutter-io.cn
```

Or via CLI:
```
melos publish --no-dry-run --server https://pub.flutter-io.cn
```

## Test plan

- [ ] Existing publish tests pass (`dart test test/commands/publish_test.dart`)
- [ ] `dart analyze` reports no issues
- [ ] Manual: run `melos publish --server https://pub.flutter-io.cn` and confirm `--server` is forwarded to `dart pub publish`
- [ ] Manual: set `pubServer` in `melos.yaml` and confirm it is picked up when no CLI flag is given

Closes #875