### PR TITLE
feat: add option to group changelog commits by type

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -96,6 +96,22 @@ The default for this option can be configured in
 [command/version/releaseUrl](/configuration/overview#releaseurl) in your
 root `pubspec.yaml` file.
 
+## --[no-]group-commits
+
+Group changelog entries by their conventional commit type, e.g. all features
+under a `Features` header and all fixes under a `Bug Fixes` header, instead of
+listing them in a single flat list. Defaults to `false`.
+
+```bash
+melos version --group-commits
+```
+
+Use `--no-group-commits` to disable.
+
+The default for this option can be configured in
+[command/version/changelogFormat/groupByType](/configuration/overview#groupbytype)
+in your root `pubspec.yaml` file.
+
 ## --[no-]dependent-constraints
 
 Update dependency version constraints of packages in this workspace that depend

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -584,6 +584,7 @@ melos:
     version:
       changelogFormat:
         includeDate: true
+        groupByType: true
 ```
 
 #### includeDate
@@ -591,3 +592,29 @@ melos:
 Whether to include the date in the generated CHANGELOG.md. Defaults to `false`.
 
 With enabled, changelog entry header will include the date in the `yyyy-MM-dd` format.
+
+#### groupByType
+
+Whether to group changelog entries by their conventional commit type. Defaults
+to `false`.
+
+When enabled, entries are grouped under a single header per type (e.g. all
+features under a `Features` header and all fixes under a `Bug Fixes` header)
+instead of being listed in a single flat list:
+
+```md
+## 1.2.0
+
+### Features
+
+ - added user authentication.
+ - implemented dark mode support.
+
+### Bug Fixes
+
+ - corrected issue with API call.
+ - resolved UI glitch on iOS.
+```
+
+This setting can be overridden per run with the `--[no-]group-commits` flag on
+`melos version`.

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -248,6 +248,21 @@
               "type": "boolean",
               "description": "Whether to fetch tags from the origin remote before versioning.\n\nDefaults to true."
             },
+            "changelogFormat": {
+              "type": "object",
+              "description": "Configure the format of the generated CHANGELOG.md.",
+              "additionalProperties": false,
+              "properties": {
+                "includeDate": {
+                  "type": "boolean",
+                  "description": "Whether to include the date in the changelog entry in the `yyyy-MM-dd` format.\n\nDisabled by default."
+                },
+                "groupByType": {
+                  "type": "boolean",
+                  "description": "Whether to group changelog entries by their conventional commit type (e.g. all features under a \"Features\" header and all fixes under a \"Bug Fixes\" header).\n\nDisabled by default."
+                }
+              }
+            },
             "hooks": {
               "description": "Hooks to run at certain points of the command lifecycle.",
               "allOf": [

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -23,6 +23,7 @@ class VersionCommandConfigs {
     this.fetchTags = true,
     this.hooks = VersionLifecycleHooks.empty,
     this.includeDateInChangelogEntry = false,
+    this.groupChangelogEntriesByType = false,
   }) : _aggregateChangelogs = aggregateChangelogs;
 
   factory VersionCommandConfigs.fromYaml(
@@ -172,6 +173,12 @@ class VersionCommandConfigs {
       path: 'command/version/changelogFormat',
     );
 
+    final groupByType = assertKeyIsA<bool?>(
+      key: 'groupByType',
+      map: changelogFormat,
+      path: 'command/version/changelogFormat',
+    );
+
     return VersionCommandConfigs(
       branch: branch,
       message: message,
@@ -186,6 +193,7 @@ class VersionCommandConfigs {
       fetchTags: fetchTags ?? true,
       hooks: hooks,
       includeDateInChangelogEntry: includeDate ?? false,
+      groupChangelogEntriesByType: groupByType ?? false,
     );
   }
 
@@ -237,6 +245,11 @@ class VersionCommandConfigs {
   /// Whether to include the date in the changelog entry in format `yyyy-MM-dd`.
   final bool includeDateInChangelogEntry;
 
+  /// Whether to group changelog entries by their conventional commit type
+  /// (e.g. all features under a "Features" header, all fixes under a
+  /// "Bug Fixes" header) instead of listing them in a single flat list.
+  final bool groupChangelogEntriesByType;
+
   Map<String, Object?> toJson() {
     return {
       if (branch != null) 'branch': branch,
@@ -252,6 +265,7 @@ class VersionCommandConfigs {
       'hooks': hooks.toJson(),
       'changelogFormat': {
         'includeDate': includeDateInChangelogEntry,
+        'groupByType': groupChangelogEntriesByType,
       },
     };
   }
@@ -273,7 +287,8 @@ class VersionCommandConfigs {
       ) &&
       other.fetchTags == fetchTags &&
       other.hooks == hooks &&
-      other.includeDateInChangelogEntry == includeDateInChangelogEntry;
+      other.includeDateInChangelogEntry == includeDateInChangelogEntry &&
+      other.groupChangelogEntriesByType == groupChangelogEntriesByType;
 
   @override
   int get hashCode =>
@@ -288,7 +303,8 @@ class VersionCommandConfigs {
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
       hooks.hashCode ^
-      includeDateInChangelogEntry.hashCode;
+      includeDateInChangelogEntry.hashCode ^
+      groupChangelogEntriesByType.hashCode;
 
   @override
   String toString() {
@@ -305,6 +321,7 @@ VersionCommandConfigs(
   fetchTags: $fetchTags,
   hooks: $hooks,
   includeDateInChangelogEntry: $includeDateInChangelogEntry,
+  groupChangelogEntriesByType: $groupChangelogEntriesByType,
 )''';
   }
 }

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -89,6 +89,14 @@ class VersionCommand extends MelosCommand {
           'Generate and print a link to the prefilled release creation page '
           'for each package after versioning',
     );
+    argParser.addFlag(
+      'group-commits',
+      help:
+          'Group changelog entries by their conventional commit type, e.g. '
+          'all features under a "Features" header and all fixes under a "Bug '
+          'Fixes" header. Overrides the "changelogFormat/groupByType" setting '
+          'in melos.yaml.',
+    );
     argParser.addOption(
       'message',
       abbr: 'm',
@@ -167,6 +175,7 @@ class VersionCommand extends MelosCommand {
     final tag = argResults!['git-tag-version'] as bool;
     final commit = argResults!['git-commit-version'] as bool;
     final releaseUrl = argResults!.optional('release-url') as bool?;
+    final groupCommits = argResults!.optional('group-commits') as bool?;
     final changelog = argResults!['changelog'] as bool;
     final commitMessage = (argResults!['message'] as String?)?.replaceAll(
       r'\n',
@@ -199,6 +208,7 @@ class VersionCommand extends MelosCommand {
         gitTag: tag,
         gitCommit: commit,
         releaseUrl: releaseUrl,
+        groupCommits: groupCommits,
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: false,
@@ -242,6 +252,7 @@ class VersionCommand extends MelosCommand {
         gitTag: tag,
         gitCommit: commit,
         releaseUrl: releaseUrl,
+        groupCommits: groupCommits,
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -14,6 +14,7 @@ mixin _VersionMixin on _RunMixin {
     bool gitTag = true,
     bool gitCommit = true,
     bool? releaseUrl,
+    bool? groupCommits,
     String? message,
     bool force = false,
     // all
@@ -62,6 +63,7 @@ mixin _VersionMixin on _RunMixin {
         gitTag: gitTag,
         gitCommit: gitCommit,
         releaseUrl: releaseUrl,
+        groupCommits: groupCommits,
         message: message,
         force: force,
         showPrivatePackages: showPrivatePackages,
@@ -85,6 +87,7 @@ mixin _VersionMixin on _RunMixin {
     bool gitTag = true,
     bool gitCommit = true,
     bool? releaseUrl,
+    bool? groupCommits,
     String? message,
     bool force = false,
     // all
@@ -319,6 +322,7 @@ mixin _VersionMixin on _RunMixin {
             commits,
             version,
             userChangelogMessage: userChangelogMessage,
+            groupCommits: groupCommits,
             logger: logger,
           );
         },
@@ -335,6 +339,7 @@ mixin _VersionMixin on _RunMixin {
           graduate: asStableRelease,
           prerelease: asPrerelease,
           preid: preid,
+          groupCommits: groupCommits,
           logger: logger,
         ),
       ),

--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -138,7 +138,7 @@ ${description?.withoutTrailing('\n') ?? ''}
         body.writeln('#### ${_packageVersionTitle(update)}');
         body.writeln();
 
-        body.writePackageUpdateChanges(update);
+        body.writePackageUpdateChanges(update, groupHeadingPrefix: '#####');
       }
     }
 

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -137,11 +137,15 @@ extension ChangelogStringBufferExtension on StringBuffer {
     }
   }
 
-  void writePackageUpdateChanges(MelosPendingPackageUpdate update) {
+  void writePackageUpdateChanges(
+    MelosPendingPackageUpdate update, {
+    String groupHeadingPrefix = '###',
+  }) {
     final config = update.workspace.config;
     final repository = config.repository;
-    final linkToCommits = config.commands.version.linkToCommits;
-    final includeCommitId = config.commands.version.includeCommitId;
+    final groupCommits =
+        update.groupCommits ??
+        config.commands.version.groupChangelogEntriesByType;
 
     String processCommitHeader(String header) =>
         repository != null ? header.withIssueLinks(repository) : header;
@@ -154,66 +158,155 @@ extension ChangelogStringBufferExtension on StringBuffer {
 
     // Entries for commits included in new version.
     final commits = _filteredAndSortedCommits(update);
-    if (commits.isNotEmpty) {
+    if (commits.isEmpty) {
+      return;
+    }
+
+    if (groupCommits) {
+      final commitsByType = <String, List<RichGitCommit>>{};
       for (final commit in commits) {
-        final parsedMessage = commit.parsedMessage;
+        (commitsByType[commit.parsedMessage.type!] ??= []).add(commit);
+      }
 
-        write(' - ');
-
-        if (parsedMessage.isBreakingChange) {
-          writeBold('BREAKING');
-          write(' ');
-        }
-
-        writeBold(parsedMessage.type!.toUpperCase());
-        if (config.commands.version.includeScopes) {
-          if (parsedMessage.scopes.isNotEmpty) {
-            write('(');
-            write(parsedMessage.scopes.join(','));
-            write(')');
-          }
-        }
-        write(': ');
-        writePunctuated(processCommitHeader(parsedMessage.description!));
-
-        if (linkToCommits || includeCommitId) {
-          final shortCommitId = commit.id.substring(0, 8);
-          final commitUrl = repository!.commitUrl(commit.id);
-          write(' (');
-          if (linkToCommits) {
-            writeLink(shortCommitId, uri: commitUrl.toString());
-          } else {
-            write(shortCommitId);
-          }
-          write(')');
-        }
-
+      for (final type in _sortedCommitTypes(commitsByType.keys)) {
+        writeln('$groupHeadingPrefix ${_commitTypeHeader(type)}');
         writeln();
-
-        final version = update.workspace.config.commands.version;
-
-        if (!version.includeCommitBody) {
-          continue;
+        for (final commit in commitsByType[type]!) {
+          writeCommitEntry(
+            update,
+            commit,
+            processCommitHeader: processCommitHeader,
+            includeType: false,
+          );
         }
-        if (parsedMessage.body == null) {
-          continue;
-        }
-
-        final shouldWriteBody =
-            !version.commitBodyOnlyBreaking || parsedMessage.isBreakingChange;
-
-        if (shouldWriteBody) {
-          writeln();
-          for (final line in parsedMessage.body!.split('\n')) {
-            write(' ' * 4);
-            writeln(line);
-          }
-          writeln();
-        }
+        writeln();
+      }
+    } else {
+      for (final commit in commits) {
+        writeCommitEntry(
+          update,
+          commit,
+          processCommitHeader: processCommitHeader,
+          includeType: true,
+        );
       }
       writeln();
     }
   }
+
+  void writeCommitEntry(
+    MelosPendingPackageUpdate update,
+    RichGitCommit commit, {
+    required String Function(String) processCommitHeader,
+    required bool includeType,
+  }) {
+    final config = update.workspace.config;
+    final repository = config.repository;
+    final version = config.commands.version;
+    final parsedMessage = commit.parsedMessage;
+
+    write(' - ');
+
+    if (parsedMessage.isBreakingChange) {
+      writeBold('BREAKING');
+      write(' ');
+    }
+
+    if (includeType) {
+      writeBold(parsedMessage.type!.toUpperCase());
+      if (version.includeScopes && parsedMessage.scopes.isNotEmpty) {
+        write('(');
+        write(parsedMessage.scopes.join(','));
+        write(')');
+      }
+      write(': ');
+    } else if (version.includeScopes && parsedMessage.scopes.isNotEmpty) {
+      // When grouping by type the type is the heading, so only the scope is
+      // written as a prefix.
+      writeBold(parsedMessage.scopes.join(','));
+      write(': ');
+    }
+
+    writePunctuated(processCommitHeader(parsedMessage.description!));
+
+    if (version.linkToCommits || version.includeCommitId) {
+      final shortCommitId = commit.id.substring(0, 8);
+      final commitUrl = repository!.commitUrl(commit.id);
+      write(' (');
+      if (version.linkToCommits) {
+        writeLink(shortCommitId, uri: commitUrl.toString());
+      } else {
+        write(shortCommitId);
+      }
+      write(')');
+    }
+
+    writeln();
+
+    if (!version.includeCommitBody) {
+      return;
+    }
+    if (parsedMessage.body == null) {
+      return;
+    }
+
+    final shouldWriteBody =
+        !version.commitBodyOnlyBreaking || parsedMessage.isBreakingChange;
+
+    if (shouldWriteBody) {
+      writeln();
+      for (final line in parsedMessage.body!.split('\n')) {
+        write(' ' * 4);
+        writeln(line);
+      }
+      writeln();
+    }
+  }
+}
+
+/// Conventional commit types mapped to their changelog group headers, in the
+/// order they should appear when grouping changelog entries by type.
+const _commitTypeHeaders = {
+  'feat': 'Features',
+  'fix': 'Bug Fixes',
+  'perf': 'Performance Improvements',
+  'refactor': 'Code Refactoring',
+  'revert': 'Reverts',
+  'docs': 'Documentation',
+  'style': 'Styles',
+  'test': 'Tests',
+  'build': 'Build System',
+  'ci': 'Continuous Integration',
+  'chore': 'Chores',
+};
+
+String _commitTypeHeader(String type) {
+  final known = _commitTypeHeaders[type.toLowerCase()];
+  if (known != null) {
+    return known;
+  }
+  if (type.isEmpty) {
+    return type;
+  }
+  return '${type[0].toUpperCase()}${type.substring(1)}';
+}
+
+List<String> _sortedCommitTypes(Iterable<String> types) {
+  final order = _commitTypeHeaders.keys.toList();
+  return types.toList()..sort((a, b) {
+    final indexA = order.indexOf(a.toLowerCase());
+    final indexB = order.indexOf(b.toLowerCase());
+    if (indexA != -1 && indexB != -1) {
+      return indexA.compareTo(indexB);
+    }
+    if (indexA != -1) {
+      return -1;
+    }
+    if (indexB != -1) {
+      return 1;
+    }
+    return a.compareTo(b);
+  });
 }
 
 List<RichGitCommit> _filteredAndSortedCommits(

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -38,6 +38,7 @@ class MelosPendingPackageUpdate {
     this.prerelease = false,
     this.graduate = false,
     this.preid,
+    this.groupCommits,
   }) : manualVersion = null,
        userChangelogMessage = null;
 
@@ -48,6 +49,7 @@ class MelosPendingPackageUpdate {
     this.manualVersion, {
     required this.logger,
     this.userChangelogMessage,
+    this.groupCommits,
   }) : reason = PackageUpdateReason.manual,
        prerelease = false,
        graduate = false,
@@ -86,6 +88,14 @@ class MelosPendingPackageUpdate {
   ///
   /// This is only used for manually versioned packages.
   final String? userChangelogMessage;
+
+  /// Overrides whether changelog entries are grouped by their conventional
+  /// commit type.
+  ///
+  /// When `null`, the value configured in `command/version/changelogFormat/`
+  /// `groupByType` is used. This is set when the `--[no-]group-commits` flag is
+  /// passed to `melos version`.
+  final bool? groupCommits;
 
   final MelosLogger logger;
 

--- a/packages/melos/test/changelog_test.dart
+++ b/packages/melos/test/changelog_test.dart
@@ -161,6 +161,98 @@ void main() {
       contains('**FEAT**: a ([#123]($issueUrl)).'),
     );
   });
+
+  group('group commits by type', () {
+    test('writes a flat list by default', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderCommitsPackageUpdate(workspace, package, [
+        testCommit(message: 'feat: a'),
+        testCommit(message: 'fix: b'),
+      ]);
+
+      expect(markdown, contains('**FEAT**: a.'));
+      expect(markdown, contains('**FIX**: b.'));
+      expect(markdown, isNot(contains('### Features')));
+      expect(markdown, isNot(contains('### Bug Fixes')));
+    });
+
+    test('groups entries under type headers when enabled via config', () {
+      final workspace = buildWorkspaceWithRepository(groupByType: true);
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderCommitsPackageUpdate(workspace, package, [
+        testCommit(message: 'feat: a'),
+        testCommit(message: 'feat: b'),
+        testCommit(message: 'fix: c'),
+      ]);
+
+      expect(markdown, contains('### Features'));
+      expect(markdown, contains('### Bug Fixes'));
+      // The type prefix is replaced by the header.
+      expect(markdown, isNot(contains('**FEAT**')));
+      expect(markdown, isNot(contains('**FIX**')));
+      expect(markdown, contains(' - a.'));
+      expect(markdown, contains(' - b.'));
+      expect(markdown, contains(' - c.'));
+      // Features are listed before bug fixes.
+      expect(
+        markdown.indexOf('### Features'),
+        lessThan(markdown.indexOf('### Bug Fixes')),
+      );
+    });
+
+    test('keeps the breaking marker and scopes when grouping', () {
+      final workspace = buildWorkspaceWithRepository(
+        groupByType: true,
+        includeScopes: true,
+      );
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderCommitsPackageUpdate(workspace, package, [
+        testCommit(message: 'feat(api)!: a'),
+        testCommit(message: 'feat(ui): b'),
+      ]);
+
+      expect(markdown, contains('### Features'));
+      expect(markdown, contains('**BREAKING** **api**: a.'));
+      expect(markdown, contains('**ui**: b.'));
+    });
+
+    test('the groupCommits override takes precedence over the config', () {
+      final workspace = buildWorkspaceWithRepository();
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderCommitsPackageUpdate(
+        workspace,
+        package,
+        [
+          testCommit(message: 'feat: a'),
+          testCommit(message: 'fix: b'),
+        ],
+        groupCommits: true,
+      );
+
+      expect(markdown, contains('### Features'));
+      expect(markdown, contains('### Bug Fixes'));
+    });
+
+    test('the groupCommits override can disable config grouping', () {
+      final workspace = buildWorkspaceWithRepository(groupByType: true);
+      final package = workspace.allPackages['test_pkg']!;
+
+      final markdown = renderCommitsPackageUpdate(
+        workspace,
+        package,
+        [testCommit(message: 'feat: a')],
+        groupCommits: false,
+      );
+
+      expect(markdown, contains('**FEAT**: a.'));
+      expect(markdown, isNot(contains('### Features')));
+    });
+  });
 }
 
 MelosWorkspace buildWorkspaceWithRepository({
@@ -168,6 +260,7 @@ MelosWorkspace buildWorkspaceWithRepository({
   bool linkToCommits = false,
   bool includeCommitId = false,
   bool includeDateInChangelogEntry = false,
+  bool groupByType = false,
 }) {
   final workspaceBuilder =
       VirtualWorkspaceBuilder(
@@ -180,6 +273,7 @@ MelosWorkspace buildWorkspaceWithRepository({
         linkToCommits: $linkToCommits
         changelogFormat:
           includeDate: $includeDateInChangelogEntry
+          groupByType: $groupByType
     ''',
       )..addPackage(
         '''
@@ -201,13 +295,29 @@ RichGitCommit testCommit({required String message}) => RichGitCommit.tryParse(
 String renderCommitPackageUpdate(
   MelosWorkspace workspace,
   Package package,
-  RichGitCommit commit,
-) {
-  final update = MelosPendingPackageUpdate(
+  RichGitCommit commit, {
+  bool? groupCommits,
+}) {
+  return renderCommitsPackageUpdate(
     workspace,
     package,
     [commit],
+    groupCommits: groupCommits,
+  );
+}
+
+String renderCommitsPackageUpdate(
+  MelosWorkspace workspace,
+  Package package,
+  List<RichGitCommit> commits, {
+  bool? groupCommits,
+}) {
+  final update = MelosPendingPackageUpdate(
+    workspace,
+    package,
+    commits,
     PackageUpdateReason.commit,
+    groupCommits: groupCommits,
     logger: workspace.logger,
   );
   final changelog = MelosChangelog(update, workspace.logger);

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -74,6 +74,8 @@ void main() {
       expect(value.includeCommitId, false);
       expect(value.linkToCommits, false);
       expect(value.updateGitTagRefs, false);
+      expect(value.includeDateInChangelogEntry, false);
+      expect(value.groupChangelogEntriesByType, false);
       expect(value.aggregateChangelogs, [
         AggregateChangelogConfig.workspace(),
       ]);
@@ -162,6 +164,36 @@ void main() {
                 description: 'Changelog for all foo packages.',
               ),
             ],
+          ),
+        );
+      });
+
+      test('throws if changelogFormat/groupByType is not a bool', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {
+              'changelogFormat': {'groupByType': 42},
+            },
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('can decode changelogFormat values', () {
+        expect(
+          VersionCommandConfigs.fromYaml(
+            const {
+              'changelogFormat': {
+                'includeDate': true,
+                'groupByType': true,
+              },
+            },
+            workspacePath: '.',
+          ),
+          const VersionCommandConfigs(
+            includeDateInChangelogEntry: true,
+            groupChangelogEntriesByType: true,
           ),
         );
       });


### PR DESCRIPTION
## Description

Implements the feature requested in #763: an option to group changelog
entries by their conventional commit type, so each type gets a single
header instead of every entry repeating its `**TYPE**` prefix in a flat list.

This is available both as a CLI flag and as a config option:

- **Flag:** `melos version --group-commits` (and `--no-group-commits`)
- **Config:** `command/version/changelogFormat/groupByType: true`

The flag overrides the config value when provided, mirroring how
`--[no-]release-url` works.

### Example output

Flat (default):

```md
## 1.2.0

 - **FEAT**: added user authentication.
 - **FEAT**: implemented dark mode support.
 - **FIX**: corrected issue with API call.
```

Grouped (`--group-commits`):

```md
## 1.2.0

### Features

 - added user authentication.
 - implemented dark mode support.

### Bug Fixes

 - corrected issue with API call.
```

Groups are ordered by a sensible conventional-commit priority (Features,
Bug Fixes, Performance Improvements, ...), with any unknown types appended
alphabetically. Breaking-change markers, scopes, commit ids/links and
commit bodies are all preserved within each group. Grouping also applies
to aggregate/workspace changelogs (with a deeper heading level so the
package hierarchy stays correct).

## Changes

- Add `groupByType` to `changelogFormat` in `VersionCommandConfigs`.
- Add the `--[no-]group-commits` flag to `melos version`, threaded through
  to the changelog generation via a `groupCommits` override on
  `MelosPendingPackageUpdate`.
- Refactor `writePackageUpdateChanges` to share a single per-commit writer
  between the flat and grouped paths (flat output is byte-for-byte
  unchanged).
- Update the JSON schema (`changelogFormat` was previously missing) and the
  docs for the `version` command and configuration overview.
- Add tests for the config parsing and the grouped changelog output,
  including the flag override in both directions.

Closes #763
