### PR TITLE
test(version): cover dev_dependencies constraint rewrite; drop redundant comments

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -615,10 +615,6 @@ mixin _VersionMixin on _RunMixin {
     final isGitDependency = dependency is GitDependency;
     final isGitTagDependency = dependency is GitTagPatternDependency;
 
-    // The section (`dependencies` or `dev_dependencies`) that
-    // `package.pubspec` actually resolved [dependency] from. Git tag pattern
-    // dependencies track their own section separately, since they can also
-    // live under `dependency_overrides` (see [GitTagPatternDependency]).
     final section = normalDependency != null
         ? 'dependencies'
         : 'dev_dependencies';
@@ -629,9 +625,6 @@ mixin _VersionMixin on _RunMixin {
         pubspecContent: pubspecContent,
         path: [dependency.section, dependencyName, 'version'],
         dependencyVersion: dependencyVersion,
-        // Git tag pattern dependencies preserve whether the *existing*
-        // constraint used caret syntax, rather than always following
-        // [dependencyVersion]'s own style.
         preserveCaretStyle: true,
       );
     } else if (isExternalHostedDependency) {
@@ -643,11 +636,6 @@ mixin _VersionMixin on _RunMixin {
       );
     } else if (isGitDependency &&
         workspace.config.commands.version.updateGitTagRefs) {
-      // The version here is fused into a single git tag string (e.g.
-      // `foo-v1.2.3`) rather than being its own scalar node, so this isn't a
-      // good fit for a `YamlEditor`-based rewrite; it's also not affected by
-      // the quoted-range-constraint bug the other branches fix, since tag
-      // names never contain quotes or spaces.
       final rewritten = pubspecContent.replaceAllMapped(
         dependencyTagReplaceRegex(dependencyName),
         (match) =>

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1064,6 +1064,33 @@ dependencies:
           );
         },
       );
+
+      test(
+        'quoted, space-separated range constraint under dev_dependencies',
+        () async {
+          const dependentPubspecYaml = '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dev_dependencies:
+  a: ">=0.4.0 <1.0.0"
+''';
+          await expectDependentPubspecRewrite(
+            dependentPubspecYaml: dependentPubspecYaml,
+            expectedDependentPubspecYaml: '''
+name: b
+resolution: workspace
+version: 1.0.0
+environment:
+  sdk: ^3.10.0
+dev_dependencies:
+  a: ^0.6.0
+''',
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Follow-up to #1041 (now merged).

## Summary

- **Adds a regression test** for the dependent-constraint rewrite under `dev_dependencies`. #1041 covered the quoted-range rewrite thoroughly for `dependencies`, hosted, and git-tag-pattern shapes, but the `section == 'dev_dependencies'` branch of `_setDependencyVersionForPackage` had no coverage. The new test drives the real `melos version` command and asserts `a: ">=0.4.0 <1.0.0"` under `dev_dependencies` is rewritten to `a: ^0.6.0`.
- **Removes the explanatory comments** added inside `_setDependencyVersionForPackage`'s rewrite branches (the `section`, `preserveCaretStyle`, and git `ref:` blocks), which restated what the code already expresses.

## Test evidence

`dart test test/commands/version_test.dart --name "regression for #1039"` — all 11 tests pass (10 from #1041 plus the new `dev_dependencies` case). `dart analyze` and `dart format --set-exit-if-changed` are clean on the changed files.

## Type of Change

- [x] 🧪 Test coverage