### PR TITLE
test: raise per-test timeout on Windows to fix flaky CI

### DIFF
--- a/packages/melos/dart_test.yaml
+++ b/packages/melos/dart_test.yaml
@@ -1,0 +1,10 @@
+# Many of Melos' tests are integration tests that shell out to real tools
+# (pub, dart/flutter analyze, git) and create temporary workspaces. On cold
+# Windows CI runners this is noticeably slower than the default 30s per-test
+# timeout allows, which caused flaky timeouts (and the temporary-directory
+# cleanup failures they trigger when a subprocess is still holding the
+# workspace). Give tests more headroom on Windows while keeping the tight
+# default elsewhere so genuine hangs are still caught quickly.
+on_os:
+  windows:
+    timeout: 4x


### PR DESCRIPTION
## Problem

`test_windows` flakes on `main` with 30 second timeouts on different integration tests across runs:

- `analyze_test.dart: Melos Analyze should run analysis using flutter & dart` ([run 29165893760](https://github.com/invertase/melos/actions/runs/29165893760))
- `init_test.dart: init creates workspace in current directory when directory is "."` ([run 29189391856](https://github.com/invertase/melos/actions/runs/29189391856))

```
TimeoutException after 0:00:30.000000: Test timed out after 30 seconds.
IOException: Melos failed to delete entry because it was in use by another process.
```

Many of Melos' tests are integration tests that shell out to real tools (pub, `dart`/`flutter analyze`, git) and create temporary workspaces. On cold Windows CI runners this is much slower than the default 30s per-test timeout. When a test times out, the spawned subprocess is still holding the temporary workspace directory, so the teardown then fails with "in use by another process", which fails the whole `test_windows` job.

## Fix

Add `packages/melos/dart_test.yaml` that quadruples the per-test timeout **on Windows only** (`on_os: windows: timeout: 4x`), keeping the tight 30s default on Linux/macOS so genuine hangs are still caught quickly. `melos test` runs `dart test` inside `packages/melos`, so the config is picked up automatically.

This supersedes #1051 (which only bumped `analyze_test`), since the flakiness spans multiple test files.