### PR TITLE
docs(version): fix comment style in dependency rewrite

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -671,9 +671,9 @@ mixin _VersionMixin on _RunMixin {
   /// values) via [YamlEditor].
   ///
   /// Returns `null` if [path] doesn't already point to an existing string
-  /// scalar (e.g. an optional `version:` key that was never present) —
-  /// mirroring the previous regex-based rewrite's behavior of leaving such
-  /// pubspecs untouched rather than inserting a new key.
+  /// scalar, for example an optional `version:` key that was never present.
+  /// This mirrors the previous rewrite behavior of leaving such pubspecs
+  /// untouched rather than inserting a new key.
   String? _rewriteDependencyVersionAtPath({
     required String pubspecContent,
     required List<Object> path,

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -72,11 +72,6 @@ enum PackageType {
 
 const _versionRegExp = r'''\d+\.\d+\.\d+[\w\-.+_]*''';
 
-// Used only for the git `ref:` tag rewrite (see [dependencyTagReplaceRegex]),
-// where the version is fused into a single tag string (e.g. `foo-v1.2.3`)
-// rather than being its own scalar node, so it isn't a candidate for a
-// `YamlEditor`-based rewrite the way the other dependency shapes are (see
-// `_setDependencyVersionForPackage` in `commands/version.dart`).
 RegExp dependencyTagReplaceRegex(String dependencyName) {
   return RegExp(
     '''(?<tag_ref>^\\s+ref\\s?:\\s?)(?<opening_quote>["']?)(?<tag>$dependencyName-v$_versionRegExp)(?<closing_quote>['"]?)''',


### PR DESCRIPTION
## Description

Small comment cleanup in the dependency-rewrite code introduced in #1041, to comply with the repository comment style:

- `version.dart` `_rewriteDependencyVersionAtPath` doc comment: replaced an em dash with a sentence break and `e.g.` with "for example".
- `package.dart`: removed the explanatory comment block above `dependencyTagReplaceRegex`.

No behavior changes.

## Type of Change

- [x] `docs` -- Documentation only changes.
