### PR TITLE
test(analyze): raise timeout so Windows CI does not flake

### DIFF
--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'dart:io';
 
 import 'package:melos/melos.dart';


### PR DESCRIPTION
## Problem

`test_windows` is failing on `main` (run [29165893760](https://github.com/invertase/melos/actions/runs/29165893760)) on:

```
test\commands\analyze_test.dart: Melos Analyze should run analysis using flutter & dart (failed)
TimeoutException after 0:00:30.000000: Test timed out after 30 seconds.
IOException: Melos failed to delete entry because it was in use by another process.
Path: C:\Users\runneradmin\AppData\Local\Temp\melos_test_270e28d4
  package:melos/src/common/io.dart 114:3  deleteEntry
  test\utils.dart 128:21                   createTemporaryWorkspace.<fn>
```

The `Melos Analyze` tests call `melos.analyze()`, which shells out to real `flutter analyze` and `dart analyze` (here two packages, run concurrently). On a cold Windows CI runner this can exceed the default 30 second test timeout. When it times out, the analyze subprocess is still holding the temporary workspace directory, so the teardown's `deleteEntry` then fails with "in use by another process", which fails the whole `test_windows` job.

This is intermittent (the four previous `main` runs passed) and unrelated to any product change.

## Fix

Add a file-level `@Timeout(Duration(minutes: 2))` to `analyze_test.dart` so the analyze integration tests have enough headroom for the slower cold start on Windows. Once the test completes within the timeout, the subprocess exits and the temp-directory cleanup succeeds.

Verified locally that the test still passes with the annotation.