### PR TITLE
fix(version): handle quoted range constraints in dependent rewrites

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -615,41 +615,56 @@ mixin _VersionMixin on _RunMixin {
     final isGitDependency = dependency is GitDependency;
     final isGitTagDependency = dependency is GitTagPatternDependency;
 
-    var updatedContents = pubspecContent;
-    if (isExternalHostedDependency) {
-      updatedContents = pubspecContent.replaceAllMapped(
-        hostedDependencyVersionReplaceRegex(dependencyName),
-        (match) => '${match.group(1)}$dependencyVersion',
+    // The section (`dependencies` or `dev_dependencies`) that
+    // `package.pubspec` actually resolved [dependency] from. Git tag pattern
+    // dependencies track their own section separately, since they can also
+    // live under `dependency_overrides` (see [GitTagPatternDependency]).
+    final section = normalDependency != null
+        ? 'dependencies'
+        : 'dev_dependencies';
+
+    String? updatedContents;
+    if (isGitTagDependency) {
+      updatedContents = _rewriteDependencyVersionAtPath(
+        pubspecContent: pubspecContent,
+        path: [dependency.section, dependencyName, 'version'],
+        dependencyVersion: dependencyVersion,
+        // Git tag pattern dependencies preserve whether the *existing*
+        // constraint used caret syntax, rather than always following
+        // [dependencyVersion]'s own style.
+        preserveCaretStyle: true,
       );
-    } else if (isGitTagDependency) {
-      updatedContents = pubspecContent.replaceAllMapped(
-        gitTagPatternDependencyVersionReplaceRegex(dependencyName),
-        (match) {
-          final hasCaret = match.group(2) == '^';
-          final prefix = match.group(1)!;
-          final replacement =
-              '$prefix${hasCaret ? '^' : ''}'
-              '${dependencyVersion.toString().replaceFirst('^', '')}';
-          return replacement;
-        },
+    } else if (isExternalHostedDependency) {
+      updatedContents = _rewriteDependencyVersionAtPath(
+        pubspecContent: pubspecContent,
+        path: [section, dependencyName, 'version'],
+        dependencyVersion: dependencyVersion,
+        preserveCaretStyle: false,
       );
     } else if (isGitDependency &&
         workspace.config.commands.version.updateGitTagRefs) {
-      updatedContents = pubspecContent.replaceAllMapped(
+      // The version here is fused into a single git tag string (e.g.
+      // `foo-v1.2.3`) rather than being its own scalar node, so this isn't a
+      // good fit for a `YamlEditor`-based rewrite; it's also not affected by
+      // the quoted-range-constraint bug the other branches fix, since tag
+      // names never contain quotes or spaces.
+      final rewritten = pubspecContent.replaceAllMapped(
         dependencyTagReplaceRegex(dependencyName),
         (match) =>
             '${match.group(1)}$dependencyName-'
             'v${dependencyVersion.min ?? dependencyVersion.max!}',
       );
+      updatedContents = rewritten == pubspecContent ? null : rewritten;
     } else {
-      updatedContents = pubspecContent.replaceAllMapped(
-        dependencyVersionReplaceRegex(dependencyName),
-        (match) => '${match.group(1)}$dependencyVersion',
+      updatedContents = _rewriteDependencyVersionAtPath(
+        pubspecContent: pubspecContent,
+        path: [section, dependencyName],
+        dependencyVersion: dependencyVersion,
+        preserveCaretStyle: false,
       );
     }
 
-    // Sanity check that contents actually changed.
-    if (pubspecContent == updatedContents) {
+    if (updatedContents == null) {
       logger.warning(
         'Failed to update dependency $dependencyName version to '
         '$dependencyVersion for package ${package.name}, '
@@ -660,6 +675,40 @@ mixin _VersionMixin on _RunMixin {
     }
 
     await writeTextFileAsync(pubspecPath, updatedContents);
+  }
+
+  /// Returns [pubspecContent] rewritten so that the version constraint
+  /// scalar at [path] is set to [dependencyVersion], preserving everything
+  /// else in the file (formatting, comments, quoting style of unrelated
+  /// values) via [YamlEditor].
+  ///
+  /// Returns `null` if [path] doesn't already point to an existing string
+  /// scalar (e.g. an optional `version:` key that was never present) —
+  /// mirroring the previous regex-based rewrite's behavior of leaving such
+  /// pubspecs untouched rather than inserting a new key.
+  String? _rewriteDependencyVersionAtPath({
+    required String pubspecContent,
+    required List<Object> path,
+    required VersionRange dependencyVersion,
+    required bool preserveCaretStyle,
+  }) {
+    final editor = YamlEditor(pubspecContent);
+    final currentNode = editor.parseAt(
+      path,
+      orElse: () => wrapAsYamlNode(null),
+    );
+    if (currentNode.value is! String) {
+      return null;
+    }
+
+    var newValue = dependencyVersion.toString();
+    if (preserveCaretStyle) {
+      final hasCaret = (currentNode.value! as String).startsWith('^');
+      newValue = '${hasCaret ? '^' : ''}${newValue.replaceFirst('^', '')}';
+    }
+
+    editor.update(path, newValue);
+    return editor.toString();
   }
 
   void _logNewVersionTable(

--- a/packages/melos/lib/src/common/git_tag_pattern_dependency.dart
+++ b/packages/melos/lib/src/common/git_tag_pattern_dependency.dart
@@ -15,12 +15,17 @@ class GitTagPatternDependency extends GitDependency {
     required this.name,
     required this.tagPattern,
     required this.version,
+    required this.section,
     required Uri url,
     String? path,
   }) : super(url, path: path);
   final String name;
   final String tagPattern;
   final Version version;
+
+  /// The top-level pubspec key (`dependencies`, `dev_dependencies`, or
+  /// `dependency_overrides`) this dependency was found under.
+  final String section;
 
   /// Searches for a git dependency with a tag_pattern in the pubspec string.
   ///
@@ -87,6 +92,7 @@ class GitTagPatternDependency extends GitDependency {
         path: path,
         tagPattern: tagPattern,
         version: version.min!,
+        section: section,
       );
     }
 

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -72,33 +72,14 @@ enum PackageType {
 
 const _versionRegExp = r'''\d+\.\d+\.\d+[\w\-.+_]*''';
 
-const _versionConstraintRegExp =
-    r"""(?<version>any|["'^<>=]*\d+\.\d+\.\d+['"<>=\w\-.+_]*)""";
-
-RegExp dependencyVersionReplaceRegex(String dependencyName) {
-  return RegExp(
-    '''(?<dependency>^\\s+$dependencyName\\s?:\\s?)(?!\$)$_versionConstraintRegExp''',
-    multiLine: true,
-  );
-}
-
-RegExp hostedDependencyVersionReplaceRegex(String dependencyName) {
-  return RegExp(
-    '''(^[ \t]*?(?<dependency>$dependencyName)[ \\t]*?:[ \\t]*?[\\s\\S]*?[ \\t]*?version:[ \\t]*?)$_versionConstraintRegExp''',
-    multiLine: true,
-  );
-}
-
+// Used only for the git `ref:` tag rewrite (see [dependencyTagReplaceRegex]),
+// where the version is fused into a single tag string (e.g. `foo-v1.2.3`)
+// rather than being its own scalar node, so it isn't a candidate for a
+// `YamlEditor`-based rewrite the way the other dependency shapes are (see
+// `_setDependencyVersionForPackage` in `commands/version.dart`).
 RegExp dependencyTagReplaceRegex(String dependencyName) {
   return RegExp(
     '''(?<tag_ref>^\\s+ref\\s?:\\s?)(?<opening_quote>["']?)(?<tag>$dependencyName-v$_versionRegExp)(?<closing_quote>['"]?)''',
-    multiLine: true,
-  );
-}
-
-RegExp gitTagPatternDependencyVersionReplaceRegex(String dependencyName) {
-  return RegExp(
-    '''(^[ \\t]*?$dependencyName[ \\t]*?:[\\s\\S]*?[ \\t]*?version:[ \\t]*?)(\\^?)$_versionConstraintRegExp''',
     multiLine: true,
   );
 }

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -694,6 +694,377 @@ The following 1 packages will be updated:
         },
       );
     });
+
+    // Regression coverage for
+    // https://github.com/invertase/melos/issues/1039: a dependent's
+    // constraint on a versioned package used to be corrupted (not just left
+    // un-rewritten) when it was declared as a quoted, space-separated range
+    // (e.g. `">=0.4.0 <1.0.0"`), because the regex used to locate the old
+    // constraint stopped matching at the first space, and the caret rewrite
+    // was spliced over only that partial match. `crypto_keys_plus` in
+    // https://github.com/Bdaya-Dev/oidc is the real-world package that hit
+    // this.
+    group('dependent constraint rewrite (regression for #1039)', () {
+      Future<void> expectDependentPubspecRewrite({
+        required String dependentPubspecYaml,
+        required String expectedDependentPubspecYaml,
+        // Extra real workspace packages to create alongside `a` and `b`,
+        // e.g. to give a sibling dependency in `b`'s pubspec something
+        // resolvable to point at.
+        Map<String, Version> extraWorkspacePackages = const {},
+      }) async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _workspaceConfigBuilder,
+          workspacePackages: ['a', 'b', ...extraWorkspacePackages.keys],
+          useLocalTmpDirectory: true,
+        );
+
+        // `a`'s starting version must be admitted by every constraint used
+        // below to declare a dependency on it, or `pub get` will (correctly)
+        // fail to resolve the workspace before `melos version` ever runs.
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(0, 4, 0)),
+        );
+
+        for (final entry in extraWorkspacePackages.entries) {
+          await createProject(
+            workspaceDir,
+            Pubspec(entry.key, version: entry.value),
+          );
+        }
+
+        await createProject(
+          workspaceDir,
+          Pubspec.parse(dependentPubspecYaml),
+          rawPubspecContent: dependentPubspecYaml,
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+
+        await melos.bootstrap(offline: true);
+        await melos.version(
+          // Avoids the "provide an additional changelog entry message?"
+          // prompt this test has no commits to answer for; irrelevant to the
+          // dependent pubspec rewrite under test.
+          updateChangelog: false,
+          // Isolates the dependent *constraint* rewrite under test from the
+          // unrelated (and separately covered) cascading dependent *version*
+          // bump, which would otherwise also touch `b`'s own `version:`.
+          updateDependentsVersions: false,
+          versionPrivatePackages: true,
+          gitCommit: false,
+          gitTag: false,
+          force: true,
+          manualVersions: {
+            'a': ManualVersionChange(Version(0, 6, 0)),
+          },
+        );
+
+        final actual = File(
+          p.join(workspaceDir.path, 'packages/b/pubspec.yaml'),
+        ).readAsStringSync();
+
+        // The rewritten pubspec must always remain valid, parseable YAML -
+        // this is the assertion that would have caught #1039 even without
+        // pinning the exact expected output below.
+        expect(() => Pubspec.parse(actual), returnsNormally);
+
+        expect(actual, expectedDependentPubspecYaml);
+      }
+
+      test(
+        'quoted, space-separated range constraint (exact bug from #1039)',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ">=0.4.0 <1.0.0"
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0
+''',
+          );
+        },
+      );
+
+      test('single-quoted, space-separated range constraint', () async {
+        const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: '>=0.4.0 <1.0.0'
+''';
+        await expectDependentPubspecRewrite(
+          dependentPubspecYaml: dependentPubspecYaml,
+          expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0
+''',
+        );
+      });
+
+      test('unquoted caret constraint (regression guard)', () async {
+        const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.4.0
+''';
+        await expectDependentPubspecRewrite(
+          dependentPubspecYaml: dependentPubspecYaml,
+          expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0
+''',
+        );
+      });
+
+      test('"any" constraint (regression guard)', () async {
+        const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: any
+''';
+        await expectDependentPubspecRewrite(
+          dependentPubspecYaml: dependentPubspecYaml,
+          expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0
+''',
+        );
+      });
+
+      test(
+        'exact pinned version constraint is replaced with an exact pin '
+        '(regression guard)',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: 0.4.0
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: 0.6.0
+''',
+          );
+        },
+      );
+
+      test(
+        'prerelease and build metadata suffix constraint (regression guard)',
+        () async {
+          // An explicit range (rather than `^0.4.0-dev.1+001`) is used here
+          // so the constraint still admits `a`'s actual starting version,
+          // `0.4.0` - a caret range anchored on a pre-release only admits
+          // versions up to (but excluding) the associated stable release.
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ">=0.4.0-dev.1+001 <1.0.0"
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0
+''',
+          );
+        },
+      );
+
+      test(
+        'trailing comment on the constraint line is preserved '
+        '(regression guard)',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ">=0.4.0 <1.0.0" # keep this note
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a: ^0.6.0 # keep this note
+''',
+          );
+        },
+      );
+
+      test(
+        'sibling dependencies are left untouched (regression guard)',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  c: ^2.0.0
+  a: ">=0.4.0 <1.0.0"
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  c: ^2.0.0
+  a: ^0.6.0
+''',
+            extraWorkspacePackages: {'c': Version(2, 0, 0)},
+          );
+        },
+      );
+
+      test(
+        'quoted, space-separated range constraint on an externally hosted '
+        'dependency',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a:
+    hosted: https://my-registry.example.com
+    version: ">=0.4.0 <1.0.0"
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a:
+    hosted: https://my-registry.example.com
+    version: ^0.6.0
+''',
+          );
+        },
+      );
+
+      test(
+        'quoted, space-separated range constraint on a git tag pattern '
+        'dependency',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a:
+    git:
+      url: github.com/a/a.git
+      path: packages/a
+      tag_pattern: a-v{{version}}
+    version: ">=0.4.0 <1.0.0"
+''';
+          // Git tag pattern dependencies preserve whether the *existing*
+          // constraint used caret syntax; `">=0.4.0 <1.0.0"` above has no
+          // leading `^`, so the rewritten value doesn't gain one either.
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dependencies:
+  a:
+    git:
+      url: github.com/a/a.git
+      path: packages/a
+      tag_pattern: a-v{{version}}
+    version: 0.6.0
+''',
+          );
+        },
+      );
+    });
   });
 }
 

--- a/packages/melos/test/package_test.dart
+++ b/packages/melos/test/package_test.dart
@@ -27,6 +27,14 @@ const pubPackageJson = '''
 ''';
 
 void main() {
+  // The `dependencies`/`dev_dependencies`/hosted `version:` rewrite paths
+  // used by `melos version` are now implemented with `YamlEditor` (see
+  // `_rewriteDependencyVersionAtPath` in `commands/version.dart`) instead of
+  // hand-rolled regexes, so they're covered end-to-end via `melos version`
+  // in `test/commands/version_test.dart` rather than as standalone regex
+  // unit tests here. Only the git `ref:` tag rewrite still uses a regex,
+  // since its version is fused into a single tag string rather than being
+  // its own scalar node.
   group('replace version RegExp', () {
     const testedVersions = [
       '0.1.2+3',
@@ -39,19 +47,6 @@ void main() {
       '0.10.0',
       '0.0.10',
     ];
-    final testedVersionRanges = testedVersions
-        .map((version) => '^$version')
-        .toList();
-
-    group('dependencyVersion', () {
-      testedVersions.forEach(testDependencyVersionReplaceRegex);
-      testedVersionRanges.forEach(testDependencyVersionReplaceRegex);
-    });
-
-    group('hostedDependencyVersion', () {
-      testedVersions.forEach(testHostedDependencyVersionReplaceRegex);
-      testedVersionRanges.forEach(testHostedDependencyVersionReplaceRegex);
-    });
 
     group('dependencyTag', () {
       testedVersions.forEach(testDependencyTagReplaceRegex);
@@ -867,56 +862,6 @@ environment:
         expect(packages['child2'], isNull);
       },
     );
-  });
-}
-
-void testDependencyVersionReplaceRegex(String version) {
-  test(version, () {
-    const dependencyName = 'foo';
-    const newVersion = '9.9.9';
-
-    final regExp = dependencyVersionReplaceRegex(dependencyName);
-
-    final input =
-        '''
-dependencies:
-  $dependencyName: $version
-''';
-    final output = input.replaceAllMapped(
-      regExp,
-      (match) => '${match.group(1)}$newVersion',
-    );
-
-    expect(output, '''
-dependencies:
-  $dependencyName: $newVersion
-''');
-  });
-}
-
-void testHostedDependencyVersionReplaceRegex(String version) {
-  test(version, () {
-    const dependencyName = 'foo';
-    const newVersion = '9.9.9';
-
-    final regExp = hostedDependencyVersionReplaceRegex(dependencyName);
-
-    final input =
-        '''
-dependencies:
-  $dependencyName:
-    version: $version
-''';
-    final output = input.replaceAllMapped(
-      regExp,
-      (match) => '${match.group(1)}$newVersion',
-    );
-
-    expect(output, '''
-dependencies:
-  $dependencyName:
-    version: $newVersion
-''');
   });
 }
 


### PR DESCRIPTION
Fixes #1039

## Summary

`melos version`'s dependent-constraint rewrite used a regex (`_versionConstraintRegExp` in `packages/melos/lib/src/package.dart`) whose trailing character class had no whitespace. Against a quoted, space-separated range constraint like `">=0.4.0 <1.0.0"`, the regex only matched up to the first space (`">=0.4.0`), and the caret rewrite in `commands/version.dart` was then spliced over that partial match — leaving the rest of the old constraint (` <1.0.0"`) behind as literal garbage:

```yaml
# before
crypto_keys_plus: ">=0.4.0 <1.0.0"
# after (broken)
crypto_keys_plus: ^0.6.0 <1.0.0"
```

This produces an unparseable `pubspec.yaml`:

```
Invalid version constraint: Cannot include other constraints with "^" constraint in "^0.6.0 <1.0.0"".
```

Rather than patching the regex, this PR migrates the plain-dependency, hosted-dependency (`hosted: {..., version: ...}`), and git-tag-pattern-dependency (`git: {..., tag_pattern: ...}` + sibling `version:`) rewrite paths in `_setDependencyVersionForPackage` to `YamlEditor` — the same tool melos already uses a few lines above for the package's own `version:` bump (`_setPubspecVersionForPackage`), and in `bootstrap.dart`/`init.dart`. Targeting the constraint by its actual YAML path instead of splicing text eliminates the whole bug class (quoting, embedded spaces, trailing comments) rather than just the one reported shape, and four now-dead regexes (`_versionConstraintRegExp`, `dependencyVersionReplaceRegex`, `hostedDependencyVersionReplaceRegex`, `gitTagPatternDependencyVersionReplaceRegex`) are removed.

The git `ref:` tag rewrite (`dependencyTagReplaceRegex`) is left as-is: its version is fused into a single tag string (`name-vX.Y.Z`) rather than being its own scalar node, so it isn't a good fit for a path-based `YamlEditor` update, and it was never affected by this bug (tag names can't contain quotes or spaces).

**Note on scope (`dependency_overrides`)**: the old regex-based rewrite scanned the whole pubspec text with `replaceAllMapped`, so if a dependency of the same name also appeared under `dependency_overrides` with a plain, version-like scalar value, it would be rewritten there too, regardless of intent. The new plain- and hosted-dependency rewrites are scoped precisely to the `dependencies`/`dev_dependencies` section `package.pubspec` actually resolved the dependency from, and no longer reach into `dependency_overrides`. This is a deliberate, and arguably more correct, behavior change — a local override generally shouldn't be silently bumped by `melos version` — and no existing test relies on the old cross-section sweep. The git-tag-pattern path is unaffected: it already tracks its own section (which can be `dependency_overrides`) via `GitTagPatternDependency.section`.

## Test evidence

**Unit/integration tests** — new regression coverage in `test/commands/version_test.dart` under `dependent constraint rewrite (regression for #1039)` exercises the real `melos version` command end-to-end (not just the rewrite function in isolation) for: the exact bug case (double- and single-quoted space-separated ranges), unquoted caret, `any`, an exact pin, a prerelease+build-metadata suffix, a trailing comment, an untouched sibling dependency, and the hosted- and git-tag-pattern-dependency variants of the same quoted-range bug. All pass with the fix; `dart test test/commands/version_test.dart test/package_test.dart` and `dart analyze`/`dart format --set-exit-if-changed` are clean.

**Bug reproduced against unpatched code** — running the new bug-case test (`quoted, space-separated range constraint (exact bug from #1039)`) against the original, unmodified `package.dart`/`version.dart` fails with exactly the corruption from the issue:

```
Expected: return normally
  Actual: <Closure: () => Pubspec>
   Which: threw ParsedYamlException:<ParsedYamlException: line 7, column 6: Unsupported value for "a". Cannot include other constraints with "^" constraint in "^0.6.0 <1.0.0"".
            ,
          7 |   a: ^0.6.0 <1.0.0"
            |      ^^^^^^^^^^^^^^
            '>
```

**End-to-end against the real repro** — cloned [Bdaya-Dev/oidc](https://github.com/Bdaya-Dev/oidc) at `d60f050` (the commit from the issue, before the constraints were manually normalized upstream), added a `dependency_overrides: melos: {path: ...}` pointing at this branch's local checkout, made a `fix(crypto_keys_plus):` commit, and ran the exact failing sequence:

```
dart run melos version --yes --no-git-tag-version --no-git-commit-version --scope="crypto_keys_plus,jose_plus"
```

Before: `packages/jose_plus/pubspec.yaml` had `crypto_keys_plus: ">=0.4.0 <1.0.0"`. After: `crypto_keys_plus: ^0.5.1` — clean, with `x509_plus`'s own (untouched, unrelated) quoted range constraint left exactly as-is. `flutter pub get` on the resulting workspace succeeds (`Got dependencies!`), confirming the rewritten pubspec is valid, in contrast to the `ParsedYamlException` unpatched melos produces on the same input.

**Full suite parity** — ran `dart test` for `packages/melos` (~400 tests) twice on the same machine: once on this branch, once on an untouched clone of `main`. Diffing the two failure sets directly (not relying on `dart test`'s own truncated summary) shows 24 failures common to both runs, all sharing the same signatures unrelated to this change (a broken terminal handle under the sandbox this was run in, crashing interactive prompts regardless of code; and antivirus/file-lock contention on temp-dir cleanup, which cascades into unrelated tests). The small number of additional failures unique to each run individually share those same signatures, land on tests outside `package_test.dart`/the constraint-rewrite paths, and vary between runs - consistent with non-deterministic environment noise, not a regression. Every failure touching dependency-constraint rewriting passes on this branch in every run.

## Type of Change

- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)

