### PR TITLE
feat(publish): add --skip-validation flag

### DIFF
--- a/docs/commands/publish.mdx
+++ b/docs/commands/publish.mdx
@@ -52,6 +52,20 @@ command:
 The CLI flag takes precedence over the `pubServer` config value when both are
 provided.
 
+## --skip-validation
+
+Publish without validation and resolution. When set, `--skip-validation` is
+forwarded to `dart pub publish`, so packages are published even if they have
+validation errors or warnings. This is useful for private package servers that
+don't require the same level of validation as pub.dev.
+
+```bash
+melos publish --no-dry-run --skip-validation
+```
+
+Note that melos already forwards `--force` to `dart pub publish` when running
+with `--no-dry-run`, since the confirmation prompt is handled by melos itself.
+
 ## --git-tag-version (-t)
 
 Add any missing git tags for release. Tags are only created if --no-dry-run is

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -30,6 +30,13 @@ class PublishCommand extends MelosCommand {
           'The URL of the package server to publish to. '
           'Overrides the pubServer option in melos.yaml.',
     );
+    argParser.addFlag(
+      publishOptionSkipValidation,
+      negatable: false,
+      help:
+          'Publish without validation and resolution (this will ignore '
+          'errors). Forwarded to `dart pub publish --skip-validation`.',
+    );
   }
 
   @override
@@ -46,6 +53,7 @@ class PublishCommand extends MelosCommand {
     final gitTagVersion = argResults![publishOptionGitTagVersion] as bool;
     final yes = argResults![publishOptionYes] as bool;
     final pubServer = argResults![publishOptionServer] as String?;
+    final skipValidation = argResults![publishOptionSkipValidation] as bool;
 
     final melos = Melos(logger: logger, config: config);
     final packageFilters = parsePackageFilters(config.path);
@@ -57,6 +65,7 @@ class PublishCommand extends MelosCommand {
       force: yes,
       gitTagVersion: gitTagVersion,
       pubServer: pubServer,
+      skipValidation: skipValidation,
     );
   }
 }

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -9,6 +9,7 @@ mixin _PublishMixin on _ExecMixin {
     // yes
     bool force = false,
     String? pubServer,
+    bool skipValidation = false,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -24,6 +25,7 @@ mixin _PublishMixin on _ExecMixin {
         gitTagVersion: gitTagVersion,
         force: force,
         pubServer: pubServer ?? workspace.config.commands.publish.pubServer,
+        skipValidation: skipValidation,
       );
     });
   }
@@ -37,6 +39,7 @@ mixin _PublishMixin on _ExecMixin {
     // yes
     bool force = false,
     String? pubServer,
+    bool skipValidation = false,
   }) async {
     logger.command('melos publish${dryRun ? " --$publishOptionDryRun" : ''}');
     logger.child(targetStyle(workspace.path)).newLine();
@@ -124,6 +127,7 @@ mixin _PublishMixin on _ExecMixin {
       dryRun: dryRun,
       gitTagVersion: gitTagVersion,
       pubServer: pubServer,
+      skipValidation: skipValidation,
     );
   }
 
@@ -180,6 +184,7 @@ mixin _PublishMixin on _ExecMixin {
     required bool dryRun,
     required bool gitTagVersion,
     String? pubServer,
+    bool skipValidation = false,
   }) async {
     final updateRegistryProgress = logger.progress(
       'Publishing ${unpublishedPackages.length} packages to registry:',
@@ -197,6 +202,10 @@ mixin _PublishMixin on _ExecMixin {
 
     if (pubServer != null) {
       execArgs.addAll(['--server', pubServer]);
+    }
+
+    if (skipValidation) {
+      execArgs.add('--skip-validation');
     }
 
     await _execForAllPackages(

--- a/packages/melos/lib/src/common/utils.dart
+++ b/packages/melos/lib/src/common/utils.dart
@@ -47,6 +47,7 @@ const publishOptionNoGitTagVersion = 'no-git-tag-version';
 const publishOptionYes = 'yes';
 const publishOptionForce = 'force';
 const publishOptionServer = 'server';
+const publishOptionSkipValidation = 'skip-validation';
 
 /// The default command used to invoke Melos itself when a script needs to run
 /// a nested Melos command, such as `melos exec` or `melos run`.

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -210,6 +210,79 @@ void main() {
       );
     });
 
+    group('skipValidation', () {
+      test(
+        'passes --skip-validation flag to dart pub publish when enabled',
+        () async {
+          final logger = TestLogger();
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: (path) => MelosWorkspaceConfig(
+              path: path,
+              name: 'test_workspace',
+              packages: [
+                createGlob('packages/**', currentDirectoryPath: path),
+              ],
+            ),
+            workspacePackages: const ['a'],
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 2, 3)),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(logger: logger, config: config);
+
+          await expectLater(
+            melos.publish(force: true, skipValidation: true),
+            completes,
+          );
+
+          expect(
+            logger.output.normalizeLines(),
+            contains('--skip-validation'),
+          );
+        },
+      );
+
+      test(
+        'does not pass --skip-validation flag to dart pub publish by default',
+        () async {
+          final logger = TestLogger();
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: (path) => MelosWorkspaceConfig(
+              path: path,
+              name: 'test_workspace',
+              packages: [
+                createGlob('packages/**', currentDirectoryPath: path),
+              ],
+            ),
+            workspacePackages: const ['a'],
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 2, 3)),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(logger: logger, config: config);
+
+          await expectLater(melos.publish(force: true), completes);
+
+          expect(
+            logger.output.normalizeLines(),
+            isNot(contains('--skip-validation')),
+          );
+        },
+      );
+    });
+
     test(
       'does not print success when dart pub publish --dry-run fails',
       () async {


### PR DESCRIPTION
## Description

Adds a \`--skip-validation\` flag to \`melos publish\`, which is forwarded to \`dart pub publish --skip-validation\`. This allows publishing packages that have pub validation errors or warnings, which is useful for private package servers (such as OnePub) that don't enforce the same rules as pub.dev.

Note that \`--force\` was already forwarded to \`dart pub publish\` whenever \`--no-dry-run\` is used, since melos handles the confirmation prompt itself (\`-y\`/\`--yes\` skips it). So this PR only adds the missing \`--skip-validation\` part of the request.

Closes #882

## Changes

- New \`--skip-validation\` flag on \`melos publish\`, threaded through \`Melos.publish\` to the \`dart pub publish\` invocation.
- Tests asserting the flag is forwarded when enabled and absent by default.
- Docs section for \`--skip-validation\` in \`docs/commands/publish.mdx\`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation Update

https://claude.ai/code/session_011m7roajtcq28M9iBo4CdUQ