### PR TITLE
fix(analyze): restore melos analyze command

### DIFF
--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -1,0 +1,51 @@
+---
+title: Analyze Command
+description: Learn more about the `analyze` command in Melos.
+---
+
+# Analyze Command
+
+<Info>Supports all [Melos filtering](/filters) flags.</Info>
+
+This command analyzes all local packages in your workspace.
+
+```bash
+melos analyze
+```
+
+<Info>
+  To learn more, visit the [Dart Analyze](https://dart.dev/tools/dart-analyze) documentation.
+</Info>
+
+
+## --fatal-infos
+Enforces a strict analysis by treating info-level issues as critical errors.
+By default this option is disabled.
+
+```bash
+melos analyze --fatal-infos
+```
+
+## --fatal-warnings
+Enables treating warnings as fatal errors. When enabled, any warning will cause the analyzer to fail.
+By default this option is enabled.
+
+```bash
+melos analyze --fatal-warnings
+```
+
+## --no-fatal-warnings
+This option configures the melos analyze command to ignore warnings, allowing the analysis process to complete successfully even if warnings are present.
+
+```bash
+melos analyze --no-fatal-warnings
+```
+
+## concurrency (-c)
+
+Defines the max concurrency value of how many packages will execute the command in at any one time. Defaults to `1`.
+
+```bash
+# Set a 5 concurrency
+melos analyze -c 5
+```

--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -9,6 +9,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:pub_updater/pub_updater.dart';
 
 import '../version.g.dart';
+import 'command_runner/analyze.dart';
 import 'command_runner/bootstrap.dart';
 import 'command_runner/clean.dart';
 import 'command_runner/exec.dart';
@@ -69,6 +70,7 @@ class MelosCommandRunner extends CommandRunner<void> {
 
     // Create built-in commands
     final builtInCommands = [
+      AnalyzeCommand(config),
       InitCommand(config),
       ExecCommand(config),
       BootstrapCommand(config),

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -1,0 +1,50 @@
+import '../commands/runner.dart';
+import '../common/utils.dart';
+import 'base.dart';
+
+class AnalyzeCommand extends MelosCommand {
+  AnalyzeCommand(super.config) {
+    setupPackageFilterParser();
+    argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
+    argParser.addFlag(
+      'fatal-infos',
+      negatable: false,
+      help:
+          'Enables treating info-lever issues as fatal errors, '
+          'stopping the process if any are encountered.',
+    );
+
+    argParser.addFlag(
+      'fatal-warnings',
+      help:
+          'Enables or disables treating warnings as fatal errors. '
+          'When enabled, any warning will cause the command to fail.',
+    );
+  }
+
+  @override
+  final String name = 'analyze';
+
+  @override
+  final String description =
+      'Analyzes all packages in your project for potential issues '
+      'in a single run. Optionally configure severity levels. '
+      'Supports all package filtering options.';
+
+  @override
+  Future<void> run() async {
+    final fatalInfos = argResults?['fatal-infos'] as bool;
+    final fatalWarnings = argResults!.optional('fatal-warnings') as bool?;
+    final concurrency = int.parse(argResults!['concurrency'] as String);
+
+    final melos = Melos(logger: logger, config: config);
+
+    return melos.analyze(
+      global: global,
+      packageFilters: parsePackageFilters(config.path),
+      concurrency: concurrency,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+    );
+  }
+}

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -1,0 +1,184 @@
+part of 'runner.dart';
+
+mixin _AnalyzeMixin on _Melos {
+  Future<void> analyze({
+    GlobalOptions? global,
+    PackageFilters? packageFilters,
+    bool fatalInfos = false,
+    bool? fatalWarnings,
+    int concurrency = 1,
+  }) async {
+    final workspace = await createWorkspace(
+      global: global,
+      packageFilters: packageFilters,
+    );
+    final packages = workspace.filteredPackages.values;
+
+    await _analyzeForAllPackages(
+      workspace,
+      packages,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+      concurrency: concurrency,
+    );
+  }
+
+  Future<void> _analyzeForAllPackages(
+    MelosWorkspace workspace,
+    Iterable<Package> packages, {
+    required bool fatalInfos,
+    bool? fatalWarnings,
+    required int concurrency,
+  }) async {
+    final failures = <String, int?>{};
+    final pool = Pool(concurrency);
+    final analyzeArgsString = _getAnalyzeArgs(
+      workspace: workspace,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+      concurrency: concurrency,
+    ).join(' ');
+    final useGroupBuffer = concurrency != 1 && packages.length != 1;
+    final dartPackageCount = packages.where((e) => !e.isFlutterPackage).length;
+    final flutterPackageCount = packages
+        .where((e) => e.isFlutterPackage)
+        .length;
+
+    logger.command('melos analyze', withDollarSign: true);
+
+    if (dartPackageCount > 0) {
+      logger
+          .child(targetStyle(analyzeArgsString))
+          .child('$runningLabel (in $dartPackageCount packages)')
+          .newLine();
+    }
+
+    if (flutterPackageCount > 0) {
+      logger
+          .child(targetStyle(analyzeArgsString.replaceFirst('dart', 'flutter')))
+          .child('$runningLabel (in $flutterPackageCount packages)')
+          .newLine();
+    }
+
+    await pool.forEach<Package, void>(packages, (package) async {
+      final group = useGroupBuffer ? package.name : null;
+      logger
+        ..horizontalLine(group: group)
+        ..log(AnsiStyles.bgBlack.bold.italic('${package.name}:'), group: group);
+
+      final packageExitCode = await _analyzeForPackage(
+        workspace,
+        package,
+        _getAnalyzeArgs(
+          package: package,
+          workspace: workspace,
+          fatalInfos: fatalInfos,
+          fatalWarnings: fatalWarnings,
+        ),
+        group: group,
+      );
+
+      if (packageExitCode > 0) {
+        failures[package.name] = packageExitCode;
+      } else {
+        logger.log(
+          AnsiStyles.bgBlack.bold.italic('${package.name}: ') +
+              AnsiStyles.bgBlack(successLabel),
+          group: group,
+        );
+      }
+    }).drain<void>();
+
+    await logger.flushGroupBufferIfNeed();
+
+    logger
+      ..horizontalLine()
+      ..newLine()
+      ..command('melos analyze', withDollarSign: true);
+
+    final resultLogger = logger.child(targetStyle(analyzeArgsString));
+
+    if (failures.isNotEmpty) {
+      final failuresLogger = resultLogger.child(
+        '$failedLabel (in ${failures.length} packages)',
+      );
+      for (final packageName in failures.keys) {
+        failuresLogger.child(
+          '${errorPackageNameStyle(packageName)} '
+          '${failures[packageName] == null ? '(dependency failed)' : '('
+                    'with exit code ${failures[packageName]})'}',
+        );
+      }
+      exitCode = 1;
+    } else {
+      resultLogger.child(successLabel);
+    }
+  }
+
+  List<String> _getAnalyzeArgs({
+    required MelosWorkspace workspace,
+    required bool fatalInfos,
+    Package? package,
+    bool? fatalWarnings,
+    // Note: The `concurrency` argument is intentionally set to a default value
+    // of 1 to prevent its direct use by the `startCommand` function. It is
+    // designed to be utilized only for logging purposes to indicate the level
+    // of concurrency being applied.
+    int concurrency = 1,
+  }) {
+    final options = _getOptionsArgs(fatalInfos, fatalWarnings, concurrency);
+    return <String>[
+      if (package?.isFlutterPackage ?? false)
+        workspace.sdkTool('flutter')
+      else
+        workspace.sdkTool('dart'),
+      'analyze',
+      options,
+    ];
+  }
+
+  String _getOptionsArgs(
+    bool fatalInfos,
+    bool? fatalWarnings,
+    int concurrency,
+  ) {
+    final options = <String>[];
+
+    if (fatalInfos) {
+      options.add('--fatal-infos');
+    }
+
+    if (fatalWarnings != null) {
+      options.add(fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings');
+    }
+
+    if (concurrency > 1) {
+      options.add('--concurrency $concurrency');
+    }
+
+    return options.join(' ');
+  }
+
+  Future<int> _analyzeForPackage(
+    MelosWorkspace workspace,
+    Package package,
+    List<String> analyzeArgs, {
+    String? group,
+  }) async {
+    final environment = {
+      EnvironmentVariableKey.melosRootPath: config.path,
+      if (workspace.sdkPath != null)
+        EnvironmentVariableKey.melosSdkPath: workspace.sdkPath!,
+      if (workspace.childProcessPath != null)
+        EnvironmentVariableKey.path: workspace.childProcessPath!,
+    };
+
+    return startCommand(
+      analyzeArgs,
+      logger: logger,
+      environment: environment,
+      workingDirectory: package.path,
+      group: group,
+    );
+  }
+}

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -51,6 +51,7 @@ import '../scripts.dart';
 import '../workspace.dart';
 import '../workspace_config.dart';
 
+part 'analyze.dart';
 part 'bootstrap.dart';
 part 'clean.dart';
 part 'exec.dart';
@@ -70,6 +71,7 @@ enum CommandWithLifecycle {
 
 class Melos extends _Melos
     with
+        _AnalyzeMixin,
         _CleanMixin,
         _BootstrapMixin,
         _ListMixin,

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -23,7 +23,9 @@ void main() {
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
       final runner = MelosCommandRunner(config);
 
       expect(
@@ -51,7 +53,9 @@ void main() {
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
       final runner = MelosCommandRunner(config);
 
       final command = runner.commands['format'];
@@ -59,6 +63,7 @@ void main() {
       // The command should be hidden (custom script behavior)
       expect(command!.hidden, isTrue);
     });
+
     test('custom analyze script overrides built-in analyze command', () async {
       final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
@@ -68,20 +73,44 @@ void main() {
             createGlob('packages/**', currentDirectoryPath: path),
           ],
           scripts: const Scripts({
-            'analyze': Script(name: 'analyze', run: 'echo "custom analyze"'),
+            'analyze': Script(
+              name: 'analyze',
+              run: 'echo "custom analyze ran"',
+            ),
           }),
         ),
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
-      final runner = MelosCommandRunner(config);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
 
+      // Structural check: the registered command for 'analyze' should be
+      // the hidden ScriptCommand, not the built-in AnalyzeCommand.
+      final runner = MelosCommandRunner(config);
       final command = runner.commands['analyze'];
       expect(command, isNotNull);
-      // The command should be hidden (custom script behavior), confirming
-      // the built-in AnalyzeCommand was NOT registered in its place.
       expect(command!.hidden, isTrue);
+
+      // Behavioral check: actually running the 'analyze' script should
+      // execute the user's custom command, not the built-in
+      // AnalyzeCommand's logic.
+      final logger = TestLogger();
+      final melos = Melos(logger: logger, config: config);
+
+      await melos.run(scriptName: 'analyze', noSelect: true);
+
+      expect(
+        logger.output.normalizeLines(),
+        contains('custom analyze ran'),
+      );
+      // The built-in AnalyzeCommand's own output format should never
+      // appear.
+      expect(
+        logger.output.normalizeLines(),
+        isNot(contains(r'$ melos analyze')),
+      );
     });
   });
 }

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -59,5 +59,29 @@ void main() {
       // The command should be hidden (custom script behavior)
       expect(command!.hidden, isTrue);
     });
+    test('custom analyze script overrides built-in analyze command', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'analyze': Script(name: 'analyze', run: 'echo "custom analyze"'),
+          }),
+        ),
+        workspacePackages: [],
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final runner = MelosCommandRunner(config);
+
+      final command = runner.commands['analyze'];
+      expect(command, isNotNull);
+      // The command should be hidden (custom script behavior), confirming
+      // the built-in AnalyzeCommand was NOT registered in its place.
+      expect(command!.hidden, isTrue);
+    });
   });
 }

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -1,0 +1,489 @@
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:melos/src/common/utils.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+import '../matchers.dart';
+import '../utils.dart';
+
+void main() {
+  group('Melos Analyze', () {
+    late Melos melos;
+    late TestLogger logger;
+    late Directory workspaceDir;
+    late Directory aDir;
+
+    setUp(() async {
+      workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a', 'b', 'c'],
+      );
+
+      aDir = await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {'c': HostedDependency(version: VersionConstraint.any)},
+        ),
+      );
+      writeTextFile(
+        p.join(aDir.path, 'analysis_options.yaml'),
+        '''
+linter:
+  rules:
+    - avoid_print
+    - eol_at_end_of_file
+    - prefer_final_locals
+    - prefer_single_quotes
+    - omit_local_variable_types
+''',
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec('b'),
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec('c'),
+      );
+
+      logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      melos = Melos(
+        logger: logger,
+        config: config,
+      );
+    });
+
+    test('should run analysis with --fatal-infos flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+          for (var i = 0; i < 10; i++) {
+            print('hello ${i + 1}');
+          }
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalInfos: true);
+
+      expect(
+        logger.output,
+        ignoringAnsii(
+          '''
+\$ melos analyze
+  └> dart analyze --fatal-infos
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+
+   info - main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+2 issues found.
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --fatal-infos
+     └> FAILED (in 1 packages)
+        └> a (with exit code 1)
+''',
+        ),
+      );
+    });
+
+    test('should run analysis with --fatal-warnings flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalWarnings: true);
+
+      expect(
+        logger.output,
+        ignoringAnsii('''
+\$ melos analyze
+  └> dart analyze --fatal-warnings
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --fatal-warnings
+     └> FAILED (in 1 packages)
+        └> a (with exit code 2)
+'''),
+      );
+    });
+
+    test('should run analysis with --no-fatal-warnings flag', () async {
+      writeTextFile(
+        p.join(aDir.path, 'main.dart'),
+        r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+      );
+
+      await melos.analyze(fatalWarnings: false);
+
+      expect(
+        logger.output,
+        ignoringAnsii('''
+\$ melos analyze
+  └> dart analyze --no-fatal-warnings
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+a: SUCCESS
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --no-fatal-warnings
+     └> SUCCESS
+'''),
+      );
+    });
+
+    test(
+      'should run analysis with --fatal-infos and --fatal-warnings',
+      () async {
+        writeTextFile(
+          p.join(aDir.path, 'main.dart'),
+          r'''
+        void main() {
+           var name = "Jessica";
+           int age = 28;
+           print("Hello, $name!");
+        }
+      ''',
+        );
+
+        await melos.analyze(fatalInfos: true, fatalWarnings: true);
+
+        expect(
+          logger.output,
+          ignoringAnsii('''
+\$ melos analyze
+  └> dart analyze --fatal-infos --fatal-warnings
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+
+warning - main.dart:3:16 - The value of the local variable 'age' isn't used. Try removing the variable or using it. - unused_local_variable
+   info - main.dart:2:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:2:23 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:3:12 - Local variables should be final. Try making the variable final. - prefer_final_locals
+   info - main.dart:3:12 - Unnecessary type annotation on a local variable. Try removing the type annotation. - omit_local_variable_types
+   info - main.dart:4:12 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:4:18 - Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes. - prefer_single_quotes
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+8 issues found.
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --fatal-infos --fatal-warnings
+     └> FAILED (in 1 packages)
+        └> a (with exit code 2)
+'''),
+        );
+      },
+    );
+
+    test('should run analysis with --concurrency flag', () async {
+      // when concurrency is set to a number bigger than 1 then
+      // the output should appears as the following
+      await melos.analyze(concurrency: 2);
+
+      final regex = RegExp(
+        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+      );
+
+      expect(regex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
+    });
+
+    test('should run analysis using flutter & dart', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a', 'b'],
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {
+            'flutter': SdkDependency('flutter'),
+          },
+        ),
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec(
+          'b',
+          dependencies: {
+            'a': HostedDependency(version: VersionConstraint.any),
+          },
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+      await melos.analyze(concurrency: 2);
+
+      expect(
+        logger.output.removeAnsiCodes().contains(
+          'flutter analyze --concurrency 2',
+        ),
+        isTrue,
+      );
+
+      final dartRegex = RegExp(
+        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+      );
+
+      expect(dartRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
+    });
+
+    test('should run analysis using flutter', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a'],
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {
+            'flutter': SdkDependency('flutter'),
+          },
+        ),
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+      await melos.analyze(concurrency: 2);
+
+      final flutterRegex = RegExp(
+        r'\$ melos analyze\s+└> flutter analyze --concurrency 2',
+      );
+
+      expect(flutterRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
+    });
+
+    test('should run analysis using dart', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a'],
+      );
+      await createProject(
+        workspaceDir,
+        Pubspec('a'),
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+      await melos.analyze(concurrency: 2);
+
+      expect(
+        logger.output.removeAnsiCodes().contains(
+          'flutter analyze --concurrency 2',
+        ),
+        isFalse,
+      );
+
+      final dartRegex = RegExp(
+        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+      );
+      expect(dartRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
+    });
+
+    test('should run analysis with --concurrency 2 flag', () async {
+      await melos.analyze(concurrency: 2);
+
+      expect(
+        logger.output,
+        ignoringAnsii('''
+\$ melos analyze
+  └> dart analyze --concurrency 2
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+No issues found!
+a: SUCCESS
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --concurrency 2
+     └> SUCCESS
+'''),
+      );
+    });
+
+    test(
+      'should run analysis with --concurrency 2 and --fatal-infos flag',
+      () async {
+        writeTextFile(
+          p.join(aDir.path, 'main.dart'),
+          r'''
+        void main() {
+          for (var i = 0; i < 10; i++) {
+            print('hello ${i + 1}');
+          }
+        }
+      ''',
+        );
+
+        await melos.analyze(concurrency: 2, fatalInfos: true);
+
+        expect(
+          logger.output,
+          ignoringAnsii('''
+\$ melos analyze
+  └> dart analyze --fatal-infos --concurrency 2
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+Analyzing a...
+
+   info - main.dart:3:13 - Don't invoke 'print' in production code. Try using a logging framework. - avoid_print
+   info - main.dart:5:10 - Missing a newline at the end of the file. Try adding a newline at the end of the file. - eol_at_end_of_file
+
+2 issues found.
+${'-' * terminalWidth}
+b:
+Analyzing b...
+No issues found!
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+Analyzing c...
+No issues found!
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos analyze
+  └> dart analyze --fatal-infos --concurrency 2
+     └> FAILED (in 1 packages)
+        └> a (with exit code 1)
+'''),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Restores the `melos analyze` command that was removed in #832 during the melos.yaml -> pubspec.yaml migration. `dart analyze`/`flutter analyze` run from a pub workspace root walks the entire directory tree, including non-workspace-member folders, rather than staying scoped to workspace packages. Running per-package with `workingDirectory` set to each package's path (as this command does) correctly stays scoped and avoids that problem.

Restored from the pre-#832 commit with minimal changes:
- `lib/src/commands/analyze.dart`: added missing `await` on `flushGroupBufferIfNeed()`
- `test/commands/analyze_test.dart`: replaced removed `normalizeNewLines()` with current `removeAnsiCodes()`/`ignoringAnsii()`, and pinned an `analysis_options.yaml` fixture so lint-based assertions don't depend on the SDK's shifting default lint set
- `docs/commands/analyze.mdx` and `command_runner/analyze.dart` restored unchanged

Wired `AnalyzeCommand` into `command_runner.dart`'s `builtInCommands` and `_AnalyzeMixin` into `Melos`'s mixin list. Existing script-precedence logic in `command_runner.dart` already skips built-in commands that conflict with a user-defined script name, so a user script named `analyze` continues to take precedence automatically.

Fixes #924

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore