### PR TITLE
fix: give a helpful error for unquoted script steps with a colon

### DIFF
--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -10,6 +10,33 @@ import 'package.dart';
 // https://regex101.com/r/44dzaz/1
 final _leadingMelosExecRegExp = RegExp(r'^\s*melos\s+exec');
 
+/// Validates a single script step parsed from YAML and returns it as a command
+/// string.
+///
+/// A step containing an unquoted colon, such as `echo Building: app`, is parsed
+/// by the YAML parser as a map (`{echo Building: app}`) rather than a string.
+/// In that case a helpful error is thrown telling the user to quote the step,
+/// instead of the cryptic type error that was reported before.
+String _parseStep(Object? value, {required int index, required String path}) {
+  if (value is Map<Object?, Object?>) {
+    final reconstructed = value.entries
+        .map(
+          (entry) => entry.value == null
+              ? '${entry.key}:'
+              : '${entry.key}: ${entry.value}',
+        )
+        .join(' ');
+    throw MelosConfigException(
+      'The step at index $index in $path contains a ":" and was parsed as '
+      'YAML map syntax instead of a command. Wrap the step in quotes, for '
+      'example:\n'
+      '  - "$reconstructed"',
+    );
+  }
+
+  return assertIsA<String>(value: value, index: index, path: path);
+}
+
 class Scripts extends MapView<String, Script> {
   const Scripts(super.map);
 
@@ -210,11 +237,7 @@ class Script {
             map: yaml,
             isRequired: false,
             assertItemIsA: (index, value) {
-              return assertIsA<String>(
-                value: value,
-                index: index,
-                path: scriptPath,
-              );
+              return _parseStep(value, index: index, path: scriptPath);
             },
           )
         : [];

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -593,7 +593,8 @@ a:
   steps:
     - echo hello
     - echo world
-''') as Map<Object?, Object?>,
+''')
+              as Map<Object?, Object?>,
           workspacePath: testWorkspacePath,
         );
         expect(scripts['a']!.steps, ['echo hello', 'echo world']);
@@ -606,7 +607,8 @@ a:
   steps:
     - "echo Checking python version:"
     - "echo Building: app"
-''') as Map<Object?, Object?>,
+''')
+              as Map<Object?, Object?>,
           workspacePath: testWorkspacePath,
         );
         expect(
@@ -622,7 +624,8 @@ a:
 a:
   steps:
     - echo Building: app
-''') as Map<Object?, Object?>,
+''')
+                as Map<Object?, Object?>,
             workspacePath: testWorkspacePath,
           ),
           throwsA(

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -7,6 +7,7 @@ import 'package:melos/src/common/platform.dart';
 import 'package:melos/src/common/retry_backoff.dart';
 import 'package:melos/src/workspace_config.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import 'matchers.dart';
 import 'utils.dart';
@@ -580,6 +581,57 @@ void main() {
             workspacePath: testWorkspacePath,
           ).validate(),
           throwsA(isA<MelosConfigException>()),
+        );
+      });
+    });
+
+    group('steps', () {
+      test('parses a list of string steps', () {
+        final scripts = Scripts.fromYaml(
+          loadYaml('''
+a:
+  steps:
+    - echo hello
+    - echo world
+''') as Map<Object?, Object?>,
+          workspacePath: testWorkspacePath,
+        );
+        expect(scripts['a']!.steps, ['echo hello', 'echo world']);
+      });
+
+      test('parses quoted steps containing a colon', () {
+        final scripts = Scripts.fromYaml(
+          loadYaml('''
+a:
+  steps:
+    - "echo Checking python version:"
+    - "echo Building: app"
+''') as Map<Object?, Object?>,
+          workspacePath: testWorkspacePath,
+        );
+        expect(
+          scripts['a']!.steps,
+          ['echo Checking python version:', 'echo Building: app'],
+        );
+      });
+
+      test('throws a helpful error for unquoted steps containing a colon', () {
+        expect(
+          () => Scripts.fromYaml(
+            loadYaml('''
+a:
+  steps:
+    - echo Building: app
+''') as Map<Object?, Object?>,
+            workspacePath: testWorkspacePath,
+          ),
+          throwsA(
+            isA<MelosConfigException>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('Wrap the step in quotes'), contains('":"')),
+            ),
+          ),
         );
       });
     });


### PR DESCRIPTION
## Description

Fixes #774.

A script step that contains an unquoted colon, such as:

```yaml
scripts:
  doc-setup:
    steps:
      - echo Building: app
```

is parsed by the YAML parser as a map (`{echo Building: app}`) rather than a string. This made melos throw a cryptic type error:

> The index 0 at scripts/doc-setup is expected to be a String but got {echo Building: app}

leaving users unsure why their step was rejected.

## Fix

Steps containing a colon legitimately need to be quoted (standard YAML behaviour). So instead of attempting to accept the map, melos now throws a clear `MelosConfigException` telling the user to wrap the step in quotes, and shows the quoted form, e.g.:

> The step at index 0 in scripts/doc-setup contains a ":" and was parsed as YAML map syntax instead of a command. Wrap the step in quotes, for example:
>   - "echo Building: app"

## Tests

Added tests under `Scripts > steps` in `workspace_config_test.dart`, parsing real YAML, that cover plain string steps, quoted steps containing a colon, and the helpful error thrown for unquoted steps with a colon.