### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/latest_melos_release.yaml
+++ b/.github/workflows/latest_melos_release.yaml
@@ -11,5 +11,5 @@ jobs:
   release_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: git push -f origin HEAD:melos-latest

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -11,6 +11,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     if: contains(github.event.head_commit.message, 'chore(release)')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/stale_issue_pr_manager.yaml
+++ b/.github/workflows/stale_issue_pr_manager.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           operations-per-run: 1000
           stale-issue-message: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,7 +10,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -28,7 +28,7 @@ jobs:
   dart_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.9.0 # Update when min sdk supported version of `melos` package changes.
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2
@@ -84,7 +84,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: subosito/flutter-action@v2

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -671,9 +671,9 @@ mixin _VersionMixin on _RunMixin {
   /// values) via [YamlEditor].
   ///
   /// Returns `null` if [path] doesn't already point to an existing string
-  /// scalar (e.g. an optional `version:` key that was never present) —
-  /// mirroring the previous regex-based rewrite's behavior of leaving such
-  /// pubspecs untouched rather than inserting a new key.
+  /// scalar, for example an optional `version:` key that was never present.
+  /// This mirrors the previous rewrite behavior of leaving such pubspecs
+  /// untouched rather than inserting a new key.
   String? _rewriteDependencyVersionAtPath({
     required String pubspecContent,
     required List<Object> path,

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -72,11 +72,6 @@ enum PackageType {
 
 const _versionRegExp = r'''\d+\.\d+\.\d+[\w\-.+_]*''';
 
-// Used only for the git `ref:` tag rewrite (see [dependencyTagReplaceRegex]),
-// where the version is fused into a single tag string (e.g. `foo-v1.2.3`)
-// rather than being its own scalar node, so it isn't a candidate for a
-// `YamlEditor`-based rewrite the way the other dependency shapes are (see
-// `_setDependencyVersionForPackage` in `commands/version.dart`).
 RegExp dependencyTagReplaceRegex(String dependencyName) {
   return RegExp(
     '''(?<tag_ref>^\\s+ref\\s?:\\s?)(?<opening_quote>["']?)(?<tag>$dependencyName-v$_versionRegExp)(?<closing_quote>['"]?)''',


### PR DESCRIPTION
Bumps the GitHub Actions that were behind their latest major version.

| Action | Before | After |
|---|---|---|
| \`actions/checkout\` | v4 | v7 |
| \`amannn/action-semantic-pull-request\` | v5 | v6 |
| \`actions/stale\` | v9 | v10 |

The remaining actions (\`subosito/flutter-action\`, \`invertase/github-action-dart-analyzer\`, \`dart-lang/setup-dart\`, \`actions-ecosystem/action-add-labels\`, \`actions-ecosystem/action-remove-labels\`, \`bluefireteam/melos-action\`) are already on their latest major version.

All three bumped actions only change the underlying Node.js runtime (to Node 24), which \`ubuntu-latest\` and \`windows-latest\` runners already support, so no workflow configuration changes were needed.