### PR TITLE
feat(version): avoid cascading releases when dependent constraints allow updated version

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -176,6 +176,18 @@ melos version --no-dependent-versions
 
 Use `--no-dependent-versions` to disable.
 
+## --[no-]smart-dependents
+
+Only bump dependent package versions and rewrite dependency constraints when declared SemVer constraints do not allow the updated version. When enabled, packages whose declared constraints already satisfy the new dependency version are skipped. (defaults to off)
+
+```bash
+melos version --smart-dependents
+```
+
+The default for this option can be configured in
+[command/version/smartDependents](/configuration/overview#smartdependents)
+in your root `pubspec.yaml` file.
+
 ## --all (-a)
 
 Version private packages that are skipped by default.

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -548,6 +548,20 @@ melos:
       updateGitTagRefs: true
 ```
 
+### smartDependents
+
+Whether to only bump dependent package versions and update constraints when
+declared SemVer constraints do not allow the updated version. When enabled,
+packages whose declared constraints already satisfy the new dependency version
+are skipped. Defaults to `false`.
+
+```yaml
+melos:
+  command:
+    version:
+      smartDependents: true
+```
+
 ### releaseUrl
 
 Whether to generate and print a link to the prefilled release creation page for

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -248,6 +248,10 @@
               "type": "boolean",
               "description": "Whether to generate and print a link to the prefilled release creation page for each package after versioning.\n\nDisabled by default."
             },
+            "smartDependents": {
+              "type": "boolean",
+              "description": "Whether to only bump dependent versions and update constraints when declared SemVer constraints do not allow the updated version.\n\nDisabled by default."
+            },
             "mode": {
               "type": "string",
               "enum": ["independent", "fixed"],

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -37,6 +37,7 @@ class VersionCommandConfigs {
     this.hooks = VersionLifecycleHooks.empty,
     this.includeDateInChangelogEntry = false,
     this.groupChangelogEntriesByType = false,
+    this.smartDependents = false,
   }) : _aggregateChangelogs = aggregateChangelogs;
 
   factory VersionCommandConfigs.fromYaml(
@@ -76,6 +77,11 @@ class VersionCommandConfigs {
     );
     final releaseUrl = assertKeyIsA<bool?>(
       key: 'releaseUrl',
+      map: yaml,
+      path: 'command/version',
+    );
+    final smartDependents = assertKeyIsA<bool?>(
+      key: 'smartDependents',
       map: yaml,
       path: 'command/version',
     );
@@ -222,6 +228,7 @@ class VersionCommandConfigs {
       hooks: hooks,
       includeDateInChangelogEntry: includeDate ?? false,
       groupChangelogEntriesByType: groupByType ?? false,
+      smartDependents: smartDependents ?? false,
     );
   }
 
@@ -256,6 +263,10 @@ class VersionCommandConfigs {
   /// Whether to generate and print a link to the prefilled release creation
   /// page for each package after versioning.
   final bool releaseUrl;
+
+  /// Whether to only bump dependent versions and update constraints when
+  /// declared SemVer constraints do not allow the updated version.
+  final bool smartDependents;
 
   /// The mode in which packages in the workspace are versioned.
   ///
@@ -294,6 +305,7 @@ class VersionCommandConfigs {
       'includeCommitId': includeCommitId,
       'linkToCommits': linkToCommits,
       'updateGitTagRefs': updateGitTagRefs,
+      'smartDependents': smartDependents,
       'mode': mode.name,
       'aggregateChangelogs': aggregateChangelogs
           .map((config) => config.toJson())
@@ -318,6 +330,7 @@ class VersionCommandConfigs {
       other.linkToCommits == linkToCommits &&
       other.updateGitTagRefs == updateGitTagRefs &&
       other.releaseUrl == releaseUrl &&
+      other.smartDependents == smartDependents &&
       other.mode == mode &&
       const DeepCollectionEquality().equals(
         other.aggregateChangelogs,
@@ -338,6 +351,7 @@ class VersionCommandConfigs {
       linkToCommits.hashCode ^
       updateGitTagRefs.hashCode ^
       releaseUrl.hashCode ^
+      smartDependents.hashCode ^
       mode.hashCode ^
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
@@ -356,6 +370,7 @@ VersionCommandConfigs(
   linkToCommits: $linkToCommits,
   updateGitTagRefs: $updateGitTagRefs,
   releaseUrl: $releaseUrl,
+  smartDependents: $smartDependents,
   mode: ${mode.name},
   aggregateChangelogs: $aggregateChangelogs,
   fetchTags: $fetchTags,

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -182,6 +182,7 @@ class VersionCommand extends MelosCommand {
     final commit = argResults!['git-commit-version'] as bool;
     final releaseUrl = argResults!.optional('release-url') as bool?;
     final groupCommits = argResults!.optional('group-commits') as bool?;
+    final smartDependents = argResults!.optional('smart-dependents') as bool?;
     final changelog = argResults!['changelog'] as bool;
     final commitMessage = (argResults!['message'] as String?)?.replaceAll(
       r'\n',
@@ -218,6 +219,8 @@ class VersionCommand extends MelosCommand {
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: false,
+        smartDependents:
+            smartDependents ?? config.commands.version.smartDependents,
         message: commitMessage,
       );
     } else {
@@ -263,8 +266,7 @@ class VersionCommand extends MelosCommand {
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
         smartDependents:
-            (argResults?['smart-dependents'] as bool?) ??
-            config.commands.version.smartDependents,
+            smartDependents ?? config.commands.version.smartDependents,
         preid: preid,
         dependentPreid: dependentPreid,
         asPrerelease: asPrerelease,

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -66,6 +66,12 @@ class VersionCommand extends MelosCommand {
           'with "--dependent-constraints" enabled.',
     );
     argParser.addFlag(
+      'smart-dependents',
+      help:
+          'Only bump dependent versions and rewrite constraints when declared '
+          'SemVer constraints do not allow the updated version.',
+    );
+    argParser.addFlag(
       'git-tag-version',
       abbr: 't',
       defaultsTo: true,
@@ -256,6 +262,9 @@ class VersionCommand extends MelosCommand {
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
+        smartDependents:
+            (argResults?['smart-dependents'] as bool?) ??
+            config.commands.version.smartDependents,
         preid: preid,
         dependentPreid: dependentPreid,
         asPrerelease: asPrerelease,

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -22,6 +22,7 @@ mixin _VersionMixin on _RunMixin {
     String? preid,
     String? dependentPreid,
     bool versionPrivatePackages = false,
+    bool? smartDependents,
     Map<String, versioning.ManualVersionChange> manualVersions = const {},
   }) async {
     if (asPrerelease && asStableRelease) {
@@ -60,6 +61,7 @@ mixin _VersionMixin on _RunMixin {
         updateChangelog: updateChangelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
+        smartDependents: smartDependents,
         gitTag: gitTag,
         gitCommit: gitCommit,
         releaseUrl: releaseUrl,
@@ -84,6 +86,7 @@ mixin _VersionMixin on _RunMixin {
     bool updateChangelog = true,
     bool updateDependentsConstraints = true,
     bool updateDependentsVersions = true,
+    bool? smartDependents,
     bool gitTag = true,
     bool gitCommit = true,
     bool? releaseUrl,
@@ -97,6 +100,8 @@ mixin _VersionMixin on _RunMixin {
     bool versionPrivatePackages = false,
     Map<String, versioning.ManualVersionChange> manualVersions = const {},
   }) async {
+    final isSmartDependents =
+        smartDependents ?? workspace.config.commands.version.smartDependents;
     if (workspace.config.commands.version.branch != null) {
       final currentBranchName = await gitGetCurrentBranchName(
         workingDirectory: workspace.path,
@@ -211,11 +216,6 @@ mixin _VersionMixin on _RunMixin {
         }
       }
     }
-    final packagesToVersion = {
-      ...packagesToManuallyVersion,
-      ...packagesToAutoVersion,
-    };
-    final dependentPackagesToVersion = <Package>{};
     final pendingPackageUpdates = <MelosPendingPackageUpdate>[];
 
     if (asStableRelease) {
@@ -236,43 +236,7 @@ mixin _VersionMixin on _RunMixin {
             logger: logger,
           ),
         );
-
-        final packageUnscoped = workspace.allPackages[package.name]!;
-        dependentPackagesToVersion.addAll(
-          packageUnscoped.dependentsInWorkspace.values.where(
-            (p) => workspace.filteredPackages[p.name] != null,
-          ),
-        );
       }
-    }
-
-    for (final package in packagesToVersion) {
-      final packageUnscoped = workspace.allPackages[package.name]!;
-      dependentPackagesToVersion.addAll(
-        packageUnscoped.dependentsInWorkspace.values.where(
-          (p) => workspace.filteredPackages[p.name] != null,
-        ),
-      );
-    }
-
-    // Transitively collect dependents in the workspace until no more are
-    // added. Ignored packages are excluded and not traversed through, so
-    // packages that would only need a version bump via an ignored
-    // intermediate are also excluded.
-    // This runs once after both the graduate and commit loops so that
-    // dependents of graduated packages are also traversed.
-    var packagesAdded = 1;
-    while (packagesAdded != 0) {
-      final packagesCountBefore = dependentPackagesToVersion.length;
-      final packages = <Package>{...dependentPackagesToVersion};
-      for (final dependentPackage in packages) {
-        dependentPackagesToVersion.addAll(
-          dependentPackage.dependentsInWorkspace.values.where(
-            (p) => workspace.filteredPackages[p.name] != null,
-          ),
-        );
-      }
-      packagesAdded = dependentPackagesToVersion.length - packagesCountBefore;
     }
 
     pendingPackageUpdates.addAll(
@@ -352,33 +316,103 @@ mixin _VersionMixin on _RunMixin {
       ),
     );
 
-    for (final package in dependentPackagesToVersion) {
-      // If updateDependentsVersions is set to false, we do not perform updates.
-      if (!updateDependentsVersions) {
-        break;
-      }
-
-      final packageHasPendingUpdate = pendingPackageUpdates.any(
-        (packageToVersion) => packageToVersion.package.name == package.name,
-      );
-
-      if (!packagesToVersion.contains(package) && !packageHasPendingUpdate) {
-        pendingPackageUpdates.add(
-          MelosPendingPackageUpdate(
-            workspace,
-            package,
-            const [],
-            PackageUpdateReason.dependency,
-            // Dependent packages that should have graduated would have already
-            // gone through graduation logic above. So graduate should use the
-            // default of 'false' here so as not to graduate anything that was
-            // specifically excluded.
-            // graduate: false,
-            prerelease: asPrerelease,
-            preid: dependentPreid ?? preid,
-            logger: logger,
-          ),
+    // Transitively collect dependents in the workspace that need to be
+    // versioned.
+    if (updateDependentsVersions) {
+      if (isSmartDependents) {
+        final packagesToCheck = List<MelosPendingPackageUpdate>.from(
+          pendingPackageUpdates,
         );
+        final processedPackages = <String>{};
+
+        while (packagesToCheck.isNotEmpty) {
+          final currentUpdate = packagesToCheck.removeAt(0);
+          if (!processedPackages.add(currentUpdate.package.name)) {
+            continue;
+          }
+
+          final packageUnscoped =
+              workspace.allPackages[currentUpdate.package.name]!;
+          for (final dependent
+              in packageUnscoped.dependentsInWorkspace.values) {
+            if (workspace.filteredPackages[dependent.name] == null) {
+              continue;
+            }
+
+            final alreadyPending = pendingPackageUpdates.any(
+              (u) => u.package.name == dependent.name,
+            );
+            if (alreadyPending) {
+              continue;
+            }
+
+            final allows = _dependencyConstraintAllowsNextVersion(
+              dependent: dependent,
+              dependencyName: currentUpdate.package.name,
+              nextVersion: currentUpdate.nextVersion,
+            );
+
+            if (!allows) {
+              final dependentUpdate = MelosPendingPackageUpdate(
+                workspace,
+                dependent,
+                const [],
+                PackageUpdateReason.dependency,
+                prerelease: asPrerelease,
+                preid: dependentPreid ?? preid,
+                logger: logger,
+              );
+              pendingPackageUpdates.add(dependentUpdate);
+              packagesToCheck.add(dependentUpdate);
+            }
+          }
+        }
+      } else {
+        // Legacy behavior: collect all dependents unconditionally.
+        final dependentPackagesToVersion = <Package>{};
+        for (final update in pendingPackageUpdates) {
+          final packageUnscoped = workspace.allPackages[update.package.name]!;
+          dependentPackagesToVersion.addAll(
+            packageUnscoped.dependentsInWorkspace.values.where(
+              (p) => workspace.filteredPackages[p.name] != null,
+            ),
+          );
+        }
+
+        var packagesAdded = 1;
+        while (packagesAdded != 0) {
+          final packagesCountBefore = dependentPackagesToVersion.length;
+          final packages = <Package>{...dependentPackagesToVersion};
+          for (final dependentPackage in packages) {
+            dependentPackagesToVersion.addAll(
+              dependentPackage.dependentsInWorkspace.values.where(
+                (p) => workspace.filteredPackages[p.name] != null,
+              ),
+            );
+          }
+          packagesAdded =
+              dependentPackagesToVersion.length - packagesCountBefore;
+        }
+
+        for (final package in dependentPackagesToVersion) {
+          final packageHasPendingUpdate = pendingPackageUpdates.any(
+            (packageToVersion) => packageToVersion.package.name == package.name,
+          );
+
+          if (!packageHasPendingUpdate) {
+            pendingPackageUpdates.add(
+              MelosPendingPackageUpdate(
+                workspace,
+                package,
+                const [],
+                PackageUpdateReason.dependency,
+                prerelease: asPrerelease,
+                preid: dependentPreid ?? preid,
+                logger: logger,
+              ),
+            );
+          }
+        }
       }
     }
 
@@ -466,6 +500,7 @@ mixin _VersionMixin on _RunMixin {
       updateDependentsConstraints: updateDependentsConstraints,
       updateChangelog: updateChangelog,
       workspace: workspace,
+      smartDependents: isSmartDependents,
     );
 
     final preCommit = workspace.config.commands.version.hooks.preCommit;
@@ -753,18 +788,57 @@ mixin _VersionMixin on _RunMixin {
     await writeTextFileAsync(pubspec, editor.toString());
   }
 
+  bool _dependencyConstraintAllowsNextVersion({
+    required Package dependent,
+    required String dependencyName,
+    required Version nextVersion,
+  }) {
+    final normalDependency = dependent.pubspec.dependencies[dependencyName];
+    final devDependency = dependent.pubspec.devDependencies[dependencyName];
+    final gitTagDependency = dependent.rawPubspecFileContent != null
+        ? GitTagPatternDependency.fromRawCommit(
+            pubspec: dependent.rawPubspecFileContent!,
+            name: dependencyName,
+          )
+        : null;
+    final dependency = gitTagDependency ?? normalDependency ?? devDependency;
+
+    if (gitTagDependency != null) {
+      return gitTagDependency.version == nextVersion;
+    }
+
+    if (dependency == null) {
+      return true;
+    }
+
+    final constraint = dependency.versionConstraint;
+    if (constraint == null) {
+      return true;
+    }
+
+    if (constraint is Version) {
+      return constraint == nextVersion;
+    }
+
+    return constraint.allows(nextVersion);
+  }
+
   Future<void> _setDependencyVersionForDependentPackage(
     Package package,
     String dependencyName,
     Version version,
-    MelosWorkspace workspace,
-  ) {
+    MelosWorkspace workspace, {
+    bool smartDependents = false,
+  }) {
     final currentVersionConstraint =
         (package.pubspec.dependencies[dependencyName] ??
                 package.pubspec.devDependencies[dependencyName])
             ?.versionConstraint;
     final hasExactVersionConstraint = currentVersionConstraint is Version;
     if (hasExactVersionConstraint) {
+      if (currentVersionConstraint == version) {
+        return Future.value();
+      }
       // If the package currently has an exact version constraint, we respect
       // that and replace it with an exact version constraint for the new
       // version.
@@ -774,6 +848,23 @@ mixin _VersionMixin on _RunMixin {
         version,
         workspace,
       );
+    }
+
+    if (smartDependents) {
+      final gitTagDependency = package.rawPubspecFileContent != null
+          ? GitTagPatternDependency.fromRawCommit(
+              pubspec: package.rawPubspecFileContent!,
+              name: dependencyName,
+            )
+          : null;
+      if (gitTagDependency != null) {
+        if (gitTagDependency.version == version) {
+          return Future.value();
+        }
+      } else if (currentVersionConstraint != null &&
+          currentVersionConstraint.allows(version)) {
+        return Future.value();
+      }
     }
 
     // By default dependency constraint using caret syntax to ensure the range
@@ -1008,6 +1099,7 @@ mixin _VersionMixin on _RunMixin {
     required bool updateDependentsConstraints,
     required bool updateChangelog,
     required MelosWorkspace workspace,
+    bool smartDependents = false,
   }) async {
     // Note: not pooling & parallelizing rights to avoid possible file
     // contention.
@@ -1040,6 +1132,7 @@ mixin _VersionMixin on _RunMixin {
                   ? pendingPackageUpdate.package.version
                   : pendingPackageUpdate.nextVersion,
               workspace,
+              smartDependents: smartDependents,
             );
           },
         );

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -850,21 +850,13 @@ mixin _VersionMixin on _RunMixin {
       );
     }
 
-    if (smartDependents) {
-      final gitTagDependency = package.rawPubspecFileContent != null
-          ? GitTagPatternDependency.fromRawCommit(
-              pubspec: package.rawPubspecFileContent!,
-              name: dependencyName,
-            )
-          : null;
-      if (gitTagDependency != null) {
-        if (gitTagDependency.version == version) {
-          return Future.value();
-        }
-      } else if (currentVersionConstraint != null &&
-          currentVersionConstraint.allows(version)) {
-        return Future.value();
-      }
+    if (smartDependents &&
+        _dependencyConstraintAllowsNextVersion(
+          dependent: package,
+          dependencyName: dependencyName,
+          nextVersion: version,
+        )) {
+      return Future.value();
     }
 
     // By default dependency constraint using caret syntax to ensure the range

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -320,99 +320,21 @@ mixin _VersionMixin on _RunMixin {
     // versioned.
     if (updateDependentsVersions) {
       if (isSmartDependents) {
-        final packagesToCheck = List<MelosPendingPackageUpdate>.from(
-          pendingPackageUpdates,
+        _collectSmartDependentUpdates(
+          workspace: workspace,
+          pendingPackageUpdates: pendingPackageUpdates,
+          asPrerelease: asPrerelease,
+          preid: preid,
+          dependentPreid: dependentPreid,
         );
-        final processedPackages = <String>{};
-
-        while (packagesToCheck.isNotEmpty) {
-          final currentUpdate = packagesToCheck.removeAt(0);
-          if (!processedPackages.add(currentUpdate.package.name)) {
-            continue;
-          }
-
-          final packageUnscoped =
-              workspace.allPackages[currentUpdate.package.name]!;
-          for (final dependent
-              in packageUnscoped.dependentsInWorkspace.values) {
-            if (workspace.filteredPackages[dependent.name] == null) {
-              continue;
-            }
-
-            final alreadyPending = pendingPackageUpdates.any(
-              (u) => u.package.name == dependent.name,
-            );
-            if (alreadyPending) {
-              continue;
-            }
-
-            final allows = _dependencyConstraintAllowsNextVersion(
-              dependent: dependent,
-              dependencyName: currentUpdate.package.name,
-              nextVersion: currentUpdate.nextVersion,
-            );
-
-            if (!allows) {
-              final dependentUpdate = MelosPendingPackageUpdate(
-                workspace,
-                dependent,
-                const [],
-                PackageUpdateReason.dependency,
-                prerelease: asPrerelease,
-                preid: dependentPreid ?? preid,
-                logger: logger,
-              );
-              pendingPackageUpdates.add(dependentUpdate);
-              packagesToCheck.add(dependentUpdate);
-            }
-          }
-        }
       } else {
-        // Legacy behavior: collect all dependents unconditionally.
-        final dependentPackagesToVersion = <Package>{};
-        for (final update in pendingPackageUpdates) {
-          final packageUnscoped = workspace.allPackages[update.package.name]!;
-          dependentPackagesToVersion.addAll(
-            packageUnscoped.dependentsInWorkspace.values.where(
-              (p) => workspace.filteredPackages[p.name] != null,
-            ),
-          );
-        }
-
-        var packagesAdded = 1;
-        while (packagesAdded != 0) {
-          final packagesCountBefore = dependentPackagesToVersion.length;
-          final packages = <Package>{...dependentPackagesToVersion};
-          for (final dependentPackage in packages) {
-            dependentPackagesToVersion.addAll(
-              dependentPackage.dependentsInWorkspace.values.where(
-                (p) => workspace.filteredPackages[p.name] != null,
-              ),
-            );
-          }
-          packagesAdded =
-              dependentPackagesToVersion.length - packagesCountBefore;
-        }
-
-        for (final package in dependentPackagesToVersion) {
-          final packageHasPendingUpdate = pendingPackageUpdates.any(
-            (packageToVersion) => packageToVersion.package.name == package.name,
-          );
-
-          if (!packageHasPendingUpdate) {
-            pendingPackageUpdates.add(
-              MelosPendingPackageUpdate(
-                workspace,
-                package,
-                const [],
-                PackageUpdateReason.dependency,
-                prerelease: asPrerelease,
-                preid: dependentPreid ?? preid,
-                logger: logger,
-              ),
-            );
-          }
-        }
+        _collectLegacyDependentUpdates(
+          workspace: workspace,
+          pendingPackageUpdates: pendingPackageUpdates,
+          asPrerelease: asPrerelease,
+          preid: preid,
+          dependentPreid: dependentPreid,
+        );
       }
     }
 
@@ -773,6 +695,113 @@ mixin _VersionMixin on _RunMixin {
           lockstepVersion: lockstepVersion,
           logger: logger,
         );
+    }
+  }
+
+  void _collectSmartDependentUpdates({
+    required MelosWorkspace workspace,
+    required List<MelosPendingPackageUpdate> pendingPackageUpdates,
+    required bool asPrerelease,
+    required String? preid,
+    required String? dependentPreid,
+  }) {
+    final packagesToCheck = List<MelosPendingPackageUpdate>.from(
+      pendingPackageUpdates,
+    );
+    final processedPackages = <String>{};
+
+    while (packagesToCheck.isNotEmpty) {
+      final currentUpdate = packagesToCheck.removeAt(0);
+      if (!processedPackages.add(currentUpdate.package.name)) {
+        continue;
+      }
+
+      final packageUnscoped =
+          workspace.allPackages[currentUpdate.package.name]!;
+      for (final dependent in packageUnscoped.dependentsInWorkspace.values) {
+        if (workspace.filteredPackages[dependent.name] == null) {
+          continue;
+        }
+
+        final alreadyPending = pendingPackageUpdates.any(
+          (u) => u.package.name == dependent.name,
+        );
+        if (alreadyPending) {
+          continue;
+        }
+
+        final allows = _dependencyConstraintAllowsNextVersion(
+          dependent: dependent,
+          dependencyName: currentUpdate.package.name,
+          nextVersion: currentUpdate.nextVersion,
+        );
+
+        if (!allows) {
+          final dependentUpdate = MelosPendingPackageUpdate(
+            workspace,
+            dependent,
+            const [],
+            PackageUpdateReason.dependency,
+            prerelease: asPrerelease,
+            preid: dependentPreid ?? preid,
+            logger: logger,
+          );
+          pendingPackageUpdates.add(dependentUpdate);
+          packagesToCheck.add(dependentUpdate);
+        }
+      }
+    }
+  }
+
+  void _collectLegacyDependentUpdates({
+    required MelosWorkspace workspace,
+    required List<MelosPendingPackageUpdate> pendingPackageUpdates,
+    required bool asPrerelease,
+    required String? preid,
+    required String? dependentPreid,
+  }) {
+    final dependentPackagesToVersion = <Package>{};
+    for (final update in pendingPackageUpdates) {
+      final packageUnscoped = workspace.allPackages[update.package.name]!;
+      dependentPackagesToVersion.addAll(
+        packageUnscoped.dependentsInWorkspace.values.where(
+          (p) => workspace.filteredPackages[p.name] != null,
+        ),
+      );
+    }
+
+    var packagesAdded = 1;
+    while (packagesAdded != 0) {
+      final packagesCountBefore = dependentPackagesToVersion.length;
+      final packages = <Package>{...dependentPackagesToVersion};
+      for (final dependentPackage in packages) {
+        dependentPackagesToVersion.addAll(
+          dependentPackage.dependentsInWorkspace.values.where(
+            (p) => workspace.filteredPackages[p.name] != null,
+          ),
+        );
+      }
+      packagesAdded = dependentPackagesToVersion.length - packagesCountBefore;
+    }
+
+    for (final package in dependentPackagesToVersion) {
+      final packageHasPendingUpdate = pendingPackageUpdates.any(
+        (packageToVersion) => packageToVersion.package.name == package.name,
+      );
+
+      if (!packageHasPendingUpdate) {
+        pendingPackageUpdates.add(
+          MelosPendingPackageUpdate(
+            workspace,
+            package,
+            const [],
+            PackageUpdateReason.dependency,
+            prerelease: asPrerelease,
+            preid: dependentPreid ?? preid,
+            logger: logger,
+          ),
+        );
+      }
     }
   }
 

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1959,6 +1959,152 @@ dev_dependencies:
           expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
         },
       );
+
+      test(
+        'CLI runner overrides smartDependents config with '
+        '--no-smart-dependents',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _smartDependentsWorkspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final runner = MelosCommandRunner(config);
+
+          await runner.run([
+            'version',
+            '--yes',
+            '--no-git-tag-version',
+            '--no-git-commit-version',
+            '--no-smart-dependents',
+            '--all',
+            '-V',
+            'a:1.0.1',
+          ]);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          // Explicit --no-smart-dependents forces legacy cascade bump.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+        },
+      );
+
+      test(
+        'CLI runner enables smartDependents with --smart-dependents flag',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _workspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final runner = MelosCommandRunner(config);
+
+          await runner.run([
+            'version',
+            '--yes',
+            '--no-git-tag-version',
+            '--no-git-commit-version',
+            '--smart-dependents',
+            '--all',
+            '-V',
+            'a:1.0.1',
+          ]);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          // Explicit --smart-dependents skips bump on compatible patch.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        },
+      );
+
+      test(
+        'skips dev_dependencies whose declared constraint allows updated '
+        'version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _workspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              devDependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+
+          await melos.bootstrap(offline: true);
+          await melos.version(
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            smartDependents: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(1, 0, 1)),
+            },
+          );
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        },
+      );
     });
   });
 }

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -1654,7 +1654,281 @@ dev_dependencies:
         );
       });
     });
+
+    group('smart-dependents', () {
+      Version pubspecVersion(Directory workspaceDir, String packageName) {
+        return Pubspec.parse(
+          File(
+            p.join(workspaceDir.path, 'packages', packageName, 'pubspec.yaml'),
+          ).readAsStringSync(),
+        ).version!;
+      }
+
+      test(
+        'skips dependents whose declared constraint allows the updated version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _workspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+
+          await melos.bootstrap(offline: true);
+          await melos.version(
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            smartDependents: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(1, 0, 1)),
+            },
+          );
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          // `b` already allowed 1.0.1 via `^1.0.0`, so it is NOT bumped.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+
+          final bPubspec = Pubspec.parse(
+            File(
+              p.join(workspaceDir.path, 'packages/b/pubspec.yaml'),
+            ).readAsStringSync(),
+          );
+          final aDep = bPubspec.dependencies['a']! as HostedDependency;
+          expect(
+            aDep.version,
+            VersionConstraint.parse('^1.0.0'),
+          );
+        },
+      );
+
+      test(
+        'versions dependents whose declared constraint does not allow the '
+        'updated version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _workspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+
+          await melos.bootstrap(offline: true);
+          await melos.version(
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            smartDependents: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(2, 0, 0)),
+            },
+          );
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(2, 0, 0));
+          // `b` did NOT allow 2.0.0 via `^1.0.0`, so it gets a patch bump and
+          // constraint rewrite.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+
+          final bPubspec = Pubspec.parse(
+            File(
+              p.join(workspaceDir.path, 'packages/b/pubspec.yaml'),
+            ).readAsStringSync(),
+          );
+          final aDep = bPubspec.dependencies['a']! as HostedDependency;
+          expect(
+            aDep.version,
+            VersionConstraint.parse('^2.0.0'),
+          );
+        },
+      );
+
+      test(
+        'stops transitive cascade at intermediate package whose constraint '
+        'allows updated version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _workspaceConfigBuilder,
+            workspacePackages: ['a', 'b', 'c'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'c',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'b': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+
+          await melos.bootstrap(offline: true);
+          await melos.version(
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            smartDependents: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(2, 0, 0)),
+            },
+          );
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(2, 0, 0));
+          // `b` did NOT allow 2.0.0, so it gets bumped to 1.0.1 and constraint
+          // updated.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+          // `c` allows 1.0.1 via `^1.0.0`, so cascade stops at `b` and `c` is
+          // NOT bumped.
+          expect(pubspecVersion(workspaceDir, 'c'), Version(1, 0, 0));
+
+          final cPubspec = Pubspec.parse(
+            File(
+              p.join(workspaceDir.path, 'packages/c/pubspec.yaml'),
+            ).readAsStringSync(),
+          );
+          final bDep = cPubspec.dependencies['b']! as HostedDependency;
+          expect(
+            bDep.version,
+            VersionConstraint.parse('^1.0.0'),
+          );
+        },
+      );
+
+      test(
+        'honors smartDependents configured in melos.yaml',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _smartDependentsWorkspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+
+          await melos.bootstrap(offline: true);
+          await melos.version(
+            versionPrivatePackages: true,
+            gitCommit: false,
+            gitTag: false,
+            force: true,
+            manualVersions: {
+              'a': ManualVersionChange(Version(1, 0, 1)),
+            },
+          );
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          // `smartDependents` was enabled in config, so `b` is skipped on
+          // compatible patch.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        },
+      );
+    });
   });
+}
+
+MelosWorkspaceConfig _smartDependentsWorkspaceConfigBuilder(String path) {
+  return MelosWorkspaceConfig(
+    path: path,
+    name: 'test_workspace',
+    packages: [
+      createGlob('packages/**', currentDirectoryPath: path),
+    ],
+    commands: const CommandConfigs(
+      version: VersionCommandConfigs(
+        fetchTags: false,
+        smartDependents: true,
+      ),
+    ),
+  );
 }
 
 MelosWorkspaceConfig _fixedModeWorkspaceConfigBuilder(String path) {

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -4,6 +4,7 @@ import 'package:ansi_styles/ansi_styles.dart';
 import 'package:glob/glob.dart';
 import 'package:melos/melos.dart';
 import 'package:melos/src/command_configs/command_configs.dart';
+import 'package:melos/src/command_runner.dart';
 import 'package:melos/src/common/git_tag_pattern_dependency.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:path/path.dart' as p;
@@ -1908,6 +1909,53 @@ dev_dependencies:
           expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
           // `smartDependents` was enabled in config, so `b` is skipped on
           // compatible patch.
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
+        },
+      );
+
+      test(
+        'CLI runner respects smartDependents from melos.yaml without explicit '
+        'flag',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _smartDependentsWorkspaceConfigBuilder,
+            workspacePackages: ['a', 'b'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await createProject(
+            workspaceDir,
+            Pubspec(
+              'b',
+              version: Version(1, 0, 0),
+              dependencies: {
+                'a': HostedDependency(
+                  version: VersionConstraint.parse('^1.0.0'),
+                ),
+              },
+            ),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final runner = MelosCommandRunner(config);
+
+          await runner.run([
+            'version',
+            '--yes',
+            '--no-git-tag-version',
+            '--no-git-commit-version',
+            '--all',
+            '-V',
+            'a:1.0.1',
+          ]);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
           expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 0));
         },
       );


### PR DESCRIPTION
## Description

In monorepos using independent versioning mode (e.g. FlutterFire), running `melos version` previously bumped and published all downstream dependent packages whenever an internal dependency updated, even when dependent packages had no code changes and their declared SemVer constraints already allowed the updated dependency version.

In FlutterFire release PR [#18606](https://github.com/firebase/flutterfire/pull/18606), updating core packages caused 13 packages (`*_web` and `*_platform_interface` plugins) to receive patch bumps and be published to pub.dev with zero functional changes, solely to tighten dependency lower bounds (e.g. `^1.3.76` -> `^1.3.77`).

This PR adds a `smartDependents` setting and `--smart-dependents` CLI flag:
- In `smartDependents` mode, Melos evaluates declared SemVer constraints (`currentConstraint.allows(nextVersion)`) before queueing downstream packages for dependent version bumps.
- When `currentConstraint.allows(nextVersion)` is `true` (e.g. compatible patch or minor bump under `^1.0.0`), the dependent package is skipped (no version bump, no changelog entry, no `pubspec.yaml` rewrite).
- When `currentConstraint.allows(nextVersion)` is `false` (e.g. `0.x` minor breaking bump or major breaking bump), the dependent package is bumped and its constraint is updated to `^nextVersion`.
- Transitive cascades stop at the first intermediate package whose constraint already satisfies its updated dependency.
- Legacy cascading behavior is preserved by default for backward compatibility with existing workspaces.

### Verification

- Executed `dart analyze lib test` with 0 issues.
- Executed `dart test test/commands/version_test.dart` (all 38 unit and regression tests pass).
- Added comprehensive unit tests in `test/commands/version_test.dart` covering:
  - Skipped dependents on compatible patch/minor bumps
  - Versioned dependents on incompatible breaking bumps
  - Transitive cascade termination at compatible boundaries
  - Workspace configuration via `melos.yaml` `command/version/smartDependents: true`

Fixes #1062

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
