### PR TITLE
fix: Exclude docs-only commits from version bumping

### DIFF
--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -56,7 +56,7 @@ ${description?.withoutTrailing('\n') ?? ''}
         .where(
           (update) =>
               update.reason == PackageUpdateReason.graduate &&
-              !update.hasVersionableCommits,
+              !update.hasChangelogCommits,
         )
         .toSet();
     final packagesWithBreakingChanges = pendingPackageUpdates.where(

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -117,7 +117,7 @@ extension ChangelogStringBufferExtension on StringBuffer {
     }
 
     if (update.reason == PackageUpdateReason.graduate &&
-        !update.hasVersionableCommits) {
+        !update.hasChangelogCommits) {
       // Package graduation entry without any new commits since the last
       // pre-release.
       writeln(
@@ -130,7 +130,7 @@ extension ChangelogStringBufferExtension on StringBuffer {
     if (update.reason == PackageUpdateReason.commit ||
         update.reason == PackageUpdateReason.manual ||
         (update.reason == PackageUpdateReason.graduate &&
-            update.hasVersionableCommits)) {
+            update.hasChangelogCommits)) {
       // Breaking change note.
       if (update.hasBreakingChanges) {
         writeln('> Note: This release has breaking changes.');
@@ -317,7 +317,7 @@ List<RichGitCommit> _filteredAndSortedCommits(
   MelosPendingPackageUpdate update,
 ) {
   final commits = update.commits
-      .where((commit) => commit.parsedMessage.isVersionableCommit)
+      .where((commit) => commit.parsedMessage.includeInChangelog)
       .toList();
 
   // Sort so that Breaking Changes appear at the top.

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -154,8 +154,8 @@ class MelosPendingPackageUpdate {
   }
 
   /// Whether this update has any commits that produce changelog entries.
-  bool get hasVersionableCommits {
-    return commits.any((commit) => commit.parsedMessage.isVersionableCommit);
+  bool get hasChangelogCommits {
+    return commits.any((commit) => commit.parsedMessage.includeInChangelog);
   }
 
   /// Whether this update contains breaking changes.

--- a/packages/melos/lib/src/common/versioning.dart
+++ b/packages/melos/lib/src/common/versioning.dart
@@ -19,7 +19,6 @@ extension ConventionalCommitVersioningExtension on ConventionalCommit {
   bool get isVersionableCommit {
     return isBreakingChange ||
         [
-          'docs',
           'feat',
           'fix',
           'bug',
@@ -27,6 +26,17 @@ extension ConventionalCommitVersioningExtension on ConventionalCommit {
           'refactor',
           'revert',
         ].contains(type);
+  }
+
+  /// Whether this commit should be listed in the changelog of its residing
+  /// package.
+  ///
+  /// This is a superset of [isVersionableCommit]: in addition to the
+  /// version-bumping commits, it includes `docs` commits so documentation
+  /// changes are recorded in the changelog without triggering a release on
+  /// their own.
+  bool get includeInChangelog {
+    return isVersionableCommit || type == 'docs';
   }
 
   /// Returns the [SemverReleaseType] for this commit, e.g.

--- a/packages/melos/test/common/versioning_test.dart
+++ b/packages/melos/test/common/versioning_test.dart
@@ -12,8 +12,14 @@ void main() {
         ConventionalCommit.tryParse('chore!: foo bar')!.isVersionableCommit,
         isTrue,
       );
+      // `docs` commits do not trigger a version bump on their own.
       expect(
         ConventionalCommit.tryParse('docs: foo bar')!.isVersionableCommit,
+        isFalse,
+      );
+      // A breaking `docs` commit is still versionable.
+      expect(
+        ConventionalCommit.tryParse('docs!: foo bar')!.isVersionableCommit,
         isTrue,
       );
       expect(
@@ -58,6 +64,39 @@ void main() {
       );
       expect(
         ConventionalCommit.tryParse('Merged foo into bar')!.isVersionableCommit,
+        isFalse,
+      );
+    });
+
+    test('includeInChangelog', () {
+      // Version-bumping commits are always included in the changelog.
+      expect(
+        ConventionalCommit.tryParse('feat: foo bar')!.includeInChangelog,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse('fix: foo bar')!.includeInChangelog,
+        isTrue,
+      );
+      // `docs` commits are included in the changelog even though they do not
+      // trigger a version bump.
+      expect(
+        ConventionalCommit.tryParse('docs: foo bar')!.includeInChangelog,
+        isTrue,
+      );
+      expect(
+        ConventionalCommit.tryParse(
+          'docs(scope): foo bar',
+        )!.includeInChangelog,
+        isTrue,
+      );
+      // Other non-versionable types are still excluded from the changelog.
+      expect(
+        ConventionalCommit.tryParse('ci: foo bar')!.includeInChangelog,
+        isFalse,
+      );
+      expect(
+        ConventionalCommit.tryParse('chore: foo bar')!.includeInChangelog,
         isFalse,
       );
     });


### PR DESCRIPTION
## Description

`melos version` currently treats `docs`-type conventional commits as version-bumping (patch), which diverges from the Conventional Commits / SemVer convention where documentation-only changes do not produce a release on their own (matching `semantic-release`).

The root cause is that `isVersionableCommit` gated two separate concerns at once:
1. whether a commit should **bump the version**, and
2. whether a commit should **appear in the changelog**.

This PR splits those concerns (Option B from #1034):

- `isVersionableCommit` no longer includes `docs` (breaking changes of any type remain versionable).
- Adds `includeInChangelog` (versionable commits **plus** `docs`) and routes changelog filtering and the graduate-flow check through it (`hasVersionableCommits` → `hasChangelogCommits`).

### Behavior

- A `docs`-only commit no longer triggers a release.
- `docs` commits still appear in the changelog when a release is produced by other commits, including the graduate-with-only-docs case (no regression).

### Tests

- Updated `versioning_test.dart`: `docs` is no longer versionable; a breaking `docs!` still is.
- Added coverage for `includeInChangelog` (feat/fix/docs → true, ci/chore → false).
- `versioning_test.dart` (55) and `changelog_test.dart` (17) pass locally.

> Note on breaking: this changes the version-bump output for docs-only changes. I've scoped it as `fix` (aligning with the standard), but happy to relabel as breaking (`!`) if maintainers consider downstream release pipelines. See open questions in #1034.

Closes #1034

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
