### PR TITLE
fix: only suggest updates compatible with the current Dart SDK

### DIFF
--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_launcher/cli_launcher.dart';
 import 'package:cli_util/cli_logging.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 import '../version.g.dart';
@@ -19,6 +20,8 @@ import 'command_runner/run.dart';
 import 'command_runner/script.dart';
 import 'command_runner/version.dart';
 import 'common/exception.dart';
+import 'common/pub_hosted.dart';
+import 'common/pub_hosted_package.dart';
 import 'common/utils.dart' as utils;
 import 'common/utils.dart';
 import 'logging.dart';
@@ -105,15 +108,25 @@ FutureOr<void> melosEntryPoint(
       return;
     }
 
-    // Check for updates.
-    final pubUpdater = PubUpdater();
+    // Check for updates, but only suggest versions that are compatible with
+    // the Dart SDK in use, to avoid suggesting an update that requires a newer
+    // SDK than is installed (https://github.com/invertase/melos/issues/910).
     const packageName = 'melos';
-    final isUpToDate = await pubUpdater.isUpToDate(
-      packageName: packageName,
-      currentVersion: melosVersion,
+    final client = PubHostedClient.fromUri(pubHosted: null);
+    PubHostedPackage? package;
+    try {
+      package = await client.fetchPackage(packageName, logger: logger);
+    } finally {
+      client.close();
+    }
+
+    final update = package?.newestCompatibleUpdate(
+      currentVersion: Version.parse(melosVersion),
+      dartSdkVersion: Version.parse(Platform.version.split(' ').first),
     );
-    if (!isUpToDate) {
-      final latestVersion = await pubUpdater.getLatestVersion(packageName);
+
+    if (update != null) {
+      final latestVersion = update.version;
       final isGlobal = context.localInstallation == null;
 
       if (isGlobal) {
@@ -125,7 +138,10 @@ FutureOr<void> melosEntryPoint(
           defaultsToWithoutPrompt: false,
         );
         if (shouldUpdate) {
-          await pubUpdater.update(packageName: packageName);
+          await PubUpdater().update(
+            packageName: packageName,
+            versionConstraint: latestVersion.toString(),
+          );
           logger.log(
             '$packageName has been updated to version $latestVersion.',
           );

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -108,9 +108,7 @@ FutureOr<void> melosEntryPoint(
       return;
     }
 
-    // Check for updates, but only suggest versions that are compatible with
-    // the Dart SDK in use, to avoid suggesting an update that requires a newer
-    // SDK than is installed (https://github.com/invertase/melos/issues/910).
+    // Check for updates.
     const packageName = 'melos';
     final client = PubHostedClient.fromUri(pubHosted: null);
     PubHostedPackage? package;

--- a/packages/melos/lib/src/common/pub_hosted_package.dart
+++ b/packages/melos/lib/src/common/pub_hosted_package.dart
@@ -45,14 +45,54 @@ class PubHostedPackage {
 
     return prioritizedVersions.map((v) => v.version).contains(version);
   }
+
+  /// Returns the newest stable version that is both newer than
+  /// [currentVersion] and compatible with [dartSdkVersion], or `null` if no
+  /// such version exists.
+  ///
+  /// This is used to avoid suggesting an update to a version that requires a
+  /// newer Dart SDK than the one currently in use. Pre-release versions are
+  /// never suggested, and pre-release users are not prompted to move to a
+  /// stable release.
+  PubPackageVersion? newestCompatibleUpdate({
+    required Version currentVersion,
+    required Version dartSdkVersion,
+  }) {
+    if (currentVersion.isPreRelease) {
+      return null;
+    }
+
+    PubPackageVersion? best;
+    for (final candidate in versions) {
+      if (candidate.version.isPreRelease ||
+          candidate.version <= currentVersion) {
+        continue;
+      }
+      final constraint = candidate.sdkConstraint;
+      if (constraint != null && !constraint.allows(dartSdkVersion)) {
+        continue;
+      }
+      if (best == null || candidate.version > best.version) {
+        best = candidate;
+      }
+    }
+    return best;
+  }
 }
 
 class PubPackageVersion {
-  PubPackageVersion({required this.version, this.published});
+  PubPackageVersion({
+    required this.version,
+    this.published,
+    this.sdkConstraint,
+  });
 
   factory PubPackageVersion.fromJson(Map<String, dynamic> json) {
     final version = json['version'] as String?;
     final published = json['published'] as String?;
+    final pubspec = json['pubspec'] as Map<String, dynamic>?;
+    final environment = pubspec?['environment'] as Map<String, dynamic>?;
+    final sdk = environment?['sdk'] as String?;
 
     if (version == null) {
       throw const FormatException('Version is not provided for the package');
@@ -61,10 +101,25 @@ class PubPackageVersion {
     return PubPackageVersion(
       version: Version.parse(version),
       published: published != null ? DateTime.tryParse(published) : null,
+      sdkConstraint: _tryParseConstraint(sdk),
     );
+  }
+
+  static VersionConstraint? _tryParseConstraint(String? constraint) {
+    if (constraint == null) {
+      return null;
+    }
+    try {
+      return VersionConstraint.parse(constraint);
+    } on FormatException {
+      return null;
+    }
   }
 
   final Version version;
 
   final DateTime? published;
+
+  /// The Dart SDK constraint declared in this version's pubspec, if any.
+  final VersionConstraint? sdkConstraint;
 }

--- a/packages/melos/test/common/pub_hosted_package_test.dart
+++ b/packages/melos/test/common/pub_hosted_package_test.dart
@@ -1,0 +1,152 @@
+import 'package:melos/src/common/pub_hosted_package.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+PubHostedPackage _package(List<(String, String?)> versions) {
+  return PubHostedPackage.fromJson({
+    'name': 'melos',
+    'latest': {'version': versions.last.$1},
+    'versions': [
+      for (final (version, sdk) in versions)
+        {
+          'version': version,
+          if (sdk != null)
+            'pubspec': {
+              'environment': {'sdk': sdk},
+            },
+        },
+    ],
+  });
+}
+
+void main() {
+  group('PubPackageVersion.fromJson', () {
+    test('parses the SDK constraint from the pubspec environment', () {
+      final version = PubPackageVersion.fromJson({
+        'version': '6.3.3',
+        'pubspec': {
+          'environment': {'sdk': '^3.8.0'},
+        },
+      });
+
+      expect(version.version, Version.parse('6.3.3'));
+      expect(version.sdkConstraint, VersionConstraint.parse('^3.8.0'));
+    });
+
+    test('leaves the SDK constraint null when absent', () {
+      final version = PubPackageVersion.fromJson({'version': '6.3.2'});
+      expect(version.sdkConstraint, isNull);
+    });
+
+    test('leaves the SDK constraint null when malformed', () {
+      final version = PubPackageVersion.fromJson({
+        'version': '6.3.2',
+        'pubspec': {
+          'environment': {'sdk': 'not-a-constraint'},
+        },
+      });
+      expect(version.sdkConstraint, isNull);
+    });
+  });
+
+  group('PubHostedPackage.newestCompatibleUpdate', () {
+    test('does not suggest a version that requires a newer Dart SDK', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('6.3.3', '^3.8.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.2'),
+        dartSdkVersion: Version.parse('3.7.2'),
+      );
+
+      expect(update, isNull);
+    });
+
+    test('suggests the newest version compatible with the Dart SDK', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('6.3.3', '^3.8.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.2'),
+        dartSdkVersion: Version.parse('3.8.1'),
+      );
+
+      expect(update?.version, Version.parse('6.3.3'));
+    });
+
+    test('picks the newest compatible version, skipping incompatible ones', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('6.3.3', '>=3.4.0 <4.0.0'),
+        ('6.3.4', '^3.8.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.2'),
+        dartSdkVersion: Version.parse('3.7.2'),
+      );
+
+      expect(update?.version, Version.parse('6.3.3'));
+    });
+
+    test('returns null when already on the newest compatible version', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('6.3.3', '^3.8.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.3'),
+        dartSdkVersion: Version.parse('3.8.1'),
+      );
+
+      expect(update, isNull);
+    });
+
+    test('treats a missing SDK constraint as compatible', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('6.3.3', null),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.2'),
+        dartSdkVersion: Version.parse('3.7.2'),
+      );
+
+      expect(update?.version, Version.parse('6.3.3'));
+    });
+
+    test('never suggests pre-release versions', () {
+      final package = _package([
+        ('6.3.2', '>=3.2.0 <4.0.0'),
+        ('7.0.0-dev.1', '>=3.2.0 <4.0.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('6.3.2'),
+        dartSdkVersion: Version.parse('3.7.2'),
+      );
+
+      expect(update, isNull);
+    });
+
+    test('does not nag pre-release users about stable releases', () {
+      final package = _package([
+        ('7.0.0-dev.1', '>=3.2.0 <4.0.0'),
+        ('7.0.0', '>=3.2.0 <4.0.0'),
+      ]);
+
+      final update = package.newestCompatibleUpdate(
+        currentVersion: Version.parse('7.0.0-dev.1'),
+        dartSdkVersion: Version.parse('3.7.2'),
+      );
+
+      expect(update, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes #910.

When running `melos --version`, melos checks pub.dev for a newer release and offers to update. Previously it always suggested the **absolute latest** version, even when that version requires a newer Dart SDK than the one currently in use. For example, on Dart 3.7.2 melos 6.3.2 would offer to update to 6.3.3, which requires Dart `^3.8.0`, producing an SDK mismatch after updating.

## Changes

- `PubPackageVersion` now parses the `environment.sdk` constraint from each version's pubspec (the pub host already returns this in `api/packages/<name>`). Malformed constraints are treated as absent.
- Added `PubHostedPackage.newestCompatibleUpdate({currentVersion, dartSdkVersion})`, which returns the newest **stable** version that is both newer than the current version and whose SDK constraint allows the running Dart SDK. Pre-release versions are never suggested, and pre-release users are not nagged toward stable releases (preserving the previous behavior).
- The update check in `melosEntryPoint` now uses melos's own `PubHostedClient` (which already honors `PUB_HOSTED_URL`) to fetch versions and decide via `newestCompatibleUpdate`. When the user accepts, the update is pinned to that compatible version via `PubUpdater.update(versionConstraint: ...)` rather than activating the absolute latest.

## Tests

Added `test/common/pub_hosted_package_test.dart` covering:
- parsing / absence / malformed SDK constraints
- not suggesting a version that requires a newer SDK (the #910 scenario)
- suggesting the newest compatible version, skipping incompatible newer ones
- no-op when already on the newest compatible version
- missing SDK constraint treated as compatible
- pre-release versions never suggested, and pre-release users not nagged
