### PR TITLE
fix(deps): require cli_launcher ^0.3.3+2 for Flutter workspace relaunch fix

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   ansi_styles: ^0.3.2+1
   args: ^2.7.0
   async: ^2.13.0
-  cli_launcher: ^0.3.3+1
+  cli_launcher: ^0.3.3+2
   cli_util: ^0.5.0
   collection: ^1.19.0
   conventional_commit: ^0.6.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ melos:
       dependencies:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
-        cli_launcher: ^0.3.3+1
+        cli_launcher: ^0.3.3+2
         cli_util: ^0.5.0
         collection: ^1.19.0
         file: ^7.0.1


### PR DESCRIPTION
## Draft — blocked on the cli_launcher release

Raises Melos's `cli_launcher` floor so consumers pick up the Flutter-workspace relaunch fix.

## Problem

When the globally activated `melos` version differs from the version a project pins in its `pubspec.lock`, cli_launcher relaunches the pinned version via `dart run <pkg>:melos`. `dart run` implicitly resolves dependencies first, and a plain `dart pub get` fails on a Dart pub-workspace containing Flutter members:

```
Because <pkg> requires the Flutter SDK, version solving failed.
Flutter users should use `flutter pub` instead of `dart pub`.
```

This broke `melos list` on Dart-only CI for Flutter workspaces such as supabase-flutter as soon as a newer `melos` was published while the project still pinned the previous version.

## Fix

The actual fix lives in cli_launcher (relaunch via `flutter pub run` for Flutter workspaces): blaugold/cli_launcher#25. This PR just raises the dependency floor in both `packages/melos/pubspec.yaml` and the workspace `command/bootstrap/dependencies` block once that fix is released.

## Blocked / TODO before marking ready

- [ ] blaugold/cli_launcher#25 merged and published.
- [ ] Confirm the published version number (assumed `0.3.3+2`, following the build-number bump pattern of the previous `fix`). Update the constraint if it differs.