### PR TITLE
fix: require cli_launcher ^0.3.3+1 for workspace null-check fix

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   ansi_styles: ^0.3.2+1
   args: ^2.7.0
   async: ^2.13.0
-  cli_launcher: ^0.3.3
+  cli_launcher: ^0.3.3+1
   cli_util: ^0.5.0
   collection: ^1.19.0
   conventional_commit: ^0.6.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ melos:
       dependencies:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
-        cli_launcher: ^0.3.3
+        cli_launcher: ^0.3.3+1
         cli_util: ^0.5.0
         collection: ^1.19.0
         file: ^7.0.1


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The null-check crash in invertase/melos#972 (path-activated workspace member) is fixed by cli_launcher's workspace member resolution and exact path matching, which landed in 0.3.3+1. The previous ^0.3.3 constraint allowed resolving to 0.3.3, which still crashes for consumers.

Closes #972


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
