### PR TITLE
feat!: configure exec command via "exec.command"

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -110,11 +110,12 @@ configured in the individual scripts that are being called as part of the step.
 
 Execute a script in multiple packages through `melos exec`.
 
-This options must either contain the command to execute in multiple packages or
-the options for the `melos exec` command.
+`run` and `exec` are mutually exclusive: a script either runs once in the
+workspace root with [`run`](/configuration/scripts#run), or across multiple
+packages with `exec`.
 
-When using the default options for `melos exec`, it's easiest to specify the
-command in the `exec` option:
+When using the default options for `melos exec`, specify the command directly as
+the value of `exec`:
 
 ```yaml
 scripts:
@@ -122,19 +123,30 @@ scripts:
     exec: echo 'Hello $(dirname $PWD)'
 ```
 
-If you need to provide options for the `exec` command, specify them in the
-`exec` option and specify the command in the `run` option:
+If you need to provide options for the `exec` command, turn `exec` into an object
+and specify the command with the `command` key alongside the options:
 
 ```yaml
 scripts:
   hello:
-    run: echo 'Hello $(dirname $PWD)'
     exec:
+      command: echo 'Hello $(dirname $PWD)'
       concurrency: 1
 ```
 
+<Warning>
+  Prior to Melos 8.0.0, the command was specified in `run` and the options in
+  `exec`. This is no longer supported. Move the command into `exec` under the
+  `command` key. See the
+  [migration guide](/guides/migrations#7xx-to-800) for details.
+</Warning>
+
 See the [`packageFilters`](/configuration/scripts#packagefilters) option for
 filtering the packages to execute the command in.
+
+### command
+
+The command to execute in each package. Required when `exec` is an object.
 
 ### concurrency
 

--- a/docs/guides/migrations.mdx
+++ b/docs/guides/migrations.mdx
@@ -5,6 +5,48 @@ description: How to migrate between major versions of Melos.
 
 # Migrations
 
+## 7.x.x to 8.0.0
+
+### Configuring `exec` scripts
+
+The way an `exec` script is configured with options has changed. Previously, the
+command was specified in `run` and the `melos exec` options in `exec`:
+
+```yaml
+# Before (no longer supported)
+scripts:
+  test:
+    run: dart test --concurrency=1
+    exec:
+      concurrency: 1
+```
+
+`run` and `exec` are now mutually exclusive: a script either runs once in the
+workspace root with `run`, or across multiple packages with `exec`. When you
+need to pass options to `exec`, move the command into `exec` under the new
+`command` key:
+
+```yaml
+# After
+scripts:
+  test:
+    exec:
+      command: dart test --concurrency=1
+      concurrency: 1
+```
+
+The shorthand form, where `exec` is a string containing the command, is
+unchanged:
+
+```yaml
+scripts:
+  hello:
+    exec: echo 'Hello $(dirname $PWD)'
+```
+
+Melos will fail with a descriptive error, including the converted configuration,
+if it encounters the old format.
+
 ## 6.x.x to 7.x.x
 
 Since the [pub workspaces](https://dart.dev/tools/pub/workspaces) feature has

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -10,6 +10,74 @@ import 'package.dart';
 // https://regex101.com/r/44dzaz/1
 final _leadingMelosExecRegExp = RegExp(r'^\s*melos\s+exec');
 
+const _scriptsExecDocsUrl =
+    'https://melos.invertase.dev/configuration/scripts#exec';
+
+/// Error message shown when a script specifies both `run` and `exec`, which is
+/// no longer supported as of Melos 8.0.0.
+String _execAndRunMigrationMessage({
+  required String name,
+  required Object run,
+  required Object exec,
+}) {
+  final buffer = StringBuffer()
+    ..writeln(
+      'The script "$name" specifies both "run" and "exec", which is no longer '
+      'supported as of Melos 8.0.0. A script either runs once in the workspace '
+      'root with "run", or across multiple packages with "exec". They are now '
+      'mutually exclusive.',
+    );
+
+  if (exec is Map) {
+    // The old format used "run" for the command and "exec" for its options.
+    // Show the user how to migrate to the new "exec.command" format.
+    final runCommand = run is String ? run : '<command>';
+    buffer
+      ..writeln()
+      ..writeln(
+        'It looks like you were using "run" for the command and "exec" for '
+        'its options. Move the command into "exec" under the new "command" '
+        'key:',
+      )
+      ..writeln()
+      ..writeln('    $name:')
+      ..writeln('      exec:')
+      ..writeln('        command: $runCommand');
+    for (final entry in exec.entries) {
+      buffer.writeln('        ${entry.key}: ${entry.value}');
+    }
+  } else {
+    buffer
+      ..writeln()
+      ..writeln(
+        'Both "run" and "exec" specify a command. Keep only one: use "run" to '
+        'run the command once in the workspace root, or "exec" to run it '
+        'across multiple packages.',
+      );
+  }
+
+  buffer
+    ..writeln()
+    ..write('For more information, see $_scriptsExecDocsUrl.');
+
+  return buffer.toString();
+}
+
+/// Error message shown when a script's `exec` is a configuration object that
+/// does not specify the command to run via the `command` key.
+String _execWithoutCommandMessage({required String name}) {
+  return 'The script "$name" uses "exec" without a command. As of Melos '
+      '8.0.0 the command must be specified with the "command" key inside '
+      '"exec":\n'
+      '\n'
+      '    $name:\n'
+      '      exec:\n'
+      '        command: <command>\n'
+      '        # ...other exec options such as concurrency\n'
+      '\n'
+      'For more information, see $_scriptsExecDocsUrl.';
+}
+
 class Scripts extends MapView<String, Script> {
   const Scripts(super.map);
 
@@ -182,25 +250,47 @@ class Script {
     }
 
     final execYaml = yaml['exec'];
+    final runYaml = yaml['run'];
+
+    // A script either runs once in the workspace root via "run", or across
+    // multiple packages via "exec". The two are mutually exclusive.
+    if (execYaml != null && runYaml != null) {
+      throw MelosConfigException(
+        _execAndRunMigrationMessage(name: name, run: runYaml, exec: execYaml),
+      );
+    }
+
     if (execYaml is String) {
-      if (yaml['run'] is String) {
-        throw MelosConfigException(
-          'The script $name specifies a command in both "run" and "exec". '
-          'Remove one of them.',
-        );
-      }
+      // Shorthand: the command to execute in each package, with the default
+      // `melos exec` options.
       run = execYaml;
       exec = const ExecOptions();
-    } else {
-      final execMap = assertKeyIsA<Map<Object?, Object?>?>(
+    } else if (execYaml != null) {
+      final execMap = assertKeyIsA<Map<Object?, Object?>>(
         key: 'exec',
         map: yaml,
         path: scriptPath,
       );
 
-      exec = execMap != null
-          ? execOptionsFromYaml(execMap, scriptName: name)
-          : null;
+      final command = assertKeyIsA<String?>(
+        key: 'command',
+        map: execMap,
+        path: '$scriptPath/exec',
+      );
+      if (command == null || command.isEmpty) {
+        throw MelosConfigException(
+          _execWithoutCommandMessage(name: name),
+        );
+      }
+
+      run = command;
+      exec = execOptionsFromYaml(execMap, scriptName: name);
+    } else if (runYaml is String && runYaml.isNotEmpty) {
+      run = assertKeyIsA<String>(
+        key: 'run',
+        map: yaml,
+        path: scriptPath,
+      );
     }
 
     final stepsList = yaml['steps'];
@@ -218,17 +308,6 @@ class Script {
             },
           )
         : [];
-
-    final runYaml = yaml['run'];
-    if (runYaml is String && runYaml.isNotEmpty) {
-      run = execYaml is String
-          ? execYaml
-          : assertKeyIsA<String>(
-              key: 'run',
-              map: yaml,
-              path: scriptPath,
-            );
-    }
 
     description = assertKeyIsA<String?>(
       key: 'description',
@@ -434,12 +513,11 @@ class Script {
         run != null &&
         run!.startsWith(_leadingMelosExecRegExp)) {
       throw MelosConfigException(
-        'Do not use "melos exec" in "run" when also providing options in '
-        '"exec". In this case the script in "run" is already being executed by '
-        '"melos exec".\n'
-        'For more information, see https://melos.invertase.dev/configuration/scripts#scriptsexec.\n'
+        'Do not use "melos exec" in the "command" of an "exec" script. The '
+        'command is already being executed by "melos exec".\n'
+        'For more information, see $_scriptsExecDocsUrl.\n'
         '\n'
-        '    run: $run',
+        '    command: $run',
       );
     }
     if (stdio == ProcessStdio.inherit && exec != null) {
@@ -461,14 +539,19 @@ class Script {
   }
 
   Map<Object?, Object?> toJson() {
+    final exec = this.exec;
     return {
       'name': name,
-      'run': run,
+      if (exec == null) 'run': run,
       if (description != null) 'description': description,
       if (env.isNotEmpty) 'env': env,
       if (packageFilters != null) 'packageFilters': packageFilters!.toJson(),
       if (steps != null) 'steps': steps,
-      if (exec != null) 'exec': exec!.toJson(),
+      if (exec != null)
+        'exec': {
+          if (run != null) 'command': run,
+          ...exec.toJson(),
+        },
       'private': isPrivate,
       if (groups != null) 'groups': groups,
       if (stdio != ProcessStdio.pipe) 'stdio': stdio.name,

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -386,14 +386,10 @@ ${'-' * terminalWidth}
       await createProject(workspaceDir, Pubspec('a'));
       await runPubGet(workspaceDir.path);
 
-      final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
-      final melos = Melos(
-        logger: logger,
-        config: config,
+      await expectLater(
+        MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir),
+        throwsA(isA<MelosConfigException>()),
       );
-
-      expect(() => melos.run(scriptName: 'test_script'), throwsException);
     });
   });
 
@@ -533,16 +529,9 @@ SUCCESS
       await createProject(workspaceDir, Pubspec('a'));
       await runPubGet(workspaceDir.path);
 
-      final logger = TestLogger();
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
-      final melos = Melos(
-        logger: logger,
-        config: config,
-      );
-
-      expect(
-        () => melos.run(scriptName: 'hello_script'),
-        throwsException,
+      await expectLater(
+        MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir),
+        throwsA(isA<MelosConfigException>()),
       );
     });
 

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -499,7 +499,7 @@ void main() {
 
   group('Scripts', () {
     group('exec', () {
-      test('supports specifying command through "exec"', () {
+      test('supports specifying command as a string through "exec"', () {
         final scripts = Scripts.fromYaml(
           createYamlMap({
             'a': {
@@ -512,12 +512,13 @@ void main() {
         expect(scripts['a']!.exec, const ExecOptions());
       });
 
-      test('supports specifying command through "run"', () {
+      test('supports specifying command through "exec.command"', () {
         final scripts = Scripts.fromYaml(
           createYamlMap({
             'a': {
-              'run': 'b',
-              'exec': <String, Object?>{},
+              'exec': {
+                'command': 'b',
+              },
             },
           }),
           workspacePath: testWorkspacePath,
@@ -526,12 +527,12 @@ void main() {
         expect(scripts['a']!.exec, const ExecOptions());
       });
 
-      test('supports specifying exec options', () {
+      test('supports specifying exec options alongside "exec.command"', () {
         final scripts = Scripts.fromYaml(
           createYamlMap({
             'a': {
-              'run': 'b',
               'exec': {
+                'command': 'b',
                 'concurrency': 1,
                 'failFast': true,
                 'orderDependents': true,
@@ -551,7 +552,7 @@ void main() {
         );
       });
 
-      test('throws when specifying command in "run" and "exec"', () {
+      test('throws when specifying a string command in "run" and "exec"', () {
         expect(
           () => Scripts.fromYaml(
             createYamlMap({
@@ -566,13 +567,62 @@ void main() {
         );
       });
 
-      test('throws when using "melos exec" in "run" and specifying "exec"', () {
+      test('throws with migration hint for the old "run" + "exec" format', () {
         expect(
           () => Scripts.fromYaml(
             createYamlMap({
               'a': {
-                'run': 'melos exec a',
+                'run': 'b',
                 'exec': {
+                  'concurrency': 1,
+                },
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ),
+          throwsA(
+            isA<MelosConfigException>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('mutually exclusive'),
+                contains('command: b'),
+                contains('concurrency: 1'),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('throws when "exec" is an object without a command', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'exec': {
+                  'concurrency': 1,
+                },
+              },
+            }),
+            workspacePath: testWorkspacePath,
+          ),
+          throwsA(
+            isA<MelosConfigException>().having(
+              (e) => e.message,
+              'message',
+              contains('without a command'),
+            ),
+          ),
+        );
+      });
+
+      test('throws when using "melos exec" in "exec.command"', () {
+        expect(
+          () => Scripts.fromYaml(
+            createYamlMap({
+              'a': {
+                'exec': {
+                  'command': 'melos exec a',
                   'concurrency': 1,
                 },
               },
@@ -630,9 +680,10 @@ void main() {
           () => Scripts.fromYaml(
             createYamlMap({
               'a': {
-                'run': 'b',
                 'stdio': 'inherit',
-                'exec': <String, Object?>{},
+                'exec': {
+                  'command': 'b',
+                },
               },
             }),
             workspacePath: testWorkspacePath,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,8 +73,8 @@ melos:
   scripts:
     test:
       description: Run tests in a specific package.
-      run: dart test --concurrency=1
       exec:
+        command: dart test --concurrency=1
         concurrency: 1
       packageFilters:
         dirExists:


### PR DESCRIPTION
## Description

Fixes #566.

Previously, configuring a `melos exec` script with options was inconsistent: the command had to go in `run` while the options went in `exec`. This meant `run` changed meaning depending on whether `exec` was present, which was confusing for newcomers:

```yaml
# Before
scripts:
  test:
    run: dart test --concurrency=1
    exec:
      concurrency: 1
```

Now `run` and `exec` are **always mutually exclusive**. A script either runs once in the workspace root with `run`, or across multiple packages with `exec`. When you need to pass options to `exec`, the command lives under the new `command` key:

```yaml
# After
scripts:
  test:
    exec:
      command: dart test --concurrency=1
      concurrency: 1
```

The shorthand string form is unchanged:

```yaml
scripts:
  hello:
    exec: echo 'Hello $(dirname $PWD)'
```

## Breaking change & migration

This is a breaking change targeting **8.0.0**. When Melos encounters the old `run` + `exec` format, it fails with a descriptive error that reconstructs the corrected config for the user:

```
The script "test" specifies both "run" and "exec", which is no longer
supported as of Melos 8.0.0. A script either runs once in the workspace
root with "run", or across multiple packages with "exec". They are now
mutually exclusive.

It looks like you were using "run" for the command and "exec" for its
options. Move the command into "exec" under the new "command" key:

    test:
      exec:
        command: dart test --concurrency=1
        concurrency: 1

For more information, see https://melos.invertase.dev/configuration/scripts#exec.
```

An `exec` object without a `command` also produces a clear error.

## Changes

- `scripts.dart`: parse the command from `exec.command`; detect and reject the old format with a migration message; require a command when `exec` is an object; update `toJson` to emit the new format.
- Migrated Melos's own `test` script in `pubspec.yaml` to the new format.
- Docs: updated the `exec` section in `scripts.mdx` and added a `7.x.x to 8.0.0` migration entry in `migrations.mdx`.
- Tests: updated/added coverage for the new format, the migration error, and the missing-command error.