### PR TITLE
fix(publish): only report success when dart pub exits 0

### DIFF
--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -211,7 +211,7 @@ mixin _PublishMixin on _ExecMixin {
       },
     );
 
-    if (exitCode != 1) {
+    if (exitCode == 0) {
       if (!dryRun && gitTagVersion) {
         logger
           ..newLine()

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:melos/melos.dart';
 import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/command_configs/publish.dart';
@@ -207,6 +209,49 @@ void main() {
         },
       );
     });
+
+    test(
+      'does not print success when dart pub publish --dry-run fails',
+      () async {
+        final previousExitCode = exitCode;
+        addTearDown(() => exitCode = previousExitCode);
+
+        final logger = TestLogger();
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+          ),
+          workspacePackages: const ['collection'],
+        );
+
+        // collection is already on pub.dev at a much higher version, so
+        // dart pub publish --dry-run exits 65. Melos used to still print
+        // "validated successfully" because it only treated exitCode == 1
+        // as failure.
+        await createProject(
+          workspaceDir,
+          Pubspec('collection', version: Version(0, 1, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.publish(force: true);
+
+        final output = logger.output.normalizeLines();
+        expect(
+          output,
+          isNot(contains('All packages were validated successfully.')),
+        );
+        expect(exitCode, isNot(0));
+      },
+    );
 
     test('should support number as pre release version', () async {
       final logger = TestLogger();


### PR DESCRIPTION
## Description

`melos publish --dry-run` runs `dart pub publish --dry-run`. That can exit 65 for a backport / older patch even when a real publish would work (dart-lang/pub#4696). Exec prints FAILED, then we printed "All packages were validated successfully" because the check was `exitCode != 1`.

Only print success when the exec exit code is 0.

Fixes #966

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
