### PR TITLE
feat(analyze): default to --fatal-infos for dart and flutter

### DIFF
--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -20,10 +20,19 @@ melos analyze
 
 ## --fatal-infos
 Enforces a strict analysis by treating info-level issues as critical errors.
-By default this option is disabled.
+By default this option is enabled for both `dart analyze` and `flutter analyze`,
+even though `dart analyze` does not treat info-level issues as fatal on its own.
 
 ```bash
 melos analyze --fatal-infos
+```
+
+## --no-fatal-infos
+Disables treating info-level issues as fatal errors, allowing the analysis
+process to complete successfully even if info-level issues are present.
+
+```bash
+melos analyze --no-fatal-infos
 ```
 
 ## --fatal-warnings

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -8,10 +8,11 @@ class AnalyzeCommand extends MelosCommand {
     argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
     argParser.addFlag(
       'fatal-infos',
-      negatable: false,
+      defaultsTo: true,
       help:
-          'Enables treating info-lever issues as fatal errors, '
-          'stopping the process if any are encountered.',
+          'Enables or disables treating info-level issues as fatal errors. '
+          'Enabled by default for both dart and flutter analyze. '
+          'Use --no-fatal-infos to disable.',
     );
 
     argParser.addFlag(

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -4,7 +4,7 @@ mixin _AnalyzeMixin on _Melos {
   Future<void> analyze({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    bool fatalInfos = false,
+    bool fatalInfos = true,
     bool? fatalWarnings,
     int concurrency = 1,
   }) async {
@@ -32,7 +32,7 @@ mixin _AnalyzeMixin on _Melos {
   }) async {
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
-    final analyzeArgsString = _getAnalyzeArgs(
+    final dartAnalyzeArgsString = _getAnalyzeArgs(
       workspace: workspace,
       fatalInfos: fatalInfos,
       fatalWarnings: fatalWarnings,
@@ -48,14 +48,21 @@ mixin _AnalyzeMixin on _Melos {
 
     if (dartPackageCount > 0) {
       logger
-          .child(targetStyle(analyzeArgsString))
+          .child(targetStyle(dartAnalyzeArgsString))
           .child('$runningLabel (in $dartPackageCount packages)')
           .newLine();
     }
 
     if (flutterPackageCount > 0) {
+      final flutterAnalyzeArgsString = _getAnalyzeArgs(
+        workspace: workspace,
+        fatalInfos: fatalInfos,
+        fatalWarnings: fatalWarnings,
+        concurrency: concurrency,
+        isFlutter: true,
+      ).join(' ');
       logger
-          .child(targetStyle(analyzeArgsString.replaceFirst('dart', 'flutter')))
+          .child(targetStyle(flutterAnalyzeArgsString))
           .child('$runningLabel (in $flutterPackageCount packages)')
           .newLine();
     }
@@ -96,7 +103,7 @@ mixin _AnalyzeMixin on _Melos {
       ..newLine()
       ..command('melos analyze', withDollarSign: true);
 
-    final resultLogger = logger.child(targetStyle(analyzeArgsString));
+    final resultLogger = logger.child(targetStyle(dartAnalyzeArgsString));
 
     if (failures.isNotEmpty) {
       final failuresLogger = resultLogger.child(
@@ -120,19 +127,18 @@ mixin _AnalyzeMixin on _Melos {
     required bool fatalInfos,
     Package? package,
     bool? fatalWarnings,
-    // Note: The `concurrency` argument is intentionally set to a default value
-    // of 1 to prevent its direct use by the `startCommand` function. It is
-    // designed to be utilized only for logging purposes to indicate the level
-    // of concurrency being applied.
+    bool isFlutter = false,
     int concurrency = 1,
   }) {
+    final useFlutter = package?.isFlutterPackage ?? isFlutter;
     final options = _getAnalyzeOptionsArgs(
-      fatalInfos,
-      fatalWarnings,
-      concurrency,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+      concurrency: concurrency,
+      isFlutter: useFlutter,
     );
     return <String>[
-      if (package?.isFlutterPackage ?? false)
+      if (useFlutter)
         workspace.sdkTool('flutter')
       else
         workspace.sdkTool('dart'),
@@ -141,15 +147,18 @@ mixin _AnalyzeMixin on _Melos {
     ];
   }
 
-  String _getAnalyzeOptionsArgs(
-    bool fatalInfos,
-    bool? fatalWarnings,
-    int concurrency,
-  ) {
+  String _getAnalyzeOptionsArgs({
+    required bool fatalInfos,
+    required bool? fatalWarnings,
+    required int concurrency,
+    required bool isFlutter,
+  }) {
     final options = <String>[];
 
     if (fatalInfos) {
       options.add('--fatal-infos');
+    } else if (isFlutter) {
+      options.add('--no-fatal-infos');
     }
 
     if (fatalWarnings != null) {

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -131,7 +131,7 @@ ${'-' * terminalWidth}
         logger.output,
         ignoringAnsii('''
 \$ melos analyze
-  └> dart analyze --fatal-warnings
+  └> dart analyze --fatal-infos --fatal-warnings
      └> RUNNING (in 3 packages)
 
 ${'-' * terminalWidth}
@@ -161,7 +161,7 @@ c: SUCCESS
 ${'-' * terminalWidth}
 
 \$ melos analyze
-  └> dart analyze --fatal-warnings
+  └> dart analyze --fatal-infos --fatal-warnings
      └> FAILED (in 1 packages)
         └> a (with exit code 2)
 '''),
@@ -180,7 +180,7 @@ ${'-' * terminalWidth}
       ''',
       );
 
-      await melos.analyze(fatalWarnings: false);
+      await melos.analyze(fatalInfos: false, fatalWarnings: false);
 
       expect(
         logger.output,
@@ -287,7 +287,7 @@ ${'-' * terminalWidth}
       await melos.analyze(concurrency: 2);
 
       final regex = RegExp(
-        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+        r'\$ melos analyze\s+└> dart analyze --fatal-infos --concurrency 2',
       );
 
       expect(regex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
@@ -328,13 +328,13 @@ ${'-' * terminalWidth}
 
       expect(
         logger.output.removeAnsiCodes().contains(
-          'flutter analyze --concurrency 2',
+          'flutter analyze --fatal-infos --concurrency 2',
         ),
         isTrue,
       );
 
       final dartRegex = RegExp(
-        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+        r'\$ melos analyze\s+└> dart analyze --fatal-infos --concurrency 2',
       );
 
       expect(dartRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
@@ -364,11 +364,65 @@ ${'-' * terminalWidth}
       await melos.analyze(concurrency: 2);
 
       final flutterRegex = RegExp(
-        r'\$ melos analyze\s+└> flutter analyze --concurrency 2',
+        r'\$ melos analyze\s+└> flutter analyze --fatal-infos --concurrency 2',
       );
 
       expect(flutterRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
     });
+
+    test('should treat fatal-infos as enabled by default', () async {
+      await melos.analyze();
+
+      final dartRegex = RegExp(
+        r'\$ melos analyze\s+└> dart analyze --fatal-infos',
+      );
+
+      expect(dartRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
+    });
+
+    test(
+      'should pass --no-fatal-infos only to flutter when disabled',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'flutter': SdkDependency('flutter'),
+            },
+          ),
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('b'),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        final melos = Melos(
+          logger: logger,
+          config: config,
+        );
+        await melos.analyze(fatalInfos: false, concurrency: 2);
+
+        final output = logger.output.removeAnsiCodes();
+
+        expect(output.contains('flutter analyze --no-fatal-infos'), isTrue);
+
+        final dartRegex = RegExp(
+          r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+        );
+        expect(dartRegex.hasMatch(output), isTrue);
+        expect(output.contains('dart analyze --no-fatal-infos'), isFalse);
+      },
+    );
 
     test('should run analysis using dart', () async {
       final workspaceDir = await createTemporaryWorkspace(
@@ -389,13 +443,13 @@ ${'-' * terminalWidth}
 
       expect(
         logger.output.removeAnsiCodes().contains(
-          'flutter analyze --concurrency 2',
+          'flutter analyze --fatal-infos --concurrency 2',
         ),
         isFalse,
       );
 
       final dartRegex = RegExp(
-        r'\$ melos analyze\s+└> dart analyze --concurrency 2',
+        r'\$ melos analyze\s+└> dart analyze --fatal-infos --concurrency 2',
       );
       expect(dartRegex.hasMatch(logger.output.removeAnsiCodes()), isTrue);
     });
@@ -407,7 +461,7 @@ ${'-' * terminalWidth}
         logger.output,
         ignoringAnsii('''
 \$ melos analyze
-  └> dart analyze --concurrency 2
+  └> dart analyze --fatal-infos --concurrency 2
      └> RUNNING (in 3 packages)
 
 ${'-' * terminalWidth}
@@ -428,7 +482,7 @@ c: SUCCESS
 ${'-' * terminalWidth}
 
 \$ melos analyze
-  └> dart analyze --concurrency 2
+  └> dart analyze --fatal-infos --concurrency 2
      └> SUCCESS
 '''),
       );

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -74,7 +74,7 @@ linter:
       ''',
       );
 
-      await melos.analyze(fatalInfos: true);
+      await melos.analyze();
 
       expect(
         logger.output,
@@ -237,7 +237,7 @@ ${'-' * terminalWidth}
       ''',
         );
 
-        await melos.analyze(fatalInfos: true, fatalWarnings: true);
+        await melos.analyze(fatalWarnings: true);
 
         expect(
           logger.output,
@@ -502,7 +502,7 @@ ${'-' * terminalWidth}
       ''',
         );
 
-        await melos.analyze(concurrency: 2, fatalInfos: true);
+        await melos.analyze(concurrency: 2);
 
         expect(
           logger.output,


### PR DESCRIPTION
## Description

Makes `melos analyze` treat info-level issues as fatal by default, for both `dart analyze` and `flutter analyze`.

Previously `--fatal-infos` defaulted to off, so `melos analyze` matched `dart analyze`'s lenient default. Now info-level issues fail the analysis by default across both SDK tools, giving consistent behavior in mixed Dart/Flutter workspaces.

### Behavior

- `melos analyze` -> `--fatal-infos` is passed to both `dart analyze` and `flutter analyze`.
- `melos analyze --no-fatal-infos` -> disables it.

There is an intentional asymmetry in how the underlying commands are invoked, because the two SDK tools differ:

| Tool | `--fatal-infos` default | Supports `--no-fatal-infos`? |
| --- | --- | --- |
| `dart analyze` | off | no |
| `flutter analyze` | on | yes |

So when `--no-fatal-infos` is requested:
- For Dart packages the flag is simply omitted (`dart analyze` is already non-fatal by default and has no `--no-fatal-infos` flag, passing it would be a usage error).
- For Flutter packages `--no-fatal-infos` is forwarded to override Flutter's fatal-by-default behavior.

### Flags

`--fatal-infos` is now negatable and defaults to `true`. `--no-fatal-infos` was added to disable it.

## Type of Change

- [x] `feat` -- A non-breaking change which adds functionality.

## Notes

This changes the default outcome of `melos analyze`: workspaces with info-level lints that previously passed will now fail unless run with `--no-fatal-infos`.
