### PR TITLE
fix(scripts): expand env variables inherited from a parent melos process on Windows

### DIFF
--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -613,6 +613,12 @@ String Function(String) _scriptArgumentFormatter(
 /// reference is never expanded. The value is therefore substituted directly for
 /// the `$FOO`, `${FOO}` and `%FOO%` reference syntaxes. Only whole-identifier
 /// references are substituted, so `$FOOBAR` is never substituted using `FOO`.
+///
+/// Variables inherited from the parent process environment are resolved too, so
+/// that a value defined by an outer script's `env:` block (and thus present in
+/// the environment of a nested `melos run`) is expanded even when the nested
+/// script does not redeclare it. The script's own [environment] takes
+/// precedence over inherited values of the same name.
 String resolveEnvironmentVariableReferences(
   String input, {
   required Map<String, String> environment,
@@ -624,7 +630,11 @@ String resolveEnvironmentVariableReferences(
   }
 
   var result = input;
-  environment.forEach((key, value) {
+  final resolvedEnvironment = {
+    ...currentPlatform.environment,
+    ...environment,
+  };
+  resolvedEnvironment.forEach((key, value) {
     // `${FOO}` and `%FOO%`, then `$FOO` (but not `$FOOBAR` when only `FOO` is
     // known).
     result = result

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -155,7 +155,10 @@ void main() {
               'echo bar',
             );
           },
-          platform: FakePlatform(operatingSystem: 'windows'),
+          platform: FakePlatform(
+            operatingSystem: 'windows',
+            environment: const {},
+          ),
         ),
       );
 
@@ -178,7 +181,10 @@ void main() {
               r'echo $FOO_BAR',
             );
           },
-          platform: FakePlatform(operatingSystem: 'windows'),
+          platform: FakePlatform(
+            operatingSystem: 'windows',
+            environment: const {},
+          ),
         ),
       );
 
@@ -194,7 +200,48 @@ void main() {
               r'echo $BAR',
             );
           },
-          platform: FakePlatform(operatingSystem: 'windows'),
+          platform: FakePlatform(
+            operatingSystem: 'windows',
+            environment: const {},
+          ),
+        ),
+      );
+
+      test(
+        'substitutes variables inherited from the parent process environment',
+        withMockPlatform(
+          () async {
+            expect(
+              resolveEnvironmentVariableReferences(
+                r'echo $INHERITED',
+                environment: const {},
+              ),
+              'echo qux',
+            );
+          },
+          platform: FakePlatform(
+            operatingSystem: 'windows',
+            environment: const {'INHERITED': 'qux'},
+          ),
+        ),
+      );
+
+      test(
+        'prefers the script environment over an inherited value',
+        withMockPlatform(
+          () async {
+            expect(
+              resolveEnvironmentVariableReferences(
+                r'echo $FOO',
+                environment: environment,
+              ),
+              'echo bar',
+            );
+          },
+          platform: FakePlatform(
+            operatingSystem: 'windows',
+            environment: const {'FOO': 'inherited'},
+          ),
         ),
       );
     });


### PR DESCRIPTION
## Description

Follow-up to the v8.2.1 Windows env variable fix (#1050). On Windows, `resolveEnvironmentVariableReferences` substituted `$FOO`/`${FOO}`/`%FOO%` references using only the current script's `env:` block. When an outer script defined `env: FOO: bar` and a step ran a nested `melos run`, the nested script (which does not redeclare `FOO`) left `$FOO` literal, because `cmd.exe` never expands POSIX-style references itself.

This resolves references against the inherited process environment as a fallback, so a value defined by an outer script's `env:` block, and thus present in the environment of the nested `melos run`, is expanded even when the nested script does not redeclare it. The script's own `env:` still takes precedence over an inherited value of the same name.

This matches the behavior on unix, where the value is injected into the child process environment and expanded natively by the shell at runtime, propagating down the process tree unchanged.

Reported in https://github.com/invertase/melos/issues/1049#issuecomment-4956490803.

### Reproduction

```yaml
foo:
  env:
    FOO: bar
  steps:
    - echo foo says $FOO
    - melos run foo:bar

foo:bar:
  steps:
    - echo bar says $FOO
```

Before, on Windows the nested step printed `bar says $FOO`. Now it prints `bar says bar`.

## Note

On Windows the substitution now draws from the entire inherited process environment, so references like `$PATH` or `$USERPROFILE` that previously stayed literal will now be expanded by Melos. This is consistent with how a real shell behaves, but it is a slight broadening of the previous behavior.

## Type of Change

- [x] `fix` -- Bug Fix (non-breaking change which fixes an issue)
