### PR TITLE
feat(intellij): configure generated script run prefixes

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -270,6 +270,20 @@ melos:
       generateAppRunConfigs: false
 ```
 
+### scriptNamePrefix
+
+The text prepended to generated IntelliJ run configuration names for Melos
+scripts.
+
+The default is `Melos Run -> `. Set this to an empty string to omit the prefix.
+
+```yaml
+melos:
+  ide:
+    intellij:
+      scriptNamePrefix: ""
+```
+
 ### runArguments
 
 Allows specifying additional run arguments per Flutter app package. This

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -132,6 +132,10 @@
                 "moduleNamePrefix": {
                   "type": "string",
                   "description": "Used when generating IntelliJ project modules files, this value specifies a string to prepend to a package's IntelliJ module name.\n\nThe default is 'melos_'."
+                },
+                "scriptNamePrefix": {
+                  "type": "string",
+                  "description": "The text prepended to generated IntelliJ run configuration names for Melos scripts.\n\nThe default is 'Melos Run -> '. Set this to an empty string to omit the prefix."
                 }
               }
             }

--- a/packages/melos/lib/src/common/intellij_project.dart
+++ b/packages/melos/lib/src/common/intellij_project.dart
@@ -315,8 +315,9 @@ class IntellijProject {
       'Melos -&gt; Clean Workspace': 'clean',
     };
 
+    final scriptNamePrefix = _workspace.config.ide.intelliJ.scriptNamePrefix;
     for (final key in _workspace.config.scripts.keys) {
-      runConfigurations["Melos Run -&gt; '$key'"] = 'run $key';
+      runConfigurations["$scriptNamePrefix'$key'"] = 'run $key';
     }
 
     await Future.forEach(runConfigurations.keys, (scriptName) async {
@@ -329,7 +330,7 @@ class IntellijProject {
       final generatedRunConfiguration = injectTemplateVariables(
         melosScriptTemplate,
         {
-          'scriptName': scriptName,
+          'scriptName': _escapeXmlAttr(scriptName),
           'scriptArgs': scriptArgs,
           'scriptPath': getMelosBinForIde(),
           'executeInTerminal': _workspace.config.ide.intelliJ.executeInTerminal

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -67,6 +67,7 @@ class IntelliJConfig {
     this.moduleNamePrefix = _defaultModuleNamePrefix,
     this.executeInTerminal = _defaultExecuteInTerminal,
     this.generateAppRunConfigs = _defaultGenerateAppRunConfigs,
+    this.scriptNamePrefix = _defaultScriptNamePrefix,
     this.runArguments = const {},
   });
 
@@ -96,6 +97,13 @@ class IntelliJConfig {
               path: 'ide/intellij',
             )
           : _defaultGenerateAppRunConfigs;
+      final scriptNamePrefix = yaml.containsKey('scriptNamePrefix')
+          ? assertKeyIsA<String>(
+              key: 'scriptNamePrefix',
+              map: yaml,
+              path: 'ide/intellij',
+            )
+          : _defaultScriptNamePrefix;
       final rawRunArgsYaml = yaml['runArguments'];
       final rawRunArgs = (rawRunArgsYaml is Map)
           ? rawRunArgsYaml.cast<Object?, Object?>()
@@ -115,6 +123,7 @@ class IntelliJConfig {
         moduleNamePrefix: moduleNamePrefix,
         executeInTerminal: executeInTerminal,
         generateAppRunConfigs: generateAppRunConfigs,
+        scriptNamePrefix: scriptNamePrefix,
         runArguments: runArguments,
       );
     } else {
@@ -129,6 +138,7 @@ class IntelliJConfig {
 
   static const empty = IntelliJConfig();
   static const _defaultModuleNamePrefix = 'melos_';
+  static const _defaultScriptNamePrefix = 'Melos Run -> ';
   static const _defaultEnabled = true;
   static const _defaultExecuteInTerminal = true;
   static const _defaultGenerateAppRunConfigs = true;
@@ -141,6 +151,8 @@ class IntelliJConfig {
 
   final bool generateAppRunConfigs;
 
+  final String scriptNamePrefix;
+
   final Map<String, List<IdeRunConfiguration>> runArguments;
 
   Object? toJson() {
@@ -149,6 +161,7 @@ class IntelliJConfig {
       'moduleNamePrefix': moduleNamePrefix,
       'executeInTerminal': executeInTerminal,
       'generateAppRunConfigs': generateAppRunConfigs,
+      'scriptNamePrefix': scriptNamePrefix,
       'runArguments': runArguments.map(
         (key, value) => MapEntry(
           key,
@@ -166,6 +179,7 @@ class IntelliJConfig {
       other.moduleNamePrefix == moduleNamePrefix &&
       other.executeInTerminal == executeInTerminal &&
       other.generateAppRunConfigs == generateAppRunConfigs &&
+      other.scriptNamePrefix == scriptNamePrefix &&
       const DeepCollectionEquality().equals(
         other.runArguments,
         runArguments,
@@ -178,6 +192,7 @@ class IntelliJConfig {
       moduleNamePrefix.hashCode ^
       executeInTerminal.hashCode ^
       generateAppRunConfigs.hashCode ^
+      scriptNamePrefix.hashCode ^
       const DeepCollectionEquality().hash(runArguments);
 
   @override
@@ -187,7 +202,8 @@ IntelliJConfig(
   enabled: $enabled,
   moduleNamePrefix: $moduleNamePrefix,
   executeInTerminal: $executeInTerminal,
-  generateAppRunConfigs: $generateAppRunConfigs
+  generateAppRunConfigs: $generateAppRunConfigs,
+  scriptNamePrefix: $scriptNamePrefix
 )
 ''';
   }

--- a/packages/melos/test/common/intellij_project_test.dart
+++ b/packages/melos/test/common/intellij_project_test.dart
@@ -321,4 +321,93 @@ void main() {
       },
     );
   });
+
+  group('Melos script run configurations', () {
+    test('uses the default script name prefix', () async {
+      final tempDir = createTestTempDir();
+      final workspaceBuilder =
+          VirtualWorkspaceBuilder(
+            path: tempDir.path,
+            '''
+        packages:
+          - .
+        scripts:
+          format: dart format .
+        ''',
+          )..addPackage(
+            '''
+          name: root
+          ''',
+            path: '.',
+          );
+      final workspace = workspaceBuilder.build();
+      final project = IntellijProject.fromWorkspace(workspace);
+      await project.writeMelosScripts();
+
+      final content = readTextFile(
+        p.join(project.runConfigurationsDir.path, 'melos_run_format.xml'),
+      );
+      expect(content, contains("name=\"Melos Run -&gt; 'format'\""));
+    });
+
+    test('supports a custom script name prefix', () async {
+      final tempDir = createTestTempDir();
+      final workspaceBuilder =
+          VirtualWorkspaceBuilder(
+            path: tempDir.path,
+            '''
+        packages:
+          - .
+        ide:
+          intellij:
+            scriptNamePrefix: "Workspace -> "
+        scripts:
+          format: dart format .
+        ''',
+          )..addPackage(
+            '''
+          name: root
+          ''',
+            path: '.',
+          );
+      final workspace = workspaceBuilder.build();
+      final project = IntellijProject.fromWorkspace(workspace);
+      await project.writeMelosScripts();
+
+      final content = readTextFile(
+        p.join(project.runConfigurationsDir.path, 'melos_run_format.xml'),
+      );
+      expect(content, contains("name=\"Workspace -&gt; 'format'\""));
+    });
+
+    test('supports an empty script name prefix', () async {
+      final tempDir = createTestTempDir();
+      final workspaceBuilder =
+          VirtualWorkspaceBuilder(
+            path: tempDir.path,
+            '''
+        packages:
+          - .
+        ide:
+          intellij:
+            scriptNamePrefix: ""
+        scripts:
+          format: dart format .
+        ''',
+          )..addPackage(
+            '''
+          name: root
+          ''',
+            path: '.',
+          );
+      final workspace = workspaceBuilder.build();
+      final project = IntellijProject.fromWorkspace(workspace);
+      await project.writeMelosScripts();
+
+      final content = readTextFile(
+        p.join(project.runConfigurationsDir.path, 'melos_run_format.xml'),
+      );
+      expect(content, contains("name=\"'format'\""));
+    });
+  });
 }

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -479,6 +479,13 @@ void main() {
       );
     });
 
+    test('has "Melos Run -> " scriptNamePrefix by default', () {
+      expect(
+        IntelliJConfig.empty.scriptNamePrefix,
+        'Melos Run -> ',
+      );
+    });
+
     group('fromYaml', () {
       test('yields default config from empty map', () {
         expect(
@@ -502,6 +509,20 @@ void main() {
         expect(
           IntelliJConfig.fromYaml(const {'moduleNamePrefix': 'prefix1'}),
           const IntelliJConfig(moduleNamePrefix: 'prefix1'),
+        );
+      });
+
+      test('supports "scriptNamePrefix" override', () {
+        expect(
+          IntelliJConfig.fromYaml(const {'scriptNamePrefix': 'prefix1'}),
+          const IntelliJConfig(scriptNamePrefix: 'prefix1'),
+        );
+      });
+
+      test('supports empty "scriptNamePrefix"', () {
+        expect(
+          IntelliJConfig.fromYaml(const {'scriptNamePrefix': ''}),
+          const IntelliJConfig(scriptNamePrefix: ''),
         );
       });
 


### PR DESCRIPTION
## Description

Allow Melos users to control the label prefix used for generated IntelliJ run configurations for workspace scripts. This lets projects remove the default `Melos Run -> ` text or replace it with wording that better fits their IDE setup.

  ## Summary

  - Add `ide.intellij.scriptNamePrefix`, defaulting to the current `Melos Run -> ` behavior.
  - Use the configured prefix when generating IntelliJ shell script run configuration names.
  - Escape XML attribute values at output time so custom prefixes can use normal text like `Workspace -> `.
  - Document the new option and expose it in the JSON schema.
  - Add focused tests for default, custom, and empty-prefix behavior.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
