### PR TITLE
fix(scripts): run nested melos commands without a global installation

### DIFF
--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -157,6 +157,7 @@ FutureOr<void> melosEntryPoint(
     final config = await _resolveConfig(
       arguments,
       context.localInstallation?.lockFileRoot,
+      melosCommand: _resolveMelosCommand(context),
     );
     await MelosCommandRunner(config).run(arguments);
   } on MelosException catch (err) {
@@ -171,17 +172,36 @@ FutureOr<void> melosEntryPoint(
   }
 }
 
+/// Resolves the command used to invoke Melos itself for nested `melos`
+/// invocations from scripts (e.g. `melos exec`).
+///
+/// When Melos is run from a local installation (e.g. as a `dev_dependency`) it
+/// is not available on the `PATH`, so scripts that run nested Melos commands
+/// would fail with "melos: command not found". In that case Melos is invoked
+/// through the Dart SDK instead, mirroring how `cli_launcher` relaunches the
+/// local installation. See https://github.com/invertase/melos/issues/511.
+List<String> _resolveMelosCommand(LaunchContext context) {
+  if (context.localInstallation == null) {
+    return defaultMelosCommand;
+  }
+  return ['dart', 'run', 'melos:melos'];
+}
+
 Future<MelosWorkspaceConfig> _resolveConfig(
   List<String> arguments,
-  Directory? workspaceRoot,
-) async {
+  Directory? workspaceRoot, {
+  List<String> melosCommand = defaultMelosCommand,
+}) async {
   if (_shouldUseEmptyConfig(arguments)) {
     return MelosWorkspaceConfig.empty();
   }
   if (workspaceRoot == null) {
     return MelosWorkspaceConfig.handleWorkspaceNotFound(Directory.current);
   }
-  return MelosWorkspaceConfig.fromWorkspaceRoot(workspaceRoot);
+  return MelosWorkspaceConfig.fromWorkspaceRoot(
+    workspaceRoot,
+    melosCommand: melosCommand,
+  );
 }
 
 bool _shouldUseEmptyConfig(List<String> arguments) {

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -79,7 +79,10 @@ mixin _RunMixin on _Melos {
     }
 
     final scriptSourceCode = targetStyle(
-      script.command(extraArgs).join(' ').withoutTrailing('\n'),
+      script
+          .command(extraArgs: extraArgs, melosCommand: config.melosCommand)
+          .join(' ')
+          .withoutTrailing('\n'),
     );
 
     logger.command('melos run ${script.name}');
@@ -312,7 +315,7 @@ mixin _RunMixin on _Melos {
     }
 
     return startCommand(
-      script.command(extraArgs),
+      script.command(extraArgs: extraArgs, melosCommand: config.melosCommand),
       logger: logger,
       environment: environment,
       workingDirectory: config.path,
@@ -369,12 +372,13 @@ mixin _RunMixin on _Melos {
   }
 
   String _buildScriptCommand(String step, Scripts scripts) {
+    final melos = config.melosCommand.join(' ');
     if (scripts.containsKey(step)) {
-      return 'melos run $step --include-private';
+      return '$melos run $step --include-private';
     }
 
     if (_isStepACommand(step)) {
-      return 'melos $step';
+      return '$melos $step';
     }
 
     return step;

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -158,7 +158,14 @@ abstract class _Melos {
   }) async {
     logger
       ..command('melos ${command.name} [${script.name}]')
-      ..child(targetStyle(script.command().join(' ').replaceAll('\n', '')))
+      ..child(
+        targetStyle(
+          script
+              .command(melosCommand: config.melosCommand)
+              .join(' ')
+              .replaceAll('\n', ''),
+        ),
+      )
       ..newLine();
 
     final exitCode = await _runScript(script, noSelect: true);

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -47,6 +47,16 @@ const publishOptionYes = 'yes';
 const publishOptionForce = 'force';
 const publishOptionServer = 'server';
 
+/// The default command used to invoke Melos itself when a script needs to run
+/// a nested Melos command, such as `melos exec` or `melos run`.
+///
+/// This relies on Melos being available on the `PATH` (i.e. a global
+/// installation). When Melos is run from a local installation (e.g. as a
+/// `dev_dependency`) it is invoked through the Dart SDK instead so that
+/// scripts work without a global installation. See
+/// https://github.com/invertase/melos/issues/511.
+const defaultMelosCommand = ['melos'];
+
 extension Let<T> on T? {
   R? let<R>(R Function(T value) cb) {
     if (this == null) {

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -418,7 +418,15 @@ class Script {
   final ProcessStdio stdio;
 
   /// Returns the full command to run when executing this script.
-  List<String> command([List<String>? extraArgs]) {
+  ///
+  /// [melosCommand] is the command used to invoke Melos itself for nested
+  /// `melos exec` calls. It defaults to [defaultMelosCommand], but is replaced
+  /// with a Dart SDK invocation when Melos runs from a local installation so
+  /// that scripts work without a global installation.
+  List<String> command({
+    List<String>? extraArgs,
+    List<String> melosCommand = defaultMelosCommand,
+  }) {
     String quoteScript(String script) => '"${script.replaceAll('"', r'\"')}"';
 
     final scriptCommand = run!.split(' ').toList();
@@ -430,7 +438,7 @@ class Script {
     if (exec == null) {
       return scriptCommand;
     } else {
-      final execCommand = ['melos', 'exec'];
+      final execCommand = [...melosCommand, 'exec'];
 
       if (exec.concurrency != null) {
         execCommand.addAll(['--concurrency', '${exec.concurrency}']);

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -272,6 +272,7 @@ class MelosWorkspaceConfig {
     this.pub = const PubClientConfig(),
     this.useRootAsPackage = false,
     this.discoverNestedWorkspaces = false,
+    this.melosCommand = defaultMelosCommand,
   }) {
     _validate();
   }
@@ -279,6 +280,7 @@ class MelosWorkspaceConfig {
   factory MelosWorkspaceConfig.fromYaml(
     Map<Object?, Object?> pubspecYaml, {
     required String path,
+    List<String> melosCommand = defaultMelosCommand,
   }) {
     final name = assertKeyIsA<String>(key: 'name', map: pubspecYaml);
     if (!isValidPubPackageName(name)) {
@@ -448,6 +450,7 @@ class MelosWorkspaceConfig {
             ),
       useRootAsPackage: useRootAsPackage,
       discoverNestedWorkspaces: discoverNestedWorkspaces,
+      melosCommand: melosCommand,
     );
   }
 
@@ -480,8 +483,9 @@ class MelosWorkspaceConfig {
 
   /// Loads the [MelosWorkspaceConfig] for the workspace at [workspaceRoot].
   static Future<MelosWorkspaceConfig> fromWorkspaceRoot(
-    Directory workspaceRoot,
-  ) async {
+    Directory workspaceRoot, {
+    List<String> melosCommand = defaultMelosCommand,
+  }) async {
     final rootPubspecFile = File(pubspecPathForDirectory(workspaceRoot.path));
 
     if (!rootPubspecFile.existsSync()) {
@@ -522,6 +526,7 @@ class MelosWorkspaceConfig {
     return MelosWorkspaceConfig.fromYaml(
       rootPubspecContent,
       path: workspaceRoot.path,
+      melosCommand: melosCommand,
     );
   }
 
@@ -634,6 +639,10 @@ class MelosWorkspaceConfig {
   /// Whether to recursively discover packages in nested workspaces.
   /// Defaults to false.
   final bool discoverNestedWorkspaces;
+
+  /// The command used to invoke Melos itself when a script runs a nested Melos
+  /// command (e.g. `melos exec`).
+  final List<String> melosCommand;
 
   /// Validates this workspace configuration for consistency.
   void _validate() {

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -395,6 +395,45 @@ ${'-' * terminalWidth}
 
       expect(() => melos.run(scriptName: 'test_script'), throwsException);
     });
+
+    group('command', () {
+      test('uses "melos" by default for "exec" scripts', () {
+        const script = Script(
+          name: 'test_script',
+          run: 'echo "hello"',
+          exec: ExecOptions(),
+        );
+
+        expect(script.command(), ['melos', 'exec', '--', r'"echo \"hello\""']);
+      });
+
+      test(
+        'uses the provided melosCommand for "exec" scripts when Melos is '
+        'installed locally',
+        () {
+          // Simulates a local installation, where Melos is not on the PATH and
+          // must be invoked through the Dart SDK.
+          // https://github.com/invertase/melos/issues/511
+          const script = Script(
+            name: 'test_script',
+            run: 'echo "hello"',
+            exec: ExecOptions(),
+          );
+
+          expect(
+            script.command(melosCommand: const ['dart', 'run', 'melos:melos']),
+            [
+              'dart',
+              'run',
+              'melos:melos',
+              'exec',
+              '--',
+              r'"echo \"hello\""',
+            ],
+          );
+        },
+      );
+    });
   });
 
   group('multiple scripts', () {


### PR DESCRIPTION
## Description

Fixes #511.

Scripts that run nested melos commands hardcoded `melos`, which is only resolvable when melos is installed globally on the `PATH`. When melos was installed locally (e.g. as a `dev_dependency`), scripts that use `exec` (or `steps` referencing other scripts / melos commands) failed:

```
melos run test
  └> melos exec -- "echo Hi"
     └> RUNNING

/bin/sh: melos: command not found
```

This made it impossible to use such scripts in CI without a global install.

## Fix

Melos already runs through [`cli_launcher`](https://pub.dev/packages/cli_launcher), which provides a `LaunchContext` describing how it was launched. At the entry point we resolve how Melos should invoke itself for nested commands and store it on `MelosWorkspaceConfig.melosCommand`, which already flows through to every command and the `Melos` runner. The two places that run scripts (`Script.command()` for `exec`, and the step builder) read it from the config.

- **Local installation** (`context.localInstallation != null`): nested commands are invoked through `dart run melos:melos`, mirroring exactly how `cli_launcher` relaunches the local installation. Works without a global install.
- **Global installation**: unchanged, keeps invoking `melos` from the `PATH`.

`melosCommand` defaults to `['melos']`, so existing behavior, tests, and direct `MelosWorkspaceConfig` construction are unaffected. It is runtime information rather than declarative config, so it is excluded from `==`, `hashCode`, `toJson`, and `toString`.

## Verification

Reproduced the original failure with a local-only install (melos removed from `PATH`), then confirmed both `exec` and `steps` scripts work after the fix:

```
melos run hello
  └> dart run melos:melos exec -- "echo Hi"
     └> RUNNING
...
pkg_a: SUCCESS
```

## Tests

- Added unit tests asserting `Script.command()` uses `melos` by default and the provided invocation when running from a local installation.
- Existing `run`, `exec`, `script`, `command_runner`, and `workspace_config` suites pass.