### PR TITLE
feat(version): add optional fixed versioning mode

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -18,6 +18,41 @@ melos version
   documentation.
 </Info>
 
+## Lockstep versioning
+
+By default, each package is versioned independently, based on the commits that
+touched that package. If you prefer all packages in the workspace to always
+share the same version, similar to the "fixed" release mode of tools like Nx
+and Lerna, enable lockstep versioning in the
+[`command/version/lockstep`](/configuration/overview#lockstep) configuration:
+
+```yaml
+melos:
+  command:
+    version:
+      lockstep: true
+```
+
+With lockstep enabled, `melos version`:
+
+- Determines a single new version for the whole workspace: the highest current
+  package version, incremented by the most significant change across all
+  packages (major if any package has a breaking change, minor if any package
+  has a new feature, otherwise patch).
+- Bumps every package in the workspace to that version, including packages
+  without changes of their own. Their changelog notes that the version was
+  bumped to keep the workspace in lockstep, while packages with changes get
+  their regular changelog entries.
+- Applies a manually specified version (`melos version <package> <version>`)
+  to all packages in the workspace.
+
+Private packages are still skipped unless `--all` is passed, and packages
+excluded with filters (e.g. `--ignore`) are not bumped, so use filters with
+care if you want the workspace to stay in sync.
+
+If there are no versionable changes in any package, `melos version` does
+nothing, just like in independent mode.
+
 ## Hooks
 
 The `version` command supports the following hooks in addition to the

--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -44,11 +44,15 @@ With lockstep enabled, `melos version`:
   bumped to keep the workspace in lockstep, while packages with changes get
   their regular changelog entries.
 - Applies a manually specified version (`melos version <package> <version>`)
-  to all packages in the workspace.
+  to all packages in the workspace. Relative version changes (`major`,
+  `minor`, `patch` or `build`) are applied to the highest current version in
+  the workspace, regardless of which package was named.
+- Leaves packages that are already at the new lockstep version untouched.
 
 Private packages are still skipped unless `--all` is passed, and packages
 excluded with filters (e.g. `--ignore`) are not bumped, so use filters with
-care if you want the workspace to stay in sync.
+care if you want the workspace to stay in sync. Since all packages are
+versioned together, `--no-dependent-versions` has no effect in lockstep mode.
 
 If there are no versionable changes in any package, `melos version` does
 nothing, just like in independent mode.

--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -18,22 +18,23 @@ melos version
   documentation.
 </Info>
 
-## Lockstep versioning
+## Fixed versioning mode
 
 By default, each package is versioned independently, based on the commits that
 touched that package. If you prefer all packages in the workspace to always
-share the same version, similar to the "fixed" release mode of tools like Nx
-and Lerna, enable lockstep versioning in the
-[`command/version/lockstep`](/configuration/overview#lockstep) configuration:
+share the same version (also known as lockstep versioning, and similar to the
+"fixed" release mode of tools like Nx and Lerna), set the
+[`command/version/mode`](/configuration/overview#mode) configuration to
+`fixed`:
 
 ```yaml
 melos:
   command:
     version:
-      lockstep: true
+      mode: fixed
 ```
 
-With lockstep enabled, `melos version`:
+In `fixed` mode, `melos version`:
 
 - Determines a single new version for the whole workspace: the highest current
   package version, incremented by the most significant change across all
@@ -47,15 +48,15 @@ With lockstep enabled, `melos version`:
   to all packages in the workspace. Relative version changes (`major`,
   `minor`, `patch` or `build`) are applied to the highest current version in
   the workspace, regardless of which package was named.
-- Leaves packages that are already at the new lockstep version untouched.
+- Leaves packages that are already at the new shared version untouched.
 
 Private packages are still skipped unless `--all` is passed, and packages
 excluded with filters (e.g. `--ignore`) are not bumped, so use filters with
 care if you want the workspace to stay in sync. Since all packages are
-versioned together, `--no-dependent-versions` has no effect in lockstep mode.
+versioned together, `--no-dependent-versions` has no effect in `fixed` mode.
 
 If there are no versionable changes in any package, `melos version` does
-nothing, just like in independent mode.
+nothing, just like in `independent` mode.
 
 ## Hooks
 

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -555,35 +555,36 @@ each package after versioning. Defaults to `false`.
 
 [glob]: https://docs.python.org/3/library/glob.html
 
-### lockstep
+### mode
 
-Whether to version all packages in the workspace together, similar to the
-"fixed" release mode of tools like Nx and Lerna in the JavaScript ecosystem.
-Defaults to `false`.
+The mode in which packages in the workspace are versioned. Either
+`independent` (the default) or `fixed`, matching the release modes of tools
+like Nx and Lerna in the JavaScript ecosystem.
 
-When enabled, every `melos version` run bumps all packages to the same new
-version. The new version is based on the highest current version in the
-workspace, incremented by the most significant change found in any package
-(a breaking change anywhere causes a major bump for all packages, a feature a
-minor bump, and so on). Packages without changes of their own are bumped too,
-with a changelog entry noting that the bump keeps the workspace in lockstep.
+In `fixed` mode (also known as lockstep versioning), every `melos version` run
+bumps all packages to the same new version. The new version is based on the
+highest current version in the workspace, incremented by the most significant
+change found in any package (a breaking change anywhere causes a major bump
+for all packages, a feature a minor bump, and so on). Packages without changes
+of their own are bumped too, with a changelog entry noting that the bump keeps
+the workspace in lockstep.
 
 ```yaml
 melos:
   command:
     version:
-      lockstep: true
+      mode: fixed
 ```
 
-When manually versioning with `melos version <package> <version>` while
-lockstep is enabled, the specified version is applied to all packages in the
-workspace. Relative version changes (`major`, `minor`, `patch` or `build`) are
-applied to the highest current version in the workspace, regardless of which
-package was named. Specifying conflicting versions for multiple packages is an
-error.
+When manually versioning with `melos version <package> <version>` in `fixed`
+mode, the specified version is applied to all packages in the workspace.
+Relative version changes (`major`, `minor`, `patch` or `build`) are applied to
+the highest current version in the workspace, regardless of which package was
+named. Specifying conflicting versions for multiple packages is an error.
 
-See the [version command documentation](/commands/version#lockstep-versioning)
-for more information.
+See the
+[version command documentation](/commands/version#fixed-versioning-mode) for
+more information.
 
 ### fetchTags
 

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -577,7 +577,9 @@ melos:
 
 When manually versioning with `melos version <package> <version>` while
 lockstep is enabled, the specified version is applied to all packages in the
-workspace, and specifying conflicting versions for multiple packages is an
+workspace. Relative version changes (`major`, `minor`, `patch` or `build`) are
+applied to the highest current version in the workspace, regardless of which
+package was named. Specifying conflicting versions for multiple packages is an
 error.
 
 See the [version command documentation](/commands/version#lockstep-versioning)

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -555,6 +555,34 @@ each package after versioning. Defaults to `false`.
 
 [glob]: https://docs.python.org/3/library/glob.html
 
+### lockstep
+
+Whether to version all packages in the workspace together, similar to the
+"fixed" release mode of tools like Nx and Lerna in the JavaScript ecosystem.
+Defaults to `false`.
+
+When enabled, every `melos version` run bumps all packages to the same new
+version. The new version is based on the highest current version in the
+workspace, incremented by the most significant change found in any package
+(a breaking change anywhere causes a major bump for all packages, a feature a
+minor bump, and so on). Packages without changes of their own are bumped too,
+with a changelog entry noting that the bump keeps the workspace in lockstep.
+
+```yaml
+melos:
+  command:
+    version:
+      lockstep: true
+```
+
+When manually versioning with `melos version <package> <version>` while
+lockstep is enabled, the specified version is applied to all packages in the
+workspace, and specifying conflicting versions for multiple packages is an
+error.
+
+See the [version command documentation](/commands/version#lockstep-versioning)
+for more information.
+
 ### fetchTags
 
 Whether to fetch tags from the `origin` remote before versioning. Defaults to

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -34,6 +34,10 @@ For customizing the versioning process, see the
 [configuration options](/configuration/overview#commandversion) for the
 `version` command.
 
+By default, each package is versioned independently. If you want all packages
+in the workspace to always share the same version, enable
+[lockstep versioning](/commands/version#lockstep-versioning).
+
 ### Automatic Versioning
 
 To determine which packages to version and how, Melos performs the following

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -35,8 +35,8 @@ For customizing the versioning process, see the
 `version` command.
 
 By default, each package is versioned independently. If you want all packages
-in the workspace to always share the same version, enable
-[lockstep versioning](/commands/version#lockstep-versioning).
+in the workspace to always share the same version, enable the
+[fixed versioning mode](/commands/version#fixed-versioning-mode).
 
 ### Automatic Versioning
 

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -248,6 +248,10 @@
               "type": "boolean",
               "description": "Whether to generate and print a link to the prefilled release creation page for each package after versioning.\n\nDisabled by default."
             },
+            "lockstep": {
+              "type": "boolean",
+              "description": "Whether to version all packages in the workspace together. When enabled, every versioning run bumps all packages to the same new version, which is determined by the most significant change across the whole workspace.\n\nDisabled by default."
+            },
             "fetchTags": {
               "type": "boolean",
               "description": "Whether to fetch tags from the origin remote before versioning.\n\nDefaults to true."

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -248,9 +248,10 @@
               "type": "boolean",
               "description": "Whether to generate and print a link to the prefilled release creation page for each package after versioning.\n\nDisabled by default."
             },
-            "lockstep": {
-              "type": "boolean",
-              "description": "Whether to version all packages in the workspace together. When enabled, every versioning run bumps all packages to the same new version, which is determined by the most significant change across the whole workspace.\n\nDisabled by default."
+            "mode": {
+              "type": "string",
+              "enum": ["independent", "fixed"],
+              "description": "The mode in which packages in the workspace are versioned. In \"fixed\" mode (also known as lockstep versioning), every versioning run bumps all packages to the same new version, which is determined by the most significant change across the whole workspace.\n\nDefaults to \"independent\"."
             },
             "fetchTags": {
               "type": "boolean",

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -4,6 +4,7 @@ export 'src/commands/runner.dart'
     show
         BootstrapException,
         ListOutputKind,
+        LockstepVersionException,
         Melos,
         NoPackageFoundScriptException,
         NoScriptException,

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -1,10 +1,14 @@
 export 'src/command_configs/command_configs.dart'
-    show BootstrapCommandConfigs, CleanCommandConfigs, VersionCommandConfigs;
+    show
+        BootstrapCommandConfigs,
+        CleanCommandConfigs,
+        VersionCommandConfigs,
+        VersioningMode;
 export 'src/commands/runner.dart'
     show
         BootstrapException,
+        FixedVersioningException,
         ListOutputKind,
-        LockstepVersionException,
         Melos,
         NoPackageFoundScriptException,
         NoScriptException,

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -6,6 +6,18 @@ import '../common/validation.dart';
 import '../lifecycle_hooks/version.dart';
 import '../workspace_config.dart';
 
+/// The mode in which packages in the workspace are versioned.
+enum VersioningMode {
+  /// Each package is versioned independently, based on its own changes.
+  independent,
+
+  /// All packages in the workspace are versioned together (also known as
+  /// lockstep versioning): every versioning run bumps all packages to the
+  /// same new version, which is determined by the most significant change
+  /// across the whole workspace.
+  fixed,
+}
+
 /// Configurations for `melos version`.
 @immutable
 class VersionCommandConfigs {
@@ -19,7 +31,7 @@ class VersionCommandConfigs {
     this.commitBodyOnlyBreaking = true,
     this.updateGitTagRefs = false,
     this.releaseUrl = false,
-    this.lockstep = false,
+    this.mode = VersioningMode.independent,
     List<AggregateChangelogConfig>? aggregateChangelogs,
     this.fetchTags = true,
     this.hooks = VersionLifecycleHooks.empty,
@@ -67,11 +79,20 @@ class VersionCommandConfigs {
       map: yaml,
       path: 'command/version',
     );
-    final lockstep = assertKeyIsA<bool?>(
-      key: 'lockstep',
+    final modeName = assertKeyIsA<String?>(
+      key: 'mode',
       map: yaml,
       path: 'command/version',
     );
+    final mode = switch (modeName) {
+      null => VersioningMode.independent,
+      'independent' => VersioningMode.independent,
+      'fixed' => VersioningMode.fixed,
+      _ => throw MelosConfigException(
+        'The value at "command/version/mode" must be either "independent" '
+        'or "fixed" but got "$modeName".',
+      ),
+    };
 
     final workspaceChangelog = assertKeyIsA<bool?>(
       key: 'workspaceChangelog',
@@ -195,7 +216,7 @@ class VersionCommandConfigs {
       linkToCommits: linkToCommits ?? repositoryIsConfigured,
       updateGitTagRefs: updateGitTagRefs ?? false,
       releaseUrl: releaseUrl ?? false,
-      lockstep: lockstep ?? false,
+      mode: mode,
       aggregateChangelogs: aggregateChangelogs,
       fetchTags: fetchTags ?? true,
       hooks: hooks,
@@ -236,12 +257,13 @@ class VersionCommandConfigs {
   /// page for each package after versioning.
   final bool releaseUrl;
 
-  /// Whether all packages in the workspace are versioned together.
+  /// The mode in which packages in the workspace are versioned.
   ///
-  /// When enabled, every versioning run bumps all packages to the same new
-  /// version, which is determined by the most significant change across the
-  /// whole workspace.
-  final bool lockstep;
+  /// In [VersioningMode.fixed] mode, every versioning run bumps all packages
+  /// to the same new version, which is determined by the most significant
+  /// change across the whole workspace. Defaults to
+  /// [VersioningMode.independent].
+  final VersioningMode mode;
 
   /// A list of changelogs configurations that will be used to generate
   /// changelogs which describe the changes in multiple packages.
@@ -272,7 +294,7 @@ class VersionCommandConfigs {
       'includeCommitId': includeCommitId,
       'linkToCommits': linkToCommits,
       'updateGitTagRefs': updateGitTagRefs,
-      'lockstep': lockstep,
+      'mode': mode.name,
       'aggregateChangelogs': aggregateChangelogs
           .map((config) => config.toJson())
           .toList(),
@@ -296,7 +318,7 @@ class VersionCommandConfigs {
       other.linkToCommits == linkToCommits &&
       other.updateGitTagRefs == updateGitTagRefs &&
       other.releaseUrl == releaseUrl &&
-      other.lockstep == lockstep &&
+      other.mode == mode &&
       const DeepCollectionEquality().equals(
         other.aggregateChangelogs,
         aggregateChangelogs,
@@ -316,7 +338,7 @@ class VersionCommandConfigs {
       linkToCommits.hashCode ^
       updateGitTagRefs.hashCode ^
       releaseUrl.hashCode ^
-      lockstep.hashCode ^
+      mode.hashCode ^
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
       hooks.hashCode ^
@@ -334,7 +356,7 @@ VersionCommandConfigs(
   linkToCommits: $linkToCommits,
   updateGitTagRefs: $updateGitTagRefs,
   releaseUrl: $releaseUrl,
-  lockstep: $lockstep,
+  mode: ${mode.name},
   aggregateChangelogs: $aggregateChangelogs,
   fetchTags: $fetchTags,
   hooks: $hooks,

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -19,6 +19,7 @@ class VersionCommandConfigs {
     this.commitBodyOnlyBreaking = true,
     this.updateGitTagRefs = false,
     this.releaseUrl = false,
+    this.lockstep = false,
     List<AggregateChangelogConfig>? aggregateChangelogs,
     this.fetchTags = true,
     this.hooks = VersionLifecycleHooks.empty,
@@ -63,6 +64,11 @@ class VersionCommandConfigs {
     );
     final releaseUrl = assertKeyIsA<bool?>(
       key: 'releaseUrl',
+      map: yaml,
+      path: 'command/version',
+    );
+    final lockstep = assertKeyIsA<bool?>(
+      key: 'lockstep',
       map: yaml,
       path: 'command/version',
     );
@@ -189,6 +195,7 @@ class VersionCommandConfigs {
       linkToCommits: linkToCommits ?? repositoryIsConfigured,
       updateGitTagRefs: updateGitTagRefs ?? false,
       releaseUrl: releaseUrl ?? false,
+      lockstep: lockstep ?? false,
       aggregateChangelogs: aggregateChangelogs,
       fetchTags: fetchTags ?? true,
       hooks: hooks,
@@ -229,6 +236,13 @@ class VersionCommandConfigs {
   /// page for each package after versioning.
   final bool releaseUrl;
 
+  /// Whether all packages in the workspace are versioned together.
+  ///
+  /// When enabled, every versioning run bumps all packages to the same new
+  /// version, which is determined by the most significant change across the
+  /// whole workspace.
+  final bool lockstep;
+
   /// A list of changelogs configurations that will be used to generate
   /// changelogs which describe the changes in multiple packages.
   List<AggregateChangelogConfig> get aggregateChangelogs =>
@@ -258,6 +272,7 @@ class VersionCommandConfigs {
       'includeCommitId': includeCommitId,
       'linkToCommits': linkToCommits,
       'updateGitTagRefs': updateGitTagRefs,
+      'lockstep': lockstep,
       'aggregateChangelogs': aggregateChangelogs
           .map((config) => config.toJson())
           .toList(),
@@ -281,6 +296,7 @@ class VersionCommandConfigs {
       other.linkToCommits == linkToCommits &&
       other.updateGitTagRefs == updateGitTagRefs &&
       other.releaseUrl == releaseUrl &&
+      other.lockstep == lockstep &&
       const DeepCollectionEquality().equals(
         other.aggregateChangelogs,
         aggregateChangelogs,
@@ -300,6 +316,7 @@ class VersionCommandConfigs {
       linkToCommits.hashCode ^
       updateGitTagRefs.hashCode ^
       releaseUrl.hashCode ^
+      lockstep.hashCode ^
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
       hooks.hashCode ^
@@ -317,6 +334,7 @@ VersionCommandConfigs(
   linkToCommits: $linkToCommits,
   updateGitTagRefs: $updateGitTagRefs,
   releaseUrl: $releaseUrl,
+  lockstep: $lockstep,
   aggregateChangelogs: $aggregateChangelogs,
   fetchTags: $fetchTags,
   hooks: $hooks,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -380,6 +380,25 @@ mixin _VersionMixin on _RunMixin {
       pendingPackageUpdates.removeWhere((update) => update.package.isPrivate);
     }
 
+    // In lockstep mode all packages are bumped to the same new version, which
+    // is derived from the most significant pending change in the workspace.
+    if (workspace.config.commands.version.lockstep &&
+        pendingPackageUpdates.isNotEmpty) {
+      final lockstepUpdates = _lockstepPendingPackageUpdates(
+        workspace: workspace,
+        pendingPackageUpdates: pendingPackageUpdates,
+        packageCommits: packageCommits,
+        versionPrivatePackages: versionPrivatePackages,
+        asPrerelease: asPrerelease,
+        asStableRelease: asStableRelease,
+        preid: preid,
+        groupCommits: groupCommits,
+      );
+      pendingPackageUpdates
+        ..clear()
+        ..addAll(lockstepUpdates);
+    }
+
     if (pendingPackageUpdates.isEmpty) {
       logger.warning(
         'No packages were found that required versioning.',
@@ -505,6 +524,154 @@ mixin _VersionMixin on _RunMixin {
           '${AnsiStyles.bgBlack.gray(pendingPackageReleases)}',
         );
       }
+    }
+  }
+
+  /// Replaces the independently computed [pendingPackageUpdates] with one
+  /// update per (non-private) package in the workspace, all sharing a single
+  /// new lockstep version.
+  ///
+  /// The lockstep version is either the version requested with
+  /// `--manual-version` or the highest current version in the workspace bumped
+  /// by the most significant release type across all pending updates.
+  List<MelosPendingPackageUpdate> _lockstepPendingPackageUpdates({
+    required MelosWorkspace workspace,
+    required List<MelosPendingPackageUpdate> pendingPackageUpdates,
+    required Map<String, List<RichGitCommit>> packageCommits,
+    required bool versionPrivatePackages,
+    required bool asPrerelease,
+    required bool asStableRelease,
+    required String? preid,
+    required bool? groupCommits,
+  }) {
+    final packages = workspace.filteredPackages.values
+        .where((package) => versionPrivatePackages || !package.isPrivate)
+        .toList();
+    if (packages.isEmpty) {
+      return [];
+    }
+
+    // The highest current version in the workspace is used as the base for
+    // the next lockstep version, so that a workspace with (temporarily)
+    // diverged versions converges instead of producing downgrades.
+    final baseVersion = packages
+        .map((package) => package.version)
+        .reduce((a, b) => a >= b ? a : b);
+
+    final manualUpdates = pendingPackageUpdates
+        .where((update) => update.reason == PackageUpdateReason.manual)
+        .toList();
+
+    final Version lockstepVersion;
+    if (manualUpdates.isNotEmpty) {
+      final manualVersions = manualUpdates
+          .map((update) => update.nextVersion)
+          .toSet();
+      if (manualVersions.length > 1) {
+        throw LockstepVersionException(
+          'All packages share a single version in lockstep mode, but multiple '
+          'different versions were specified manually: '
+          '${manualVersions.join(', ')}.',
+        );
+      }
+      lockstepVersion = manualVersions.single;
+    } else {
+      final releaseType = pendingPackageUpdates
+          .map((update) => update.semverReleaseType)
+          .whereType<SemverReleaseType>()
+          .reduce((a, b) => a.index >= b.index ? a : b);
+      lockstepVersion = versioning.nextVersion(
+        baseVersion,
+        releaseType,
+        graduate: asStableRelease,
+        prerelease: asPrerelease,
+        preid: preid,
+      );
+    }
+
+    for (final package in packages) {
+      if (package.version > lockstepVersion) {
+        throw LockstepVersionException(
+          'The lockstep version $lockstepVersion is lower than the current '
+          'version ${package.version} of package "${package.name}".',
+        );
+      }
+    }
+
+    final existingUpdates = {
+      for (final update in pendingPackageUpdates) update.package.name: update,
+    };
+
+    return [
+      for (final package in packages)
+        _lockstepUpdateForPackage(
+          workspace: workspace,
+          package: package,
+          existingUpdate: existingUpdates[package.name],
+          commits: packageCommits[package.name] ?? const [],
+          lockstepVersion: lockstepVersion,
+          asPrerelease: asPrerelease,
+          asStableRelease: asStableRelease,
+          preid: preid,
+          groupCommits: groupCommits,
+        ),
+    ];
+  }
+
+  MelosPendingPackageUpdate _lockstepUpdateForPackage({
+    required MelosWorkspace workspace,
+    required Package package,
+    required MelosPendingPackageUpdate? existingUpdate,
+    required List<RichGitCommit> commits,
+    required Version lockstepVersion,
+    required bool asPrerelease,
+    required bool asStableRelease,
+    required String? preid,
+    required bool? groupCommits,
+  }) {
+    switch (existingUpdate?.reason) {
+      case PackageUpdateReason.manual:
+        return MelosPendingPackageUpdate.manual(
+          workspace,
+          package,
+          existingUpdate!.commits,
+          lockstepVersion,
+          userChangelogMessage: existingUpdate.userChangelogMessage,
+          groupCommits: existingUpdate.groupCommits,
+          logger: logger,
+        );
+      case PackageUpdateReason.commit:
+      case PackageUpdateReason.graduate:
+        return MelosPendingPackageUpdate(
+          workspace,
+          package,
+          existingUpdate!.commits,
+          existingUpdate.reason,
+          graduate: existingUpdate.graduate,
+          prerelease: existingUpdate.prerelease,
+          preid: existingUpdate.preid,
+          groupCommits: existingUpdate.groupCommits,
+          lockstepVersion: lockstepVersion,
+          logger: logger,
+        );
+      case PackageUpdateReason.dependency:
+      case PackageUpdateReason.lockstep:
+      case null:
+        // Packages without changes of their own are bumped purely to stay in
+        // lockstep with the rest of the workspace. This includes packages that
+        // would only have received a dependency bump in independent mode.
+        return MelosPendingPackageUpdate(
+          workspace,
+          package,
+          commits,
+          PackageUpdateReason.lockstep,
+          graduate: asStableRelease,
+          prerelease: asPrerelease,
+          preid: preid,
+          groupCommits: groupCommits,
+          lockstepVersion: lockstepVersion,
+          logger: logger,
+        );
     }
   }
 
@@ -756,6 +923,8 @@ mixin _VersionMixin on _RunMixin {
                           return 'dependency was updated';
                         case PackageUpdateReason.graduate:
                           return 'graduate to stable';
+                        case PackageUpdateReason.lockstep:
+                          return 'lockstep with workspace';
                       }
                     })(),
                   ),
@@ -1041,6 +1210,17 @@ mixin _VersionMixin on _RunMixin {
         },
       );
     });
+  }
+}
+
+class LockstepVersionException extends MelosException {
+  LockstepVersionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() {
+    return 'LockstepVersionException: $message';
   }
 }
 

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -384,10 +384,18 @@ mixin _VersionMixin on _RunMixin {
     // is derived from the most significant pending change in the workspace.
     if (workspace.config.commands.version.lockstep &&
         pendingPackageUpdates.isNotEmpty) {
+      if (!updateDependentsVersions) {
+        logger.warning(
+          'All packages are versioned together in lockstep mode, so '
+          'disabling dependent versioning has no effect.',
+        );
+      }
       final lockstepUpdates = _lockstepPendingPackageUpdates(
         workspace: workspace,
         pendingPackageUpdates: pendingPackageUpdates,
         packageCommits: packageCommits,
+        ignoredPackagesWithChanges: ignoredPackagesWithChanges,
+        manualVersions: manualVersions,
         versionPrivatePackages: versionPrivatePackages,
         asPrerelease: asPrerelease,
         asStableRelease: asStableRelease,
@@ -532,21 +540,44 @@ mixin _VersionMixin on _RunMixin {
   /// new lockstep version.
   ///
   /// The lockstep version is either the version requested with
-  /// `--manual-version` or the highest current version in the workspace bumped
-  /// by the most significant release type across all pending updates.
+  /// `--manual-version` (relative version changes are applied to the highest
+  /// current version in the workspace) or the highest current version in the
+  /// workspace bumped by the most significant release type across all pending
+  /// updates.
   List<MelosPendingPackageUpdate> _lockstepPendingPackageUpdates({
     required MelosWorkspace workspace,
     required List<MelosPendingPackageUpdate> pendingPackageUpdates,
     required Map<String, List<RichGitCommit>> packageCommits,
+    required Set<String> ignoredPackagesWithChanges,
+    required Map<String, versioning.ManualVersionChange> manualVersions,
     required bool versionPrivatePackages,
     required bool asPrerelease,
     required bool asStableRelease,
     required String? preid,
     required bool? groupCommits,
   }) {
-    final packages = workspace.filteredPackages.values
-        .where((package) => versionPrivatePackages || !package.isPrivate)
-        .toList();
+    final packages = workspace.filteredPackages.values.where((package) {
+      if (!versionPrivatePackages && package.isPrivate) {
+        return false;
+      }
+      // Packages that depend (directly or transitively) on an ignored package
+      // with pending changes are not versioned, since versioning them without
+      // also versioning the ignored dependency could produce a broken
+      // release. This mirrors the skip logic for independent versioning.
+      if (ignoredPackagesWithChanges.isNotEmpty) {
+        final unscoped = workspace.allPackages[package.name]!;
+        if (unscoped.allTransitiveDependenciesInWorkspace.keys.any(
+          ignoredPackagesWithChanges.contains,
+        )) {
+          logger.warning(
+            'Package "${package.name}" is not versioned in lockstep because '
+            'it depends on an ignored package that has pending changes.',
+          );
+          return false;
+        }
+      }
+      return true;
+    }).toList();
     if (packages.isEmpty) {
       return [];
     }
@@ -564,17 +595,22 @@ mixin _VersionMixin on _RunMixin {
 
     final Version lockstepVersion;
     if (manualUpdates.isNotEmpty) {
-      final manualVersions = manualUpdates
-          .map((update) => update.nextVersion)
-          .toSet();
-      if (manualVersions.length > 1) {
+      // Manual version changes are applied to the workspace base version
+      // rather than to the individually named packages, so that e.g.
+      // `melos version <package> patch` bumps the whole workspace one patch
+      // version, regardless of which package was named.
+      final manualTargets = {
+        for (final update in manualUpdates)
+          manualVersions[update.package.name]!(baseVersion),
+      };
+      if (manualTargets.length > 1) {
         throw LockstepVersionException(
           'All packages share a single version in lockstep mode, but multiple '
           'different versions were specified manually: '
-          '${manualVersions.join(', ')}.',
+          '${manualTargets.join(', ')}.',
         );
       }
-      lockstepVersion = manualVersions.single;
+      lockstepVersion = manualTargets.single;
     } else {
       final releaseType = pendingPackageUpdates
           .map((update) => update.semverReleaseType)
@@ -602,8 +638,28 @@ mixin _VersionMixin on _RunMixin {
       for (final update in pendingPackageUpdates) update.package.name: update,
     };
 
-    return [
-      for (final package in packages)
+    final updates = <MelosPendingPackageUpdate>[];
+    for (final package in packages) {
+      // Packages already at the lockstep version are left untouched, to avoid
+      // rewriting pubspecs and changelogs without an actual version change.
+      if (package.version == lockstepVersion) {
+        final existingUpdate = existingUpdates[package.name];
+        if (existingUpdate != null &&
+            existingUpdate.reason != PackageUpdateReason.dependency) {
+          logger.warning(
+            'Package "${package.name}" has pending changes but is already at '
+            'the lockstep version $lockstepVersion, so it is not versioned.',
+          );
+        } else {
+          logger.log(
+            'Package "${package.name}" is already at the lockstep version '
+            '$lockstepVersion, skipping.',
+          );
+        }
+        continue;
+      }
+
+      updates.add(
         _lockstepUpdateForPackage(
           workspace: workspace,
           package: package,
@@ -615,7 +671,9 @@ mixin _VersionMixin on _RunMixin {
           preid: preid,
           groupCommits: groupCommits,
         ),
-    ];
+      );
+    }
+    return updates;
   }
 
   MelosPendingPackageUpdate _lockstepUpdateForPackage({

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -380,13 +380,14 @@ mixin _VersionMixin on _RunMixin {
       pendingPackageUpdates.removeWhere((update) => update.package.isPrivate);
     }
 
-    // In lockstep mode all packages are bumped to the same new version, which
-    // is derived from the most significant pending change in the workspace.
-    if (workspace.config.commands.version.lockstep &&
+    // In fixed versioning mode all packages are bumped in lockstep to the
+    // same new version, which is derived from the most significant pending
+    // change in the workspace.
+    if (workspace.config.commands.version.mode == VersioningMode.fixed &&
         pendingPackageUpdates.isNotEmpty) {
       if (!updateDependentsVersions) {
         logger.warning(
-          'All packages are versioned together in lockstep mode, so '
+          'All packages are versioned together in fixed versioning mode, so '
           'disabling dependent versioning has no effect.',
         );
       }
@@ -604,9 +605,9 @@ mixin _VersionMixin on _RunMixin {
           manualVersions[update.package.name]!(baseVersion),
       };
       if (manualTargets.length > 1) {
-        throw LockstepVersionException(
-          'All packages share a single version in lockstep mode, but multiple '
-          'different versions were specified manually: '
+        throw FixedVersioningException(
+          'All packages share a single version in fixed versioning mode, but '
+          'multiple different versions were specified manually: '
           '${manualTargets.join(', ')}.',
         );
       }
@@ -627,7 +628,7 @@ mixin _VersionMixin on _RunMixin {
 
     for (final package in packages) {
       if (package.version > lockstepVersion) {
-        throw LockstepVersionException(
+        throw FixedVersioningException(
           'The lockstep version $lockstepVersion is lower than the current '
           'version ${package.version} of package "${package.name}".',
         );
@@ -1271,14 +1272,14 @@ mixin _VersionMixin on _RunMixin {
   }
 }
 
-class LockstepVersionException extends MelosException {
-  LockstepVersionException(this.message);
+class FixedVersioningException extends MelosException {
+  FixedVersioningException(this.message);
 
   final String message;
 
   @override
   String toString() {
-    return 'LockstepVersionException: $message';
+    return 'FixedVersioningException: $message';
   }
 }
 

--- a/packages/melos/lib/src/common/aggregate_changelog.dart
+++ b/packages/melos/lib/src/common/aggregate_changelog.dart
@@ -48,6 +48,9 @@ ${description?.withoutTrailing('\n') ?? ''}
     final dependencyOnlyPackages = pendingPackageUpdates.where(
       (update) => update.reason == PackageUpdateReason.dependency,
     );
+    final lockstepOnlyPackages = pendingPackageUpdates.where(
+      (update) => update.reason == PackageUpdateReason.lockstep,
+    );
     // Only packages graduated without any new commits since the last
     // pre-release are listed in the dedicated graduation section. Graduated
     // packages with new commits are treated like regular changes so their
@@ -61,11 +64,15 @@ ${description?.withoutTrailing('\n') ?? ''}
         .toSet();
     final packagesWithBreakingChanges = pendingPackageUpdates.where(
       (update) =>
-          !graduatedPackages.contains(update) && update.hasBreakingChanges,
+          !graduatedPackages.contains(update) &&
+          update.reason != PackageUpdateReason.lockstep &&
+          update.hasBreakingChanges,
     );
     final packagesWithOtherChanges = pendingPackageUpdates.where(
       (update) =>
-          !graduatedPackages.contains(update) && !update.hasBreakingChanges,
+          !graduatedPackages.contains(update) &&
+          update.reason != PackageUpdateReason.lockstep &&
+          !update.hasBreakingChanges,
     );
 
     body.writeln(_changelogFileHeader);
@@ -127,6 +134,20 @@ ${description?.withoutTrailing('\n') ?? ''}
       );
       body.writeln();
       for (final update in dependencyOnlyPackages) {
+        body.writeln(' - ${_packageVersionTitle(update)}');
+      }
+    }
+    if (lockstepOnlyPackages.isNotEmpty) {
+      body.writeln();
+      body.writeln('Packages versioned in lockstep only:');
+      body.writeln();
+      body.writeln(
+        '> Packages listed below have no changes of their own. Their versions '
+        'have been bumped to keep all packages in this workspace in '
+        'lockstep.',
+      );
+      body.writeln();
+      for (final update in lockstepOnlyPackages) {
         body.writeln(' - ${_packageVersionTitle(update)}');
       }
     }

--- a/packages/melos/lib/src/common/changelog.dart
+++ b/packages/melos/lib/src/common/changelog.dart
@@ -116,6 +116,14 @@ extension ChangelogStringBufferExtension on StringBuffer {
       writeln();
     }
 
+    if (update.reason == PackageUpdateReason.lockstep) {
+      // Lockstep version bump entry for a package without changes of its own.
+      writeln(
+        ' - Bump version to keep all packages in the workspace in lockstep.',
+      );
+      writeln();
+    }
+
     if (update.reason == PackageUpdateReason.graduate &&
         !update.hasChangelogCommits) {
       // Package graduation entry without any new commits since the last

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -25,6 +25,10 @@ enum PackageUpdateReason {
 
   /// Package is being graduated to a stable version from a prerelease.
   graduate,
+
+  /// Changed to keep the package version in lockstep with the other packages
+  /// in the workspace, even though the package has no changes of its own.
+  lockstep,
 }
 
 @immutable
@@ -39,6 +43,7 @@ class MelosPendingPackageUpdate {
     this.graduate = false,
     this.preid,
     this.groupCommits,
+    this.lockstepVersion,
   }) : manualVersion = null,
        userChangelogMessage = null;
 
@@ -53,7 +58,8 @@ class MelosPendingPackageUpdate {
   }) : reason = PackageUpdateReason.manual,
        prerelease = false,
        graduate = false,
-       preid = null;
+       preid = null,
+       lockstepVersion = null;
 
   /// Commits that triggered this pending update. Can be empty if
   /// [PackageUpdateReason] is [PackageUpdateReason.dependency].
@@ -84,6 +90,13 @@ class MelosPendingPackageUpdate {
   /// user.
   final Version? manualVersion;
 
+  /// The shared next version of all packages in the workspace, when lockstep
+  /// versioning is enabled.
+  ///
+  /// When set, this version is used instead of computing the next version
+  /// from this package's own commits.
+  final Version? lockstepVersion;
+
   /// Changelog message that the user provided directly.
   ///
   /// This is only used for manually versioned packages.
@@ -112,6 +125,7 @@ class MelosPendingPackageUpdate {
   /// Next pub version that will occur as part of this package update.
   Version get nextVersion {
     return manualVersion ??
+        lockstepVersion ??
         versioning.nextVersion(
           currentVersion,
           semverReleaseType!,
@@ -124,9 +138,11 @@ class MelosPendingPackageUpdate {
   /// Taking into account all the commits in this update, what is the highest
   /// [SemverReleaseType].
   ///
-  /// Is `null` for manually versioned packages.
+  /// Is `null` for manually versioned packages and packages that are only
+  /// versioned to keep the workspace in lockstep.
   SemverReleaseType? get semverReleaseType {
-    if (reason == PackageUpdateReason.manual) {
+    if (reason == PackageUpdateReason.manual ||
+        reason == PackageUpdateReason.lockstep) {
       return null;
     }
 

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1092,7 +1092,385 @@ dev_dependencies:
         },
       );
     });
+
+    group('lockstep', () {
+      Future<void> runGit(Directory workspaceDir, List<String> args) async {
+        final result = await Process.run(
+          'git',
+          [
+            '-c',
+            'user.name=Melos Test',
+            '-c',
+            'user.email=test@melos.invertase.dev',
+            ...args,
+          ],
+          workingDirectory: workspaceDir.path,
+        );
+        if (result.exitCode != 0) {
+          throw Exception(
+            'git ${args.join(' ')} failed:\n${result.stdout}\n${result.stderr}',
+          );
+        }
+      }
+
+      Future<void> commitPackageChange(
+        Directory workspaceDir,
+        String packageName,
+        String message,
+      ) async {
+        File(
+          p.join(workspaceDir.path, 'packages', packageName, 'change.txt'),
+        ).writeAsStringSync(message);
+        await runGit(workspaceDir, ['add', '.']);
+        await runGit(workspaceDir, ['commit', '-m', message]);
+      }
+
+      Version pubspecVersion(Directory workspaceDir, String packageName) {
+        return Pubspec.parse(
+          File(
+            p.join(workspaceDir.path, 'packages', packageName, 'pubspec.yaml'),
+          ).readAsStringSync(),
+        ).version!;
+      }
+
+      String packageChangelog(Directory workspaceDir, String packageName) {
+        return File(
+          p.join(workspaceDir.path, 'packages', packageName, 'CHANGELOG.md'),
+        ).readAsStringSync();
+      }
+
+      test(
+        'bumps all packages to the same version based on the most '
+        'significant change',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _lockstepWorkspaceConfigBuilder,
+            workspacePackages: ['a', 'b', 'c'],
+            useLocalTmpDirectory: true,
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec('b', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'c',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+          await runGit(workspaceDir, ['init']);
+          await runGit(workspaceDir, ['add', '.']);
+          await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+          await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
+          await commitPackageChange(workspaceDir, 'b', 'feat: a new feature');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // The feature in "b" causes a minor bump for the whole workspace.
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 1, 0));
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 1, 0));
+          expect(pubspecVersion(workspaceDir, 'c'), Version(1, 1, 0));
+
+          // The dependency constraint of "c" on "a" is updated to the
+          // lockstep version.
+          final pubspecC = Pubspec.parse(
+            File(
+              p.join(workspaceDir.path, 'packages/c/pubspec.yaml'),
+            ).readAsStringSync(),
+          );
+          final constraint =
+              (pubspecC.dependencies['a']! as HostedDependency).version;
+          expect(constraint, VersionConstraint.parse('^1.1.0'));
+
+          // Packages with changes get their regular changelog entries.
+          expect(packageChangelog(workspaceDir, 'a'), contains('a bug fix'));
+          expect(
+            packageChangelog(workspaceDir, 'b'),
+            contains('a new feature'),
+          );
+          // Packages without changes get a lockstep changelog entry.
+          expect(
+            packageChangelog(workspaceDir, 'c'),
+            contains(
+              'Bump version to keep all packages in the workspace in '
+              'lockstep.',
+            ),
+          );
+
+          // The workspace changelog lists the lockstep-only package in its
+          // own section.
+          final workspaceChangelog = File(
+            p.join(workspaceDir.path, 'CHANGELOG.md'),
+          ).readAsStringSync();
+          expect(
+            workspaceChangelog,
+            contains('Packages versioned in lockstep only:'),
+          );
+          expect(workspaceChangelog, contains('`c` - `v1.1.0`'));
+        },
+      );
+
+      test('a breaking change bumps all packages with a major '
+          'version', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0)),
+        );
+        await runGit(workspaceDir, ['init']);
+        await runGit(workspaceDir, ['add', '.']);
+        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await commitPackageChange(workspaceDir, 'a', 'feat!: breaking change');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(gitCommit: false, gitTag: false, force: true);
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(2, 0, 0));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(2, 0, 0));
+      });
+
+      test('diverged versions converge on the highest current '
+          'version', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(2, 3, 0)),
+        );
+        await runGit(workspaceDir, ['init']);
+        await runGit(workspaceDir, ['add', '.']);
+        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(gitCommit: false, gitTag: false, force: true);
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(2, 3, 1));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(2, 3, 1));
+      });
+
+      test('a manual version is applied to all packages', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(
+          gitCommit: false,
+          gitTag: false,
+          force: true,
+          // Skip changelogs to avoid the changelog message prompt for
+          // manually versioned packages without commits.
+          updateChangelog: false,
+          manualVersions: {
+            'a': ManualVersionChange(Version(2, 0, 0)),
+          },
+        );
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(2, 0, 0));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(2, 0, 0));
+      });
+
+      test('conflicting manual versions throw', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+
+        await expectLater(
+          melos.version(
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            updateChangelog: false,
+            manualVersions: {
+              'a': ManualVersionChange(Version(2, 0, 0)),
+              'b': ManualVersionChange(Version(3, 0, 0)),
+            },
+          ),
+          throwsA(isA<LockstepVersionException>()),
+        );
+      });
+
+      test('a manual version below a current version throws', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(3, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+
+        await expectLater(
+          melos.version(
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            updateChangelog: false,
+            manualVersions: {
+              'a': ManualVersionChange(Version(2, 0, 0)),
+            },
+          ),
+          throwsA(isA<LockstepVersionException>()),
+        );
+      });
+
+      test('private packages are not versioned by default', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0), publishTo: 'none'),
+        );
+        await runGit(workspaceDir, ['init']);
+        await runGit(workspaceDir, ['add', '.']);
+        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(gitCommit: false, gitTag: false, force: true);
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+      });
+
+      test('does nothing when there are no versionable changes', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(gitCommit: false, gitTag: false, force: true);
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 0));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        expect(
+          logger.output,
+          contains('No packages were found that required versioning.'),
+        );
+      });
+    });
   });
+}
+
+MelosWorkspaceConfig _lockstepWorkspaceConfigBuilder(String path) {
+  return MelosWorkspaceConfig(
+    path: path,
+    name: 'test_workspace',
+    packages: [
+      createGlob('packages/**', currentDirectoryPath: path),
+    ],
+    commands: const CommandConfigs(
+      version: VersionCommandConfigs(
+        fetchTags: false,
+        lockstep: true,
+      ),
+    ),
+  );
 }
 
 MelosWorkspaceConfig _workspaceConfigBuilder(String path) {

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1093,7 +1093,7 @@ dev_dependencies:
       );
     });
 
-    group('lockstep', () {
+    group('fixed mode', () {
       Future<void> runGit(Directory workspaceDir, List<String> args) async {
         final result = await Process.run(
           'git',
@@ -1146,7 +1146,7 @@ dev_dependencies:
         'significant change',
         () async {
           final workspaceDir = await createTemporaryWorkspace(
-            configBuilder: _lockstepWorkspaceConfigBuilder,
+            configBuilder: _fixedModeWorkspaceConfigBuilder,
             workspacePackages: ['a', 'b', 'c'],
             useLocalTmpDirectory: true,
           );
@@ -1230,7 +1230,7 @@ dev_dependencies:
       test('a breaking change bumps all packages with a major '
           'version', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1261,7 +1261,7 @@ dev_dependencies:
       test('diverged versions converge on the highest current '
           'version', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1291,7 +1291,7 @@ dev_dependencies:
 
       test('a manual version is applied to all packages', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1327,7 +1327,7 @@ dev_dependencies:
 
       test('conflicting manual versions throw', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1357,13 +1357,13 @@ dev_dependencies:
               'b': ManualVersionChange(Version(3, 0, 0)),
             },
           ),
-          throwsA(isA<LockstepVersionException>()),
+          throwsA(isA<FixedVersioningException>()),
         );
       });
 
       test('a manual version below a current version throws', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1392,13 +1392,13 @@ dev_dependencies:
               'a': ManualVersionChange(Version(2, 0, 0)),
             },
           ),
-          throwsA(isA<LockstepVersionException>()),
+          throwsA(isA<FixedVersioningException>()),
         );
       });
 
       test('private packages are not versioned by default', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1429,7 +1429,7 @@ dev_dependencies:
       test('a relative manual version is applied to the highest current '
           'version', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1468,7 +1468,7 @@ dev_dependencies:
       test('packages already at the lockstep version are left '
           'untouched', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1515,7 +1515,7 @@ dev_dependencies:
       test('does not version packages that depend on an ignored package '
           'with changes', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b', 'core'],
           useLocalTmpDirectory: true,
         );
@@ -1573,7 +1573,7 @@ dev_dependencies:
 
       test('does nothing when there are no versionable changes', () async {
         final workspaceDir = await createTemporaryWorkspace(
-          configBuilder: _lockstepWorkspaceConfigBuilder,
+          configBuilder: _fixedModeWorkspaceConfigBuilder,
           workspacePackages: ['a', 'b'],
           useLocalTmpDirectory: true,
         );
@@ -1604,7 +1604,7 @@ dev_dependencies:
   });
 }
 
-MelosWorkspaceConfig _lockstepWorkspaceConfigBuilder(String path) {
+MelosWorkspaceConfig _fixedModeWorkspaceConfigBuilder(String path) {
   return MelosWorkspaceConfig(
     path: path,
     name: 'test_workspace',
@@ -1614,7 +1614,7 @@ MelosWorkspaceConfig _lockstepWorkspaceConfigBuilder(String path) {
     commands: const CommandConfigs(
       version: VersionCommandConfigs(
         fetchTags: false,
-        lockstep: true,
+        mode: VersioningMode.fixed,
       ),
     ),
   );

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1102,6 +1102,8 @@ dev_dependencies:
             'user.name=Melos Test',
             '-c',
             'user.email=test@melos.invertase.dev',
+            '-c',
+            'commit.gpgsign=false',
             ...args,
           ],
           workingDirectory: workspaceDir.path,
@@ -1422,6 +1424,151 @@ dev_dependencies:
 
         expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
         expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+      });
+
+      test('a relative manual version is applied to the highest current '
+          'version', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(2, 3, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(
+          gitCommit: false,
+          gitTag: false,
+          force: true,
+          updateChangelog: false,
+          manualVersions: {
+            // Although "a" is at 1.0.0, the patch bump is applied to the
+            // highest current version in the workspace.
+            'a': ManualVersionChange.incrementBySemverReleaseType(
+              SemverReleaseType.patch,
+            ),
+          },
+        );
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(2, 3, 1));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(2, 3, 1));
+      });
+
+      test('packages already at the lockstep version are left '
+          'untouched', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(2, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(
+          gitCommit: false,
+          gitTag: false,
+          force: true,
+          updateChangelog: false,
+          manualVersions: {
+            'a': ManualVersionChange(Version(2, 0, 0)),
+          },
+        );
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(2, 0, 0));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(2, 0, 0));
+        expect(
+          logger.output,
+          contains('already at the lockstep version 2.0.0'),
+        );
+        // No changelog was written for the package that was already at the
+        // lockstep version.
+        expect(
+          File(
+            p.join(workspaceDir.path, 'packages/b/CHANGELOG.md'),
+          ).existsSync(),
+          isFalse,
+        );
+      });
+
+      test('does not version packages that depend on an ignored package '
+          'with changes', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _lockstepWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b', 'core'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('core', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'b',
+            version: Version(1, 0, 0),
+            dependencies: {
+              'core': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+            },
+          ),
+        );
+        await runGit(workspaceDir, ['init']);
+        await runGit(workspaceDir, ['add', '.']);
+        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
+        await commitPackageChange(workspaceDir, 'core', 'feat!: breaking');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(
+          packageFilters: PackageFilters(ignore: [Glob('core')]),
+          gitCommit: false,
+          gitTag: false,
+          force: true,
+        );
+
+        // Only "a" is versioned; "core" is ignored and "b" depends on the
+        // ignored "core" which has pending changes.
+        expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        expect(pubspecVersion(workspaceDir, 'core'), Version(1, 0, 0));
+        expect(
+          logger.output,
+          contains(
+            'Package "b" is not versioned in lockstep because it depends on '
+            'an ignored package that has pending changes.',
+          ),
+        );
       });
 
       test('does nothing when there are no versionable changes', () async {

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -75,7 +75,7 @@ void main() {
       expect(value.includeCommitId, false);
       expect(value.linkToCommits, false);
       expect(value.updateGitTagRefs, false);
-      expect(value.lockstep, false);
+      expect(value.mode, VersioningMode.independent);
       expect(value.includeDateInChangelogEntry, false);
       expect(value.groupChangelogEntriesByType, false);
       expect(value.aggregateChangelogs, [
@@ -131,10 +131,20 @@ void main() {
         );
       });
 
-      test('throws if lockstep is not a bool', () {
+      test('throws if mode is not a string', () {
         expect(
           () => VersionCommandConfigs.fromYaml(
-            const {'lockstep': 42},
+            const {'mode': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('throws if mode is not a valid mode', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'mode': 'lockstep'},
             workspacePath: '.',
           ),
           throwsMelosConfigException(),
@@ -151,7 +161,7 @@ void main() {
               'includeCommitId': true,
               'linkToCommits': true,
               'updateGitTagRefs': true,
-              'lockstep': true,
+              'mode': 'fixed',
               'workspaceChangelog': true,
               'changelogs': [
                 {
@@ -169,7 +179,7 @@ void main() {
             includeCommitId: true,
             linkToCommits: true,
             updateGitTagRefs: true,
-            lockstep: true,
+            mode: VersioningMode.fixed,
             aggregateChangelogs: [
               AggregateChangelogConfig.workspace(),
               AggregateChangelogConfig(

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -75,6 +75,7 @@ void main() {
       expect(value.includeCommitId, false);
       expect(value.linkToCommits, false);
       expect(value.updateGitTagRefs, false);
+      expect(value.lockstep, false);
       expect(value.includeDateInChangelogEntry, false);
       expect(value.groupChangelogEntriesByType, false);
       expect(value.aggregateChangelogs, [
@@ -130,6 +131,16 @@ void main() {
         );
       });
 
+      test('throws if lockstep is not a bool', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'lockstep': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
       test('can decode values', () {
         expect(
           VersionCommandConfigs.fromYaml(
@@ -140,6 +151,7 @@ void main() {
               'includeCommitId': true,
               'linkToCommits': true,
               'updateGitTagRefs': true,
+              'lockstep': true,
               'workspaceChangelog': true,
               'changelogs': [
                 {
@@ -157,6 +169,7 @@ void main() {
             includeCommitId: true,
             linkToCommits: true,
             updateGitTagRefs: true,
+            lockstep: true,
             aggregateChangelogs: [
               AggregateChangelogConfig.workspace(),
               AggregateChangelogConfig(


### PR DESCRIPTION
## Description

Adds an optional fixed versioning mode (lockstep) to `melos version`, matching the "fixed" release mode of Nx and Lerna in the JavaScript ecosystem.

```yaml
melos:
  command:
    version:
      mode: fixed  # defaults to: independent
```

When `mode: fixed` is enabled, every versioning run bumps all packages in the workspace to the same new version:

- The new version is based on the highest current version in the workspace, incremented by the most significant change found in any package (a breaking change anywhere causes a major bump for all packages, a feature a minor bump, otherwise patch).
- Packages with changes keep their regular conventional-commit changelog entries; packages without changes of their own get a changelog entry noting the bump keeps the workspace in lockstep, and are listed in a dedicated section of the workspace changelog.
- A manually specified version (`melos version <package> <version>`) is applied to all packages. Relative manual bumps (`patch`/`minor`/`major`/`build`) are applied to the highest current version in the workspace, regardless of which package was named. Conflicting manual versions for different packages, or a manual version below a current package version, fail with a `FixedVersioningException`.
- Packages already at the shared version are left untouched (no pubspec rewrite, no duplicate changelog entry).
- Packages that depend on an ignored package with pending changes are skipped with a warning, mirroring independent mode's safeguard against broken releases.
- Private packages are still skipped unless `--all` is passed, and dependency constraints on workspace packages are updated as usual. `--no-dependent-versions` has no effect in fixed mode and logs a warning.
- Defaults to `independent`, so existing workspaces are unaffected.

## Implementation notes

- The independent per-package pending updates are computed as before and then unified into one update per package sharing a single version, so all existing behavior (graduation, prereleases, changelog rendering, tagging, dependent constraint updates) is reused.
- New `PackageUpdateReason.lockstep` covers packages bumped only to stay in sync; it renders a dedicated changelog line and its own workspace changelog section.
- The new `VersioningMode` enum (`independent` | `fixed`) is exported from the public API and leaves room for future modes (e.g. grouped/linked versioning).
- Per-package git tags (`foo-v1.2.3`) are still created so change detection for future runs keeps working.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update (`docs/commands/version.mdx`, `docs/configuration/overview.mdx`, `docs/guides/automated-releases.mdx`, `melos.yaml.schema.json`)
- [x] ✅ Tests (config parsing/validation and 11 end-to-end fixed-mode versioning tests, including git-history-based bumps, manual versions, filters, and private packages)
