### PR TITLE
fix: include commits in changelog when graduating a pre-release

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -225,7 +225,7 @@ mixin _VersionMixin on _RunMixin {
           MelosPendingPackageUpdate(
             workspace,
             package,
-            const [],
+            packageCommits[package.name] ?? const [],
             PackageUpdateReason.graduate,
             graduate: asStableRelease,
             prerelease: asPrerelease,

--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -48,14 +48,24 @@ ${description?.withoutTrailing('\n') ?? ''}
     final dependencyOnlyPackages = pendingPackageUpdates.where(
       (update) => update.reason == PackageUpdateReason.dependency,
     );
-    final graduatedPackages = pendingPackageUpdates.where(
-      (update) => update.reason == PackageUpdateReason.graduate,
-    );
+    // Only packages graduated without any new commits since the last
+    // pre-release are listed in the dedicated graduation section. Graduated
+    // packages with new commits are treated like regular changes so their
+    // commits appear in the changelog.
+    final graduatedPackages = pendingPackageUpdates
+        .where(
+          (update) =>
+              update.reason == PackageUpdateReason.graduate &&
+              !update.hasVersionableCommits,
+        )
+        .toSet();
     final packagesWithBreakingChanges = pendingPackageUpdates.where(
-      (update) => update.hasBreakingChanges,
+      (update) =>
+          !graduatedPackages.contains(update) && update.hasBreakingChanges,
     );
     final packagesWithOtherChanges = pendingPackageUpdates.where(
-      (update) => !update.hasBreakingChanges,
+      (update) =>
+          !graduatedPackages.contains(update) && !update.hasBreakingChanges,
     );
 
     body.writeln(_changelogFileHeader);

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -116,8 +116,10 @@ extension ChangelogStringBufferExtension on StringBuffer {
       writeln();
     }
 
-    if (update.reason == PackageUpdateReason.graduate) {
-      // Package graduation entry.
+    if (update.reason == PackageUpdateReason.graduate &&
+        !update.hasVersionableCommits) {
+      // Package graduation entry without any new commits since the last
+      // pre-release.
       writeln(
         ' - Graduate package to a stable release. See pre-releases prior to '
         'this version for changelog entries.',
@@ -126,7 +128,9 @@ extension ChangelogStringBufferExtension on StringBuffer {
     }
 
     if (update.reason == PackageUpdateReason.commit ||
-        update.reason == PackageUpdateReason.manual) {
+        update.reason == PackageUpdateReason.manual ||
+        (update.reason == PackageUpdateReason.graduate &&
+            update.hasVersionableCommits)) {
       // Breaking change note.
       if (update.hasBreakingChanges) {
         writeln('> Note: This release has breaking changes.');

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -143,9 +143,15 @@ class MelosPendingPackageUpdate {
         .reduce(math.max)];
   }
 
+  /// Whether this update has any commits that produce changelog entries.
+  bool get hasVersionableCommits {
+    return commits.any((commit) => commit.parsedMessage.isVersionableCommit);
+  }
+
   /// Whether this update contains breaking changes.
   bool get hasBreakingChanges {
-    if (reason == PackageUpdateReason.manual) {
+    if (reason == PackageUpdateReason.manual ||
+        reason == PackageUpdateReason.graduate) {
       return commits.any((commit) => commit.parsedMessage.isBreakingChange);
     }
 

--- a/packages/melos/test/changelog_test.dart
+++ b/packages/melos/test/changelog_test.dart
@@ -161,6 +161,55 @@ void main() {
       contains('**FEAT**: a ([#123]($issueUrl)).'),
     );
   });
+
+  group('graduate', () {
+    // Regression test for: https://github.com/invertase/melos/issues/782
+    test('includes commits made since the pre-release in the changelog', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderGraduatePackageUpdate(workspace, package, [
+        testCommit(message: 'feat: a new feature'),
+        testCommit(message: 'fix: a bug fix'),
+      ]);
+
+      expect(markdown, contains('**FEAT**: a new feature.'));
+      expect(markdown, contains('**FIX**: a bug fix.'));
+      expect(
+        markdown,
+        isNot(contains('Graduate package to a stable release')),
+      );
+    });
+
+    test('falls back to the pre-release note when there are no commits', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderGraduatePackageUpdate(workspace, package, []);
+
+      expect(
+        markdown,
+        contains(
+          'Graduate package to a stable release. See pre-releases prior to '
+          'this version for changelog entries.',
+        ),
+      );
+    });
+
+    test('ignores non-versionable commits and shows the pre-release note', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderGraduatePackageUpdate(workspace, package, [
+        testCommit(message: 'chore: not versionable'),
+      ]);
+
+      expect(
+        markdown,
+        contains('Graduate package to a stable release'),
+      );
+    });
+  });
 }
 
 MelosWorkspace buildWorkspaceWithRepository({
@@ -208,6 +257,23 @@ String renderCommitPackageUpdate(
     package,
     [commit],
     PackageUpdateReason.commit,
+    logger: workspace.logger,
+  );
+  final changelog = MelosChangelog(update, workspace.logger);
+  return changelog.markdown;
+}
+
+String renderGraduatePackageUpdate(
+  MelosWorkspace workspace,
+  Package package,
+  List<RichGitCommit> commits,
+) {
+  final update = MelosPendingPackageUpdate(
+    workspace,
+    package,
+    commits,
+    PackageUpdateReason.graduate,
+    graduate: true,
     logger: workspace.logger,
   );
   final changelog = MelosChangelog(update, workspace.logger);


### PR DESCRIPTION
## Description

Fixes #782.

When graduating a pre-release to a stable release (`melos version -g`), commits made *since* the last pre-release were dropped from the changelog. Every graduated package got the placeholder:

> Graduate package to a stable release. See pre-releases prior to this version for changelog entries.

This was wrong when there were unreleased commits between the last pre-release and the graduation.

## Root cause

Graduated packages were constructed with an empty commits list (`const []`) in `version.dart`, and `changelog.dart` always emitted the placeholder for any `graduate` update.

## Changes

- **`commands/version.dart`** — pass the package's actual commits to the graduate `MelosPendingPackageUpdate` instead of an empty list.
- **`common/pending_package_update.dart`** — add a `hasVersionableCommits` getter, and make `hasBreakingChanges` derive from commits (like `manual`) for graduate updates.
- **`common/changelog.dart`** — render commit entries when a graduated package has versionable commits; fall back to the "see pre-releases" placeholder only when there are none.
- **`common/aggregate_changelog.dart`** — only graduated packages without new commits go to the dedicated graduation section; graduated packages with commits flow through the normal breaking/other-changes sections.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Graduate with new commits | placeholder only | commits rendered |
| Graduate with no new commits | placeholder | placeholder (unchanged) |
| Graduate with only non-versionable commits (e.g. `chore:`) | placeholder | placeholder (unchanged) |

## Tests

Added a `graduate` group in `test/changelog_test.dart` covering all three cases.