### PR TITLE
feat(melos): add melos test command

### DIFF
--- a/packages/melos/lib/src/command_runner.dart
+++ b/packages/melos/lib/src/command_runner.dart
@@ -18,6 +18,7 @@ import 'command_runner/list.dart';
 import 'command_runner/publish.dart';
 import 'command_runner/run.dart';
 import 'command_runner/script.dart';
+import 'command_runner/test.dart';
 import 'command_runner/version.dart';
 import 'common/exception.dart';
 import 'common/pub_hosted.dart';
@@ -78,6 +79,7 @@ class MelosCommandRunner extends CommandRunner<void> {
       PublishCommand(config),
       VersionCommand(config),
       FormatCommand(config),
+      TestCommand(config),
     ];
 
     // Add built-in commands only if they don't conflict with custom scripts

--- a/packages/melos/lib/src/command_runner/test.dart
+++ b/packages/melos/lib/src/command_runner/test.dart
@@ -1,0 +1,31 @@
+import '../commands/runner.dart';
+import 'base.dart';
+
+class TestCommand extends MelosCommand {
+  TestCommand(super.config) {
+    setupPackageFilterParser();
+    argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
+  }
+
+  @override
+  final String name = 'test';
+
+  @override
+  final String description =
+      'Run `flutter test`/`dart test` for all packages in the workspace '
+      'that have a test/ directory, in a single run. '
+      'Supports all package filtering options.';
+
+  @override
+  Future<void> run() async {
+    final concurrency = int.parse(argResults!['concurrency'] as String);
+
+    final melos = Melos(logger: logger, config: config);
+
+    return melos.test(
+      global: global,
+      packageFilters: parsePackageFilters(config.path),
+      concurrency: concurrency,
+    );
+  }
+}

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -59,6 +59,7 @@ part 'init.dart';
 part 'list.dart';
 part 'publish.dart';
 part 'run.dart';
+part 'test.dart';
 part 'version.dart';
 
 enum CommandWithLifecycle {
@@ -78,7 +79,8 @@ class Melos extends _Melos
         _VersionMixin,
         _PublishMixin,
         _FormatMixin,
-        _InitMixin {
+        _InitMixin,
+        _TestMixin {
   Melos({
     required this.config,
     Logger? logger,

--- a/packages/melos/lib/src/commands/test.dart
+++ b/packages/melos/lib/src/commands/test.dart
@@ -1,0 +1,159 @@
+part of 'runner.dart';
+
+mixin _TestMixin on _Melos {
+  Future<void> test({
+    GlobalOptions? global,
+    PackageFilters? packageFilters,
+    int concurrency = 1,
+  }) async {
+    final workspace = await createWorkspace(
+      global: global,
+      packageFilters: packageFilters,
+    );
+    final packages = workspace.filteredPackages.values.where(
+      (pkg) => Directory(p.join(pkg.path, 'test')).existsSync(),
+    );
+
+    await _testForAllPackages(workspace, packages, concurrency: concurrency);
+  }
+
+  Future<void> _testForAllPackages(
+    MelosWorkspace workspace,
+    Iterable<Package> packages, {
+    required int concurrency,
+  }) async {
+    if (packages.isEmpty) {
+      logger.command('melos test', withDollarSign: true);
+      logger.child('No packages with a test/ directory found.');
+      return;
+    }
+
+    final failures = <String, int?>{};
+    final pool = Pool(concurrency);
+    final testArgsString = _getTestArgs(
+      workspace: workspace,
+      concurrency: concurrency,
+    ).join(' ');
+    final useGroupBuffer = concurrency != 1 && packages.length != 1;
+    final dartPackageCount = packages.where((e) => !e.isFlutterPackage).length;
+    final flutterPackageCount = packages
+        .where((e) => e.isFlutterPackage)
+        .length;
+
+    logger.command('melos test', withDollarSign: true);
+
+    if (dartPackageCount > 0) {
+      logger
+          .child(targetStyle(testArgsString))
+          .child('$runningLabel (in $dartPackageCount packages)')
+          .newLine();
+    }
+
+    if (flutterPackageCount > 0) {
+      logger
+          .child(targetStyle(testArgsString.replaceFirst('dart', 'flutter')))
+          .child('$runningLabel (in $flutterPackageCount packages)')
+          .newLine();
+    }
+
+    await pool.forEach<Package, void>(packages, (package) async {
+      final group = useGroupBuffer ? package.name : null;
+      logger
+        ..horizontalLine(group: group)
+        ..log(AnsiStyles.bgBlack.bold.italic('${package.name}:'), group: group);
+
+      final packageExitCode = await _testForPackage(
+        workspace,
+        package,
+        _getTestArgs(
+          package: package,
+          workspace: workspace,
+          concurrency: concurrency,
+        ),
+        group: group,
+      );
+
+      if (packageExitCode > 0) {
+        failures[package.name] = packageExitCode;
+      } else {
+        logger.log(
+          AnsiStyles.bgBlack.bold.italic('${package.name}: ') +
+              AnsiStyles.bgBlack(successLabel),
+          group: group,
+        );
+      }
+    }).drain<void>();
+
+    await logger.flushGroupBufferIfNeed();
+
+    logger
+      ..horizontalLine()
+      ..newLine()
+      ..command('melos test', withDollarSign: true);
+
+    final resultLogger = logger.child(targetStyle(testArgsString));
+
+    if (failures.isNotEmpty) {
+      final failuresLogger = resultLogger.child(
+        '$failedLabel (in ${failures.length} packages)',
+      );
+      for (final packageName in failures.keys) {
+        failuresLogger.child(
+          '${errorPackageNameStyle(packageName)} '
+          '${failures[packageName] == null ? '(dependency failed)' : '('
+                    'with exit code ${failures[packageName]})'}',
+        );
+      }
+      exitCode = 1;
+    } else {
+      resultLogger.child(successLabel);
+    }
+  }
+
+  List<String> _getTestArgs({
+    required MelosWorkspace workspace,
+    Package? package,
+    int concurrency = 1,
+  }) {
+    final options = _getOptionsArgs(concurrency);
+    return <String>[
+      if (package?.isFlutterPackage ?? false)
+        workspace.sdkTool('flutter')
+      else
+        workspace.sdkTool('dart'),
+      'test',
+      options,
+    ];
+  }
+
+  String _getOptionsArgs(int concurrency) {
+    final options = <String>[];
+    if (concurrency > 1) {
+      options.add('--concurrency=$concurrency');
+    }
+    return options.join(' ');
+  }
+
+  Future<int> _testForPackage(
+    MelosWorkspace workspace,
+    Package package,
+    List<String> testArgs, {
+    String? group,
+  }) async {
+    final environment = {
+      EnvironmentVariableKey.melosRootPath: config.path,
+      if (workspace.sdkPath != null)
+        EnvironmentVariableKey.melosSdkPath: workspace.sdkPath!,
+      if (workspace.childProcessPath != null)
+        EnvironmentVariableKey.path: workspace.childProcessPath!,
+    };
+
+    return startCommand(
+      testArgs,
+      logger: logger,
+      environment: environment,
+      workingDirectory: package.path,
+      group: group,
+    );
+  }
+}

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -59,5 +59,29 @@ void main() {
       // The command should be hidden (custom script behavior)
       expect(command!.hidden, isTrue);
     });
+    test('custom test script overrides built-in test command', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'test': Script(name: 'test', run: 'echo "custom test"'),
+          }),
+        ),
+        workspacePackages: [],
+      );
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final runner = MelosCommandRunner(config);
+
+      final command = runner.commands['test'];
+      expect(command, isNotNull);
+      // The command should be hidden (custom script behavior), confirming
+      // the built-in TestCommand was NOT registered in its place.
+      expect(command!.hidden, isTrue);
+    });
   });
 }

--- a/packages/melos/test/command_runner_test.dart
+++ b/packages/melos/test/command_runner_test.dart
@@ -23,7 +23,9 @@ void main() {
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
       final runner = MelosCommandRunner(config);
 
       expect(
@@ -51,7 +53,9 @@ void main() {
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
       final runner = MelosCommandRunner(config);
 
       final command = runner.commands['format'];
@@ -59,6 +63,7 @@ void main() {
       // The command should be hidden (custom script behavior)
       expect(command!.hidden, isTrue);
     });
+
     test('custom test script overrides built-in test command', () async {
       final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
@@ -68,20 +73,39 @@ void main() {
             createGlob('packages/**', currentDirectoryPath: path),
           ],
           scripts: const Scripts({
-            'test': Script(name: 'test', run: 'echo "custom test"'),
+            'test': Script(name: 'test', run: 'echo "custom test ran"'),
           }),
         ),
         workspacePackages: [],
       );
 
-      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
-      final runner = MelosCommandRunner(config);
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+        workspaceDir,
+      );
 
+      // Structural check: the registered command for 'test' should be the
+      // hidden ScriptCommand, not the built-in TestCommand.
+      final runner = MelosCommandRunner(config);
       final command = runner.commands['test'];
       expect(command, isNotNull);
-      // The command should be hidden (custom script behavior), confirming
-      // the built-in TestCommand was NOT registered in its place.
       expect(command!.hidden, isTrue);
+
+      // Behavioral check: actually running the 'test' script should execute
+      // the user's custom command, not the built-in TestCommand's logic.
+      final logger = TestLogger();
+      final melos = Melos(logger: logger, config: config);
+
+      await melos.run(scriptName: 'test', noSelect: true);
+
+      expect(
+        logger.output.normalizeLines(),
+        contains('custom test ran'),
+      );
+      // The built-in TestCommand's own output format should never appear.
+      expect(
+        logger.output.normalizeLines(),
+        isNot(contains('No packages with a test/ directory found.')),
+      );
     });
   });
 }

--- a/packages/melos/test/commands/test_test.dart
+++ b/packages/melos/test/commands/test_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+import '../matchers.dart';
+import '../utils.dart';
+
+void main() {
+  group('Melos Test', () {
+    test('skips packages without a test/ directory', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a', 'b'],
+      );
+
+      final aDir = await createProject(workspaceDir, Pubspec('a'));
+      writeTextFile(
+        p.join(aDir.path, 'test', 'a_test.dart'),
+        '''
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(1, 1);
+  });
+}
+''',
+        recursive: true,
+      );
+
+      await createProject(workspaceDir, Pubspec('b'));
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(logger: logger, config: config);
+
+      await melos.test();
+
+      expect(logger.output.normalizeLines(), contains('a:'));
+      expect(logger.output.normalizeLines(), isNot(contains('b:')));
+    });
+
+    test(
+      'reports no packages found when none have a test/ directory',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b'],
+        );
+        await createProject(workspaceDir, Pubspec('a'));
+        await createProject(workspaceDir, Pubspec('b'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.test();
+
+        expect(
+          logger.output.normalizeLines(),
+          ignoringAnsii(
+            contains('No packages with a test/ directory found.'),
+          ),
+        );
+      },
+    );
+
+    test('sets exitCode to 1 when a package test run fails', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a'],
+      );
+      final aDir = await createProject(workspaceDir, Pubspec('a'));
+      writeTextFile(
+        p.join(aDir.path, 'test', 'a_test.dart'),
+        '''
+import 'package:test/test.dart';
+
+void main() {
+  test('fails', () {
+    expect(1, 2);
+  });
+}
+''',
+        recursive: true,
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(logger: logger, config: config);
+
+      final previousExitCode = exitCode;
+      await melos.test();
+
+      expect(exitCode, 1);
+
+      exitCode = previousExitCode;
+    });
+    test(
+      'correctly detects a flutter package inside a pub workspace',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: TestLogger(), config: config);
+        final workspace = await melos.createWorkspace();
+
+        final package = workspace.filteredPackages.values.first;
+
+        expect(package.name, 'a');
+        // Regression check for https://github.com/invertase/melos/issues/830:
+        // package-type detection must still work under pub workspace
+        // resolution, since `melos test` relies on it to pick
+        // `flutter test` vs `dart test`.
+        expect(package.isFlutterPackage, isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Adds a built-in `melos test` command that runs `dart test` (or `flutter test` for Flutter packages) across every workspace package that has a `test/` directory, in a single invocation. Mirrors `melos analyze`'s package-type detection to choose the right tool per package, and reuses the existing `--concurrency` and package-filtering conventions from `melos exec`/`melos format`.

Closes #830.

### Design notes

- Not replicating `very_good_cli`'s single-isolate batching for v1 — straightforward per-package invocation, as discussed on the issue. Happy to revisit if that's wanted.
- `dart test`/`flutter test` scope to the package's own `test/` directory, so this command doesn't depend on the workspace walk-up scoping work being done separately for `melos analyze`.

### Verification

The tracking issue raised a concern about whether package-type detection (`isFlutterPackage`) works correctly under pub workspace resolution. Checked this directly rather than assuming: `isFlutterPackage` is based purely on each package's own declared `dependencies:` in its `pubspec.yaml` (`pubspec.dependencies.keys`), which is unaffected by how pub workspaces resolve versions. Added a regression test (`correctly detects a flutter package inside a pub workspace`) confirming this holds under actual `resolution: workspace` mode.

Also ran:
- `dart analyze` — clean
- `dart format --set-exit-if-changed` — clean
- `dart test test/commands/test_test.dart` — 4/4 passing (skips packages without `test/`, reports when none match, propagates a real failing test's exit code, and the workspace/flutter-detection regression check)

### Known open question

The repo's own `pubspec.yaml` has a custom `melos.scripts.test` entry that runs the dev suite. Melos's built-in-command registration skips a built-in command if a custom script of the same name exists — so as it stands, running `melos test` in *this* repo will still invoke the legacy script, not this new command. Left `pubspec.yaml` untouched rather than deciding this unilaterally — happy to remove/rename the old script in a follow-up commit here if that's the preferred resolution, just wanted a maintainer call on it first.

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore