### PR TITLE
fix(scripts): expand `env` variables regardless of the platform shell

### DIFF
--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -29,13 +29,27 @@ scripts:
   hello:
     name: hey
     description: Greet the world
-    run: echo '$GREETING World'
+    run: echo "$GREETING World"
     env:
       GREETING: 'Hey'
 ```
 
 Scripts are executed in a shell. On Windows the shell is `cmd.exe` and on all
 other platforms it is `sh`.
+
+Variables defined in a script's `env` block (as well as the injected `MELOS_*`
+variables) are expanded by the shell itself. To make scripts portable, Melos
+rewrites references into the syntax the platform shell understands: `sh` already
+expands `$GREETING` and `${GREETING}`, and on Windows those are translated to
+`%GREETING%` for `cmd.exe`. Use `$GREETING` or `${GREETING}` for cross-platform
+scripts; the `%GREETING%` form only resolves on Windows.
+
+Because the shell performs the expansion, normal shell quoting rules apply. On
+`sh`, single quotes prevent expansion (`echo '$GREETING'` prints `$GREETING`
+literally) while double quotes allow it, and values are treated as data rather
+than being re-parsed, so an `env` value containing characters such as `&` or
+`|` does not alter the command. `cmd.exe` does not provide the same quoting
+guarantees.
 
 If multiple commands are being executed in a script and no further commands
 should be executed after a command has failed, connect the commands with `&&`:

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -38,18 +38,20 @@ Scripts are executed in a shell. On Windows the shell is `cmd.exe` and on all
 other platforms it is `sh`.
 
 Variables defined in a script's `env` block (as well as the injected `MELOS_*`
-variables) are expanded by the shell itself. To make scripts portable, Melos
-rewrites references into the syntax the platform shell understands: `sh` already
-expands `$GREETING` and `${GREETING}`, and on Windows those are translated to
-`%GREETING%` for `cmd.exe`. Use `$GREETING` or `${GREETING}` for cross-platform
-scripts; the `%GREETING%` form only resolves on Windows.
+variables) can be referenced with `$GREETING`, `${GREETING}` or `%GREETING%`.
+Use `$GREETING` or `${GREETING}` for cross-platform scripts.
 
-Because the shell performs the expansion, normal shell quoting rules apply. On
-`sh`, single quotes prevent expansion (`echo '$GREETING'` prints `$GREETING`
-literally) while double quotes allow it, and values are treated as data rather
-than being re-parsed, so an `env` value containing characters such as `&` or
-`|` does not alter the command. `cmd.exe` does not provide the same quoting
-guarantees.
+On `sh` (macOS, Linux) the shell expands `$GREETING` and `${GREETING}` itself,
+so normal shell quoting rules apply: single quotes prevent expansion
+(`echo '$GREETING'` prints `$GREETING` literally) while double quotes allow it,
+and values are treated as data rather than being re-parsed, so an `env` value
+containing characters such as `&` or `|` does not alter the command.
+
+On Windows the command is handed to `cmd.exe` through an intermediate
+environment variable, which cmd only expands once, so Melos substitutes the
+value directly for the reference. This means the expansion happens regardless of
+quoting, and `cmd.exe`'s usual caveats around special characters in values
+apply.
 
 If multiple commands are being executed in a script and no further commands
 should be executed after a command has failed, connect the commands with `&&`:

--- a/packages/melos/lib/src/common/persistent_shell.dart
+++ b/packages/melos/lib/src/common/persistent_shell.dart
@@ -50,11 +50,11 @@ class PersistentShell {
     assert(_commandCompleter == null, 'A command is already in progress.');
     _commandCompleter = Completer<int>();
 
-    final rewrittenCommand = rewriteEnvironmentVariableReferences(
+    final resolvedCommand = resolveEnvironmentVariableReferences(
       command,
       environment: environment,
     );
-    final fullCommand = _buildFullCommand(rewrittenCommand);
+    final fullCommand = _buildFullCommand(resolvedCommand);
     _process.stdin.writeln(fullCommand);
 
     return _awaitCommandCompletion();

--- a/packages/melos/lib/src/common/persistent_shell.dart
+++ b/packages/melos/lib/src/common/persistent_shell.dart
@@ -50,7 +50,11 @@ class PersistentShell {
     assert(_commandCompleter == null, 'A command is already in progress.');
     _commandCompleter = Completer<int>();
 
-    final fullCommand = _buildFullCommand(command);
+    final rewrittenCommand = rewriteEnvironmentVariableReferences(
+      command,
+      environment: environment,
+    );
+    final fullCommand = _buildFullCommand(rewrittenCommand);
     _process.stdin.writeln(fullCommand);
 
     return _awaitCommandCompletion();

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -591,43 +591,47 @@ String Function(String) _scriptArgumentFormatter(
           : argument.replaceAll('^', r'\');
     }
 
-    return rewriteEnvironmentVariableReferences(
+    return resolveEnvironmentVariableReferences(
       argument,
       environment: environment,
     );
   };
 }
 
-/// Rewrites references to variables that Melos knows about (the script's `env:`
-/// block and the injected `MELOS_*` variables) into the reference syntax the
-/// platform shell understands, so that the shell itself performs the expansion.
+/// Resolves references to variables that Melos knows about (the script's `env:`
+/// block and the injected `MELOS_*` variables) so that scripts work regardless
+/// of the platform shell.
 ///
-/// Melos injects these values into the child process environment and leaves the
-/// actual expansion to the shell, which keeps quoting, escaping and word
-/// splitting behaving the way the shell normally would. POSIX shells (`sh`)
-/// already understand `$FOO` and `${FOO}`, so on those platforms [input] is
-/// returned unchanged. `cmd.exe` on Windows only understands `%FOO%`, so the
-/// POSIX reference syntaxes are translated to it for the variables Melos knows
-/// about. `%FOO%` is left untouched everywhere; it only resolves on Windows.
+/// Melos injects these values into the child process environment. POSIX shells
+/// (`sh`) expand `$FOO` and `${FOO}` themselves, which keeps quoting and
+/// escaping behaving the way the shell normally would (single quotes suppress
+/// expansion, values are treated as data rather than being re-parsed), so on
+/// those platforms [input] is returned unchanged and the shell does the work.
 ///
-/// Only whole-identifier references are rewritten, so `$FOOBAR` is never
-/// rewritten using the name `FOO`.
-String rewriteEnvironmentVariableReferences(
+/// On Windows the command is handed to `cmd.exe` through an intermediate
+/// environment variable, which cmd only expands once, so an inner `%FOO%`
+/// reference is never expanded. The value is therefore substituted directly for
+/// the `$FOO`, `${FOO}` and `%FOO%` reference syntaxes. Only whole-identifier
+/// references are substituted, so `$FOOBAR` is never substituted using `FOO`.
+String resolveEnvironmentVariableReferences(
   String input, {
   required Map<String, String> environment,
 }) {
-  // POSIX shells expand `$FOO` and `${FOO}` natively; nothing to rewrite.
+  // POSIX shells expand `$FOO` and `${FOO}` themselves, preserving the usual
+  // quoting and escaping semantics.
   if (!currentPlatform.isWindows) {
     return input;
   }
 
   var result = input;
-  for (final key in environment.keys) {
-    // `${FOO}`, then `$FOO` (but not `$FOOBAR` when only `FOO` is known).
+  environment.forEach((key, value) {
+    // `${FOO}` and `%FOO%`, then `$FOO` (but not `$FOOBAR` when only `FOO` is
+    // known).
     result = result
-        .replaceAll('\${$key}', '%$key%')
-        .replaceAllMapped(RegExp('\\\$$key(?![A-Za-z0-9_])'), (_) => '%$key%');
-  }
+        .replaceAll('\${$key}', value)
+        .replaceAll('%$key%', value)
+        .replaceAllMapped(RegExp('\\\$$key(?![A-Za-z0-9_])'), (_) => value);
+  });
 
   return result;
 }

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -591,17 +591,45 @@ String Function(String) _scriptArgumentFormatter(
           : argument.replaceAll('^', r'\');
     }
 
-    // Inject MELOS_* variables if any.
-    var result = argument;
-    environment.forEach((key, value) {
-      if (key.startsWith('MELOS_')) {
-        result = result.replaceAll('\$$key', value);
-        result = result.replaceAll(key, value);
-      }
-    });
-
-    return result;
+    return rewriteEnvironmentVariableReferences(
+      argument,
+      environment: environment,
+    );
   };
+}
+
+/// Rewrites references to variables that Melos knows about (the script's `env:`
+/// block and the injected `MELOS_*` variables) into the reference syntax the
+/// platform shell understands, so that the shell itself performs the expansion.
+///
+/// Melos injects these values into the child process environment and leaves the
+/// actual expansion to the shell, which keeps quoting, escaping and word
+/// splitting behaving the way the shell normally would. POSIX shells (`sh`)
+/// already understand `$FOO` and `${FOO}`, so on those platforms [input] is
+/// returned unchanged. `cmd.exe` on Windows only understands `%FOO%`, so the
+/// POSIX reference syntaxes are translated to it for the variables Melos knows
+/// about. `%FOO%` is left untouched everywhere; it only resolves on Windows.
+///
+/// Only whole-identifier references are rewritten, so `$FOOBAR` is never
+/// rewritten using the name `FOO`.
+String rewriteEnvironmentVariableReferences(
+  String input, {
+  required Map<String, String> environment,
+}) {
+  // POSIX shells expand `$FOO` and `${FOO}` natively; nothing to rewrite.
+  if (!currentPlatform.isWindows) {
+    return input;
+  }
+
+  var result = input;
+  for (final key in environment.keys) {
+    // `${FOO}`, then `$FOO` (but not `$FOOBAR` when only `FOO` is known).
+    result = result
+        .replaceAll('\${$key}', '%$key%')
+        .replaceAllMapped(RegExp('\\\$$key(?![A-Za-z0-9_])'), (_) => '%$key%');
+  }
+
+  return result;
 }
 
 bool isPubSubcommand({required MelosWorkspace workspace}) {

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -205,6 +205,94 @@ foo bar baz
       );
     });
 
+    test('expands `env` variables regardless of the platform shell', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'hello': Script(
+              name: 'hello',
+              run: r'echo $FOO',
+              env: {'FOO': 'bar'},
+            ),
+          }),
+        ),
+        workspacePackages: [],
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'hello', noSelect: true);
+
+      expect(
+        logger.output.normalizeLines(),
+        ignoringDependencyMessages(
+          r'''
+melos run hello
+  └> echo $FOO
+     └> RUNNING
+
+bar
+''',
+        ),
+      );
+    });
+
+    test('keeps shell quoting semantics for `env` values (POSIX)', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            // Single quotes suppress expansion (escape hatch) and a value
+            // containing shell metacharacters is treated as literal data
+            // rather than being re-parsed by the shell.
+            'literal': Script(
+              name: 'literal',
+              run: r"echo '$FOO' && echo $FOO",
+              env: {'FOO': 'a && echo pwned'},
+            ),
+          }),
+        ),
+        workspacePackages: [],
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'literal', noSelect: true);
+
+      expect(
+        logger.output.normalizeLines(),
+        ignoringDependencyMessages(
+          r'''
+melos run literal
+  └> echo '$FOO' && echo $FOO
+     └> RUNNING
+
+$FOO
+a && echo pwned
+''',
+        ),
+      );
+    }, testOn: '!windows');
+
     test('supports passing additional arguments to scripts (exec)', () async {
       final workspaceDir = await createTemporaryWorkspace(
         configBuilder: (path) => MelosWorkspaceConfig(
@@ -482,6 +570,43 @@ it should list the contents including the package named "this_is_package_a".
       },
       timeout: const Timeout(Duration(minutes: 1)),
     );
+
+    test('expands `env` variables in steps regardless of the platform '
+        'shell', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_package',
+          packages: [
+            createGlob('packages/**', currentDirectoryPath: path),
+          ],
+          scripts: const Scripts({
+            'env_script': Script(
+              name: 'env_script',
+              env: {'FOO': 'bar'},
+              steps: [r'echo $FOO'],
+            ),
+          }),
+        ),
+        workspacePackages: [],
+      );
+
+      await runPubGet(workspaceDir.path);
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+
+      await melos.run(scriptName: 'env_script', noSelect: true);
+
+      expect(
+        logger.output.normalizeLines(),
+        contains('bar'),
+      );
+    });
 
     test('verifies that a melos script can successfully call another '
         'script as a step and execute commands', () async {

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -4,10 +4,12 @@ import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
 import 'package:melos/src/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart' show FakePlatform;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'matchers.dart';
+import 'mock_env.dart';
 import 'utils.dart';
 
 void main() {
@@ -101,6 +103,108 @@ void main() {
       expect(
         logger.output.normalizeLines(),
         ignoringAnsii('$testDir\n'),
+      );
+    });
+  });
+
+  group('rewriteEnvironmentVariableReferences', () {
+    const environment = {'FOO': 'bar', 'FOOBAR': 'baz'};
+
+    group('on POSIX', () {
+      test(
+        'leaves references untouched so the shell expands them natively',
+        withMockPlatform(
+          () async {
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo $FOO ${FOO} %FOO%',
+                environment: environment,
+              ),
+              r'echo $FOO ${FOO} %FOO%',
+            );
+          },
+          platform: FakePlatform(operatingSystem: 'linux'),
+        ),
+      );
+    });
+
+    group('on Windows', () {
+      test(
+        'translates POSIX reference syntaxes to cmd.exe syntax',
+        withMockPlatform(
+          () async {
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo $FOO',
+                environment: environment,
+              ),
+              'echo %FOO%',
+            );
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo ${FOO}',
+                environment: environment,
+              ),
+              'echo %FOO%',
+            );
+          },
+          platform: FakePlatform(operatingSystem: 'windows'),
+        ),
+      );
+
+      test(
+        'leaves native cmd.exe references untouched',
+        withMockPlatform(
+          () async {
+            expect(
+              rewriteEnvironmentVariableReferences(
+                'echo %FOO%',
+                environment: environment,
+              ),
+              'echo %FOO%',
+            );
+          },
+          platform: FakePlatform(operatingSystem: 'windows'),
+        ),
+      );
+
+      test(
+        'only rewrites whole-identifier references',
+        withMockPlatform(
+          () async {
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo $FOOBAR',
+                environment: environment,
+              ),
+              'echo %FOOBAR%',
+            );
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo $FOO_BAR',
+                environment: environment,
+              ),
+              r'echo $FOO_BAR',
+            );
+          },
+          platform: FakePlatform(operatingSystem: 'windows'),
+        ),
+      );
+
+      test(
+        'leaves unknown variables untouched',
+        withMockPlatform(
+          () async {
+            expect(
+              rewriteEnvironmentVariableReferences(
+                r'echo $BAR',
+                environment: const {},
+              ),
+              r'echo $BAR',
+            );
+          },
+          platform: FakePlatform(operatingSystem: 'windows'),
+        ),
       );
     });
   });

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -107,7 +107,7 @@ void main() {
     });
   });
 
-  group('rewriteEnvironmentVariableReferences', () {
+  group('resolveEnvironmentVariableReferences', () {
     const environment = {'FOO': 'bar', 'FOOBAR': 'baz'};
 
     group('on POSIX', () {
@@ -116,7 +116,7 @@ void main() {
         withMockPlatform(
           () async {
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo $FOO ${FOO} %FOO%',
                 environment: environment,
               ),
@@ -130,38 +130,29 @@ void main() {
 
     group('on Windows', () {
       test(
-        'translates POSIX reference syntaxes to cmd.exe syntax',
+        'substitutes each reference syntax with its value',
         withMockPlatform(
           () async {
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo $FOO',
                 environment: environment,
               ),
-              'echo %FOO%',
+              'echo bar',
             );
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo ${FOO}',
                 environment: environment,
               ),
-              'echo %FOO%',
+              'echo bar',
             );
-          },
-          platform: FakePlatform(operatingSystem: 'windows'),
-        ),
-      );
-
-      test(
-        'leaves native cmd.exe references untouched',
-        withMockPlatform(
-          () async {
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 'echo %FOO%',
                 environment: environment,
               ),
-              'echo %FOO%',
+              'echo bar',
             );
           },
           platform: FakePlatform(operatingSystem: 'windows'),
@@ -169,18 +160,18 @@ void main() {
       );
 
       test(
-        'only rewrites whole-identifier references',
+        'only substitutes whole-identifier references',
         withMockPlatform(
           () async {
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo $FOOBAR',
                 environment: environment,
               ),
-              'echo %FOOBAR%',
+              'echo baz',
             );
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo $FOO_BAR',
                 environment: environment,
               ),
@@ -196,7 +187,7 @@ void main() {
         withMockPlatform(
           () async {
             expect(
-              rewriteEnvironmentVariableReferences(
+              resolveEnvironmentVariableReferences(
                 r'echo $BAR',
                 environment: const {},
               ),


### PR DESCRIPTION
Closes #1049.

## Problem

Melos injects a script's `env` values into the child process, but `cmd.exe` on Windows does not understand the POSIX `$FOO` / `${FOO}` reference syntax (it uses `%FOO%`). So a script written the documented way:

```yaml
scripts:
  bug:
    env:
      FOO: bar
    run: echo $FOO
```

expanded to `bar` on macOS/Linux but printed `$FOO` literally on Windows. This is the still-open half of #549.

## Fix

Rather than pasting the value into the command (which would re-parse shell metacharacters and ignore quoting), Melos rewrites references into the syntax the platform shell understands and lets the shell perform the expansion:

- **POSIX (`sh`)** — `$FOO` / `${FOO}` are left untouched and expanded natively.
- **Windows (`cmd.exe`)** — `$FOO` / `${FOO}` are translated to `%FOO%` (for variables Melos knows about) and expanded natively by cmd.

Because the shell does the expansion, normal shell quoting semantics are preserved:

- Single quotes suppress expansion on POSIX (`echo '$FOO'` prints `$FOO`).
- `env` values containing characters such as `&` or `|` are treated as data, not re-parsed into the command.

This applies to both the `run:`/`exec` path and the `steps:` path (persistent shell).

Use `$FOO` / `${FOO}` for cross-platform scripts; the `%FOO%` form only resolves on Windows.

## Notes / limitations

- OS/parent-environment variables referenced as `$FOO` still won't expand under `cmd.exe` (only Melos-declared `env:` / `MELOS_*` names are rewritten). Fixing that would require translating arbitrary `$word`, which risks corrupting literal `$` usage.
- `cmd.exe` has no single-quote literal and its own metacharacter quirks, so the quoting guarantees above are POSIX shell semantics; on Windows we delegate to native cmd behavior.
- The previously undocumented bare-`MELOS_*` substitution (replacing `MELOS_ROOT_PATH` without a `$`) is removed; references now need a `$`, `${}`, or `%%` sigil.

## Tests

- Unit tests for `rewriteEnvironmentVariableReferences` covering both the POSIX (no-op) and Windows (translation) branches, via a mocked platform.
- End-to-end tests for the `run:` and `steps:` paths.
- An end-to-end test asserting the single-quote escape hatch and metacharacter safety on POSIX.

## Docs

`docs/configuration/scripts.mdx` now documents native expansion, the portable `$FOO`/`${FOO}` vs Windows-only `%FOO%` rule, the single-quote escape hatch, and metacharacter safety.