### PR TITLE
feat(exec): add `--group-logs` to print per-package output once all packages finish

### DIFF
--- a/docs/commands/exec.mdx
+++ b/docs/commands/exec.mdx
@@ -46,3 +46,30 @@ the script fails in an individual package. Defaults to `false`.
 # Fail fast
 melos exec --fail-fast -- "dart analyze ."
 ```
+
+## --group-logs
+
+When executing a command in multiple packages concurrently, the output of the
+packages is streamed as it is produced, which means the logs of the different
+packages are interleaved and hard to follow.
+
+With `--group-logs`, the output of each package is buffered instead and printed
+once every package has finished, grouped per package and in the order the
+output was produced. Packages in which the command failed are printed last, so
+failures are at the end of the log where they are easy to spot. Defaults to
+`false`.
+
+The flag only has an effect when the command runs in more than one package with
+a concurrency greater than 1. When the command runs in a single package or with
+`--concurrency 1`, the output cannot interleave in the first place, so
+`--group-logs` is a no-op and the output is streamed as usual.
+
+```bash
+# Print the output grouped per package, once all packages have finished
+melos exec --group-logs -- "dart analyze ."
+```
+
+<Info>
+  Since the output is only printed once all packages have finished, nothing is
+  printed while the command is running.
+</Info>

--- a/docs/configuration/scripts.mdx
+++ b/docs/configuration/scripts.mdx
@@ -183,6 +183,19 @@ leaf packages first and then in packages that depend on them and so on. This is
 useful for example, for a script that generates code in multiple packages, which
 depend on each other. Defaults to `false`.
 
+### groupLogs
+
+Whether the output of the packages should be buffered and printed grouped per
+package once every package has finished, instead of being streamed and
+interleaved while the packages run. The output of packages in which the script
+failed is printed last. Defaults to `false`.
+
+As with the command line flag, this only has an effect when the script runs in
+more than one package with a [`concurrency`](#concurrency) greater than 1 — with
+`concurrency: 1` it is a no-op.
+
+See [`melos exec --group-logs`](/commands/exec#--group-logs) for more details.
+
 ## env
 
 A map of environment variables that will be passed to the executed command.

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -368,6 +368,14 @@
                         "failFast": {
                           "type": "boolean",
                           "description": "Whether exec should fail fast and not execute the script in further packages if the script fails in a individual package."
+                        },
+                        "orderDependents": {
+                          "type": "boolean",
+                          "description": "Whether exec should order the execution of the script based on the dependency graph of the packages."
+                        },
+                        "groupLogs": {
+                          "type": "boolean",
+                          "description": "Whether the output of each package should be buffered and printed grouped per package once every package has finished, with failed packages printed last."
                         }
                       }
                     }

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -19,6 +19,16 @@ class ExecCommand extends MelosCommand {
           'packages if the script fails in a individual package.',
     );
     argParser.addFlag(
+      'group-logs',
+      help:
+          'Whether the output of each package should be buffered and printed '
+          'grouped per package once every package has finished, instead of '
+          'being streamed and interleaved while the packages run. The output '
+          'of packages in which the command failed is printed last. Only has '
+          'an effect when running in more than one package with a concurrency '
+          'greater than 1.',
+    );
+    argParser.addFlag(
       'order-dependents',
       abbr: 'o',
       help:
@@ -58,12 +68,14 @@ class ExecCommand extends MelosCommand {
     final concurrency = int.parse(argResults!['concurrency'] as String);
     final failFast = argResults!['fail-fast'] as bool;
     final orderDependents = argResults!['order-dependents'] as bool;
+    final groupLogs = argResults!['group-logs'] as bool;
 
     return melos.exec(
       execArgs,
       concurrency: concurrency,
       failFast: failFast,
       orderDependents: orderDependents,
+      groupLogs: groupLogs,
       global: global,
       packageFilters: packageFilters,
     );

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -8,6 +8,7 @@ mixin _ExecMixin on _Melos {
     int? concurrency,
     bool failFast = false,
     bool orderDependents = false,
+    bool groupLogs = false,
     Map<String, String> extraEnvironment = const {},
   }) async {
     concurrency ??= Platform.numberOfProcessors;
@@ -36,6 +37,7 @@ mixin _ExecMixin on _Melos {
       failFast: failFast,
       concurrency: concurrency,
       orderDependents: orderDependents,
+      groupLogs: groupLogs,
       additionalEnvironment: extraEnvironment,
     );
   }
@@ -48,6 +50,7 @@ mixin _ExecMixin on _Melos {
     bool prefixLogs = true,
     Map<String, String> extraEnvironment = const {},
     ProcessOutputCancelToken? cancelToken,
+    String? group,
   }) async {
     final packagePrefix = '[${AnsiStyles.blue.bold(package.name)}]: ';
 
@@ -96,6 +99,7 @@ mixin _ExecMixin on _Melos {
       // The parent env is injected manually above
       includeParentEnvironment: false,
       cancelToken: cancelToken,
+      group: group,
     );
   }
 
@@ -106,6 +110,7 @@ mixin _ExecMixin on _Melos {
     required int concurrency,
     required bool failFast,
     required bool orderDependents,
+    bool groupLogs = false,
     Map<String, String> additionalEnvironment = const {},
   }) async {
     final allPackagesList = workspace.allPackages.values.toList(
@@ -128,7 +133,9 @@ mixin _ExecMixin on _Melos {
     final pool = Pool(concurrency);
 
     final execArgsString = execArgs.join(' ');
-    final prefixLogs = concurrency != 1 && executablePackages.length != 1;
+    final isConcurrent = concurrency != 1 && executablePackagesList.length != 1;
+    final useGroupBuffer = groupLogs && isConcurrent;
+    final prefixLogs = isConcurrent && !useGroupBuffer;
 
     logger.command('melos exec', withDollarSign: true);
     logger
@@ -157,10 +164,15 @@ mixin _ExecMixin on _Melos {
             return;
           }
 
+          final group = useGroupBuffer ? package.name : null;
+
           if (!prefixLogs) {
             logger
-              ..horizontalLine()
-              ..log(AnsiStyles.bgBlack.bold.italic('${package.name}:'));
+              ..horizontalLine(group: group)
+              ..log(
+                AnsiStyles.bgBlack.bold.italic('${package.name}:'),
+                group: group,
+              );
           }
 
           final packageExitCode = await _execForPackage(
@@ -170,6 +182,7 @@ mixin _ExecMixin on _Melos {
             prefixLogs: prefixLogs,
             extraEnvironment: additionalEnvironment,
             cancelToken: processOutputCancelToken,
+            group: group,
           );
 
           packageResults[package.name]?.complete(packageExitCode);
@@ -180,6 +193,7 @@ mixin _ExecMixin on _Melos {
             logger.log(
               AnsiStyles.bgBlack.bold.italic('${package.name}: ') +
                   AnsiStyles.bgBlack(successLabel),
+              group: group,
             );
           }
 
@@ -194,6 +208,13 @@ mixin _ExecMixin on _Melos {
       if (failFast) {
         runningPids.forEach(Process.killPid);
       }
+    }
+
+    if (useGroupBuffer) {
+      // Print the buffered output of every package, grouped per package and in
+      // the order the packages started, with the failed packages last so that
+      // they are easy to spot at the end of the log.
+      await logger.flushGroupBufferIfNeed(lastGroups: failures.keys.toList());
     }
 
     logger

--- a/packages/melos/lib/src/logging.dart
+++ b/packages/melos/lib/src/logging.dart
@@ -271,9 +271,25 @@ class MelosLogger with _DelegateLogger {
     _groupBuffer[group] = [...previous, _GroupBufferWriteMessage(message)];
   }
 
-  Future<void> flushGroupBufferIfNeed() {
-    for (final entry in _groupBuffer.entries) {
-      for (final value in entry.value) {
+  /// Prints everything that has been buffered for a group, one group at a
+  /// time, so that the output of concurrently running commands is not
+  /// interleaved.
+  ///
+  /// Groups are flushed in the order they were first written to, except for
+  /// the groups listed in [lastGroups], which are flushed last (keeping their
+  /// relative order). This is used to print the output of failed packages at
+  /// the end, where it is easy to spot.
+  Future<void> flushGroupBufferIfNeed({
+    Iterable<String> lastGroups = const [],
+  }) {
+    final deferredGroups = lastGroups.toSet();
+    final groupNames = [
+      ..._groupBuffer.keys.where((group) => !deferredGroups.contains(group)),
+      ..._groupBuffer.keys.where(deferredGroups.contains),
+    ];
+
+    for (final groupName in groupNames) {
+      for (final value in _groupBuffer[groupName]!) {
         switch (value) {
           case _GroupBufferStdoutMessage(:final message):
             stdout(message);

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -154,16 +154,23 @@ class ExecOptions {
     this.concurrency,
     this.failFast,
     this.orderDependents,
+    this.groupLogs,
   });
 
   final int? concurrency;
   final bool? failFast;
   final bool? orderDependents;
 
+  /// Whether the output of the packages should be buffered and printed grouped
+  /// per package once every package has finished, instead of being streamed
+  /// and interleaved while the packages run.
+  final bool? groupLogs;
+
   Map<String, Object?> toJson() => {
     if (concurrency != null) 'concurrency': concurrency,
     if (failFast != null) 'failFast': failFast,
     if (orderDependents != null) 'orderDependents': orderDependents,
+    if (groupLogs != null) 'groupLogs': groupLogs,
   };
 
   @override
@@ -172,14 +179,16 @@ class ExecOptions {
       runtimeType == other.runtimeType &&
       concurrency == other.concurrency &&
       failFast == other.failFast &&
-      orderDependents == other.orderDependents;
+      orderDependents == other.orderDependents &&
+      groupLogs == other.groupLogs;
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
       concurrency.hashCode ^
       failFast.hashCode ^
-      orderDependents.hashCode;
+      orderDependents.hashCode ^
+      groupLogs.hashCode;
 
   @override
   String toString() =>
@@ -188,6 +197,7 @@ ExecOptions(
   concurrency: $concurrency,
   failFast: $failFast,
   orderDependents: $orderDependents,
+  groupLogs: $groupLogs,
 )''';
 }
 
@@ -451,10 +461,17 @@ class Script {
       path: execPath,
     );
 
+    final groupLogs = assertKeyIsA<bool?>(
+      key: 'groupLogs',
+      map: yaml,
+      path: execPath,
+    );
+
     return ExecOptions(
       concurrency: concurrency,
       failFast: failFast,
       orderDependents: orderDependents,
+      groupLogs: groupLogs,
     );
   }
 
@@ -529,6 +546,10 @@ class Script {
 
       if (exec.orderDependents ?? false) {
         execCommand.add('--order-dependents');
+      }
+
+      if (exec.groupLogs ?? false) {
+        execCommand.add('--group-logs');
       }
 
       execCommand.addAll(['--', quoteScript(scriptCommand.join(' '))]);

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -865,5 +865,346 @@ ${'-' * terminalWidth}
         );
       });
     });
+
+    group('group logs', () {
+      /// Writes a script that prints two lines with a delay in between, so
+      /// that the output of concurrently running packages would interleave if
+      /// it was not buffered.
+      void createLoggingFile(
+        Directory dir, {
+        required String package,
+        int delay = 0,
+        int exitCode = 0,
+      }) {
+        File('${dir.path}/log_lines.dart').writeAsStringSync('''
+        import 'dart:io';
+        Future<void> main() async {
+          stdout.writeln('$package line 1');
+          await Future.delayed(Duration(milliseconds: $delay));
+          stdout.writeln('$package line 2');
+          exit($exitCode);
+        }
+        ''');
+      }
+
+      test(
+        'prints the output of each package grouped once all have finished',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            workspacePackages: ['a', 'b', 'c'],
+          );
+
+          final a = await createProject(workspaceDir, Pubspec('a'));
+          createLoggingFile(a, package: 'a', delay: 600);
+
+          final b = await createProject(workspaceDir, Pubspec('b'));
+          createLoggingFile(b, package: 'b', delay: 300);
+
+          final c = await createProject(workspaceDir, Pubspec('c'));
+          createLoggingFile(c, package: 'c');
+
+          final logger = TestLogger();
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(logger: logger, config: config);
+
+          await melos.exec(
+            ['dart', 'log_lines.dart'],
+            concurrency: 3,
+            groupLogs: true,
+          );
+
+          expect(
+            logger.output.normalizeLines(),
+            ignoringAnsii(
+              '''
+\$ melos exec
+  └> dart log_lines.dart
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+a line 1
+a line 2
+a: SUCCESS
+${'-' * terminalWidth}
+b:
+b line 1
+b line 2
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+c line 1
+c line 2
+c: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> dart log_lines.dart
+     └> SUCCESS
+''',
+            ),
+          );
+        },
+      );
+
+      test('prints the output of failed packages last', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b', 'c'],
+        );
+
+        final a = await createProject(workspaceDir, Pubspec('a'));
+        createLoggingFile(a, package: 'a', delay: 600);
+
+        final b = await createProject(workspaceDir, Pubspec('b'));
+        createLoggingFile(b, package: 'b', exitCode: 1);
+
+        final c = await createProject(workspaceDir, Pubspec('c'));
+        createLoggingFile(c, package: 'c', delay: 300);
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.exec(
+          ['dart', 'log_lines.dart'],
+          concurrency: 3,
+          groupLogs: true,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          ignoringAnsii(
+            '''
+\$ melos exec
+  └> dart log_lines.dart
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+a:
+a line 1
+a line 2
+a: SUCCESS
+${'-' * terminalWidth}
+c:
+c line 1
+c line 2
+c: SUCCESS
+${'-' * terminalWidth}
+b:
+b line 1
+b line 2
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> dart log_lines.dart
+     └> FAILED (in 1 packages)
+        └> b (with exit code 1)
+''',
+          ),
+        );
+      });
+
+      test('is a no-op when running with a concurrency of 1', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b'],
+        );
+
+        await createProject(workspaceDir, Pubspec('a'));
+        await createProject(workspaceDir, Pubspec('b'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.exec(
+          ['echo', 'hello', 'world'],
+          concurrency: 1,
+          groupLogs: true,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          ignoringAnsii(
+            '''
+\$ melos exec
+  └> echo hello world
+     └> RUNNING (in 2 packages)
+
+${'-' * terminalWidth}
+a:
+hello world
+a: SUCCESS
+${'-' * terminalWidth}
+b:
+hello world
+b: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> echo hello world
+     └> SUCCESS
+''',
+          ),
+        );
+      });
+
+      // `--fail-fast` completes the packages it skips without running them,
+      // so those packages never write anything to the group buffer. Flushing
+      // the buffer must cope with that, even though the skipped packages are
+      // reported as failures and therefore asked to be flushed last.
+      //
+      // The dependency chain (with `orderDependents`) is only there to make
+      // the skipping deterministic: `b` runs and fails in the first layer, so
+      // `c` and `a` are skipped in the layers after it.
+      test('handles packages that were skipped by failFast', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b', 'c'],
+        );
+
+        final a = await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'c': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+        createLoggingFile(a, package: 'a');
+
+        final b = await createProject(workspaceDir, Pubspec('b'));
+        createLoggingFile(b, package: 'b', exitCode: 1);
+
+        final c = await createProject(
+          workspaceDir,
+          Pubspec(
+            'c',
+            dependencies: {
+              'b': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+        createLoggingFile(c, package: 'c');
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.exec(
+          ['dart', 'log_lines.dart'],
+          concurrency: 3,
+          orderDependents: true,
+          failFast: true,
+          groupLogs: true,
+        );
+
+        // Only `b` ran, so only its output is flushed. `c` and `a` have no
+        // buffered output at all, but are still listed as failures.
+        expect(
+          logger.output.normalizeLines(),
+          ignoringAnsii(
+            '''
+\$ melos exec
+  └> dart log_lines.dart
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+b:
+b line 1
+b line 2
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> dart log_lines.dart
+     └> FAILED (in 3 packages)
+        └> b (with exit code 1)
+        └> c (dependency failed)
+        └> a (dependency failed)
+''',
+          ),
+        );
+      });
+
+      test('groups the output of packages run in dependency order', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          workspacePackages: ['a', 'b', 'c'],
+        );
+
+        // `a` depends on `b` and `c`, so `b` and `c` run concurrently in the
+        // first layer and `a` runs on its own in the second one.
+        final a = await createProject(
+          workspaceDir,
+          Pubspec(
+            'a',
+            dependencies: {
+              'b': HostedDependency(version: VersionConstraint.any),
+              'c': HostedDependency(version: VersionConstraint.any),
+            },
+          ),
+        );
+        createLoggingFile(a, package: 'a');
+
+        final b = await createProject(workspaceDir, Pubspec('b'));
+        createLoggingFile(b, package: 'b', delay: 300);
+
+        final c = await createProject(workspaceDir, Pubspec('c'));
+        createLoggingFile(c, package: 'c');
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(logger: logger, config: config);
+
+        await melos.exec(
+          ['dart', 'log_lines.dart'],
+          concurrency: 3,
+          orderDependents: true,
+          groupLogs: true,
+        );
+
+        // The buffer is flushed once, after the last layer has finished, in
+        // the order in which the packages started.
+        expect(
+          logger.output.normalizeLines(),
+          ignoringAnsii(
+            '''
+\$ melos exec
+  └> dart log_lines.dart
+     └> RUNNING (in 3 packages)
+
+${'-' * terminalWidth}
+b:
+b line 1
+b line 2
+b: SUCCESS
+${'-' * terminalWidth}
+c:
+c line 1
+c line 2
+c: SUCCESS
+${'-' * terminalWidth}
+a:
+a line 1
+a line 2
+a: SUCCESS
+${'-' * terminalWidth}
+
+\$ melos exec
+  └> dart log_lines.dart
+     └> SUCCESS
+''',
+          ),
+        );
+      });
+    });
   });
 }

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -613,6 +613,7 @@ void main() {
                 'concurrency': 1,
                 'failFast': true,
                 'orderDependents': true,
+                'groupLogs': true,
               },
             },
           }),
@@ -625,6 +626,7 @@ void main() {
             concurrency: 1,
             failFast: true,
             orderDependents: true,
+            groupLogs: true,
           ),
         );
       });


### PR DESCRIPTION
Resolves #134

## Problem

`melos exec` streams each package's output as it is produced, so with concurrency > 1 the logs interleave and failures can be buried anywhere in the log.

## Change

Adds an opt-in `--group-logs` flag to `melos exec` (and a `groupLogs` option to a script's `exec` block):

- Each package's output is buffered and printed once **all** packages have finished, grouped per package under the same `<package>:` headers `melos analyze` / `melos test` already use.
- Groups print in start order, **except failed packages, which print last**.
- No-op with a single package or `--concurrency 1`; default behaviour unchanged.

Implementation reuses the existing group buffer in `MelosLogger`; the only logger change is a `lastGroups` parameter on `flushGroupBufferIfNeed` that defers the given groups to the end of the flush.

## Verification

`dart analyze` and `dart format` clean. New tests in `test/commands/exec_test.dart` cover grouped output, failures last, no-op at concurrency 1, and the `--fail-fast` / `--order-dependents` combinations.