### PR TITLE
fix(version): honour `--yes` for manual versioning prompts

### DIFF
--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -300,19 +300,26 @@ mixin _VersionMixin on _RunMixin {
                 'Found commits for manually versioned package "$name".',
               );
 
-              promptForMessage = promptBool(
-                message:
-                    'Do you want to provide an additional changelog entry '
-                    'message?',
-                defaultsToWithoutPrompt: false,
-              );
+              // `--yes`/`force` skips all confirmation prompts, so never
+              // prompt here; fall back to the same default that is used when
+              // no prompt is possible.
+              promptForMessage =
+                  !force &&
+                  promptBool(
+                    message:
+                        'Do you want to provide an additional changelog entry '
+                        'message?',
+                    defaultsToWithoutPrompt: false,
+                  );
             }
 
             if (promptForMessage) {
-              userChangelogMessage = promptInput(
-                'Provide a changelog entry message',
-                defaultsTo: defaultUserChangelogMessage,
-              );
+              userChangelogMessage = force
+                  ? defaultUserChangelogMessage
+                  : promptInput(
+                      'Provide a changelog entry message',
+                      defaultsTo: defaultUserChangelogMessage,
+                    );
             }
           }
 

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -201,7 +201,14 @@ T _promptWithTerminal<T>(
   bool requirePrompt = false,
 }) {
   if (stdin.hasTerminal) {
-    return runPrompt();
+    try {
+      return runPrompt();
+    } on StdinException {
+      // `stdin.hasTerminal` can be true while stdin does not actually support
+      // the terminal operations the prompt requires (e.g. reading the echo
+      // mode fails with errno 19 in some sandboxed/piped environments).
+      // Degrade to the non-interactive behaviour below instead of crashing.
+    }
   }
 
   if (!requirePrompt) {

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1092,7 +1092,73 @@ dev_dependencies:
         },
       );
     });
+
+    // Regression test for: https://github.com/invertase/melos/issues/1057
+    test(
+      '--yes does not prompt when manually versioning with a changelog',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _workspaceConfigBuilder,
+          workspacePackages: ['a'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(0, 0, 1)),
+        );
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+
+        await melos.bootstrap();
+
+        // Any attempt to prompt in this zone blows up, so the test fails if
+        // `--yes` (`force`) is not honoured, regardless of whether a terminal
+        // is attached.
+        await IOOverrides.runZoned(
+          () => melos.version(
+            updateDependentsConstraints: false,
+            updateDependentsVersions: false,
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(0, 1, 0)),
+            },
+          ),
+          stdin: _ThrowingStdin.new,
+        );
+
+        final pubspec = Pubspec.parse(
+          File(
+            p.join(workspaceDir.path, 'packages/a/pubspec.yaml'),
+          ).readAsStringSync(),
+        );
+        expect(pubspec.version, Version(0, 1, 0));
+
+        final changelog = File(
+          p.join(workspaceDir.path, 'packages/a/CHANGELOG.md'),
+        ).readAsStringSync();
+        expect(changelog, contains('0.1.0'));
+        expect(changelog, contains('Bump "a" to `0.1.0`.'));
+      },
+    );
   });
+}
+
+/// A [Stdin] that claims to have a terminal but fails on every terminal
+/// operation, like the environments described in
+/// https://github.com/invertase/melos/issues/1057.
+class _ThrowingStdin implements Stdin {
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw StateError(
+    'Unexpected prompt: stdin was used while running with `--yes`.',
+  );
 }
 
 MelosWorkspaceConfig _workspaceConfigBuilder(String path) {

--- a/packages/melos/test/utils_test.dart
+++ b/packages/melos/test/utils_test.dart
@@ -277,4 +277,64 @@ void main() {
       });
     });
   });
+
+  group('prompts', () {
+    // Regression test for https://github.com/invertase/melos/issues/1057.
+    //
+    // Some environments report `stdin.hasTerminal == true` while any actual
+    // terminal operation (such as reading the echo mode) fails with a
+    // `StdinException`. Prompting must degrade to the non-interactive
+    // defaults in that case instead of crashing.
+    test('fall back to defaults when the terminal throws StdinException', () {
+      IOOverrides.runZoned(
+        () {
+          expect(
+            promptBool(defaultsToWithoutPrompt: true),
+            isTrue,
+          );
+          expect(
+            promptInput('message', defaultsTo: 'default'),
+            'default',
+          );
+          expect(
+            () => promptBool(requirePrompt: true),
+            throwsA(isA<PromptException>()),
+          );
+        },
+        stdin: _BrokenStdin.new,
+      );
+    });
+  });
+}
+
+class _BrokenStdin implements Stdin {
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  bool get echoMode => throw const StdinException(
+    'Error getting terminal echo mode, OS Error: Operation not supported by '
+    'device, errno = 19',
+  );
+
+  @override
+  set echoMode(bool value) => throw const StdinException(
+    'Error setting terminal echo mode, OS Error: Operation not supported by '
+    'device, errno = 19',
+  );
+
+  @override
+  bool get lineMode => throw const StdinException(
+    'Error getting terminal line mode, OS Error: Operation not supported by '
+    'device, errno = 19',
+  );
+
+  @override
+  set lineMode(bool value) => throw const StdinException(
+    'Error setting terminal line mode, OS Error: Operation not supported by '
+    'device, errno = 19',
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
Fixes #1057 — "Regression: `--yes` flag ignored in `melos version -V` (manual versioning), throws StdinException in non-interactive environments".

## Root cause

Two independent defects, both needed for the reported crash:

1. **`--yes` ignored (primary).** In `packages/melos/lib/src/commands/version.dart`, the manual-versioning changelog block called `promptBool(...)` (and then `promptInput(...)`) without consulting `force` — unlike the "shall I continue?" prompt further down, which correctly does `force || promptBool()`. `--yes` maps to `force`, so manual versioning prompted regardless.
2. **Prompt fallback never engaged (secondary).** `_promptWithTerminal` in `packages/melos/lib/src/common/utils.dart` only fell back to non-interactive defaults when `!stdin.hasTerminal`. In the reporter's environment `stdin.hasTerminal` is `true`, but `package:prompts` touching `stdin.echoMode` throws `StdinException` ("Operation not supported by device, errno = 19"), so melos crashed instead of degrading.

## Changes

- `version.dart`: gate `promptForMessage` and the follow-up `promptInput` on `!force`, preserving the existing no-prompt defaults (`defaultsToWithoutPrompt: false`, `defaultUserChangelogMessage`). With `--yes` the behaviour is now identical to running in a non-interactive shell.
- `utils.dart`: wrap `runPrompt()` in a `try`/`catch` on `StdinException` and fall through to the non-interactive path below it, so a terminal that claims to exist but does not work degrades rather than crashing.

## Tests

Two regression tests, each verified to **fail before** the corresponding fix and **pass after**:

- `test/commands/version_test.dart` — runs `melos.version(force: true, manualVersions: ...)` inside an `IOOverrides` zone with a `Stdin` that reports `hasTerminal == true` and throws on every operation, so any prompt attempt fails the test. Asserts the version bump and the default changelog entry are still written.
- `test/utils_test.dart` — `promptBool`/`promptInput` fall back to their defaults when the terminal throws `StdinException`, and still throw `PromptException` when `requirePrompt: true`.

Verified with Dart 3.12.2: `dart analyze packages/melos` clean, `dart format` clean, and `dart test test/commands/version_test.dart test/utils_test.dart` (from `packages/melos`) fully green (36 tests).

## Notes for review

- No CHANGELOG edit — melos generates changelogs via `melos version`.
- The full test suite beyond these two files was not run; the two affected suites pass in full.
