### PR TITLE
docs: fix broken markdown heading for removed `melos analyze`

### DIFF
--- a/docs/guides/migrations.mdx
+++ b/docs/guides/migrations.mdx
@@ -93,10 +93,10 @@ If you are using an older version of the Dart SDK, you can still use Melos
 with pub workspaces, but then you have to rely on the `7.0.0-dev.x` versions.
 </Info>
 
-### 'melos analyze` no longer exists
+### `melos analyze` no longer exists
 
 Since `flutter/dart analyze` now runs in the full pub workspace, the
-`melos analyze` command has been removed,
+`melos analyze` command has been removed.
 
 ### Root packages
 


### PR DESCRIPTION
Addresses #924

The v7 migration note about the removed `melos analyze` command has a broken heading:

```
### 'melos analyze` no longer exists
```

It opens the inline-code span with a stray straight quote (`'`) and closes it with a backtick, so it renders as literal `'melos analyze` instead of code. This fixes the heading to use backticks on both sides (matching how `melos analyze` is written in the body just below), and ends the following sentence with a period instead of a trailing comma.

Scope is intentionally limited to the rendering/punctuation fix; it doesn't touch the technical wording about whether `dart analyze` covers the full workspace (still under discussion in #924).