### PR TITLE
ci: bump action versions and drop actions running on Node 20 or older

### DIFF
--- a/.github/workflows/issue_manager.yaml
+++ b/.github/workflows/issue_manager.yaml
@@ -23,18 +23,23 @@ jobs:
           fi
       - name: Add 'needs attention' label if OP responded
         if: env.op_comment == 'true'
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: 'needs attention'
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
+            -f "labels[]=needs attention"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Remove 'blocked waiting for response' label if OP responded
         if: env.op_comment == 'true'
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: 'blocked: waiting for response'
+        run: |
+          LABEL='blocked: waiting for response'
+          ENCODED_LABEL=$(jq -rn --arg label "$LABEL" '$label | @uri')
+          if gh api "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" --jq '.[].name' | grep -qxF "$LABEL"; then
+            gh api --method DELETE \
+              "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/$ENCODED_LABEL"
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
   label-new-issue:
     if: github.event.action == 'opened'
     runs-on: ubuntu-latest
@@ -42,8 +47,9 @@ jobs:
       issues: write
     steps:
       - name: Add 'needs triage' label to new issue
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: 'needs triage'
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" \
+            -f "labels[]=needs triage"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/stale_issue_pr_manager.yaml
+++ b/.github/workflows/stale_issue_pr_manager.yaml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           operations-per-run: 1000
           stale-issue-message: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,10 +18,7 @@ jobs:
       - name: Install Tools
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Analyze
-        uses: invertase/github-action-dart-analyzer@v3
-        with:
-          fatal-infos: true
-          fatal-warnings: true
+        run: melos analyze --fatal-infos --fatal-warnings
 
   # This job ensures `melos` compiles and runs fine on the
   # minimum Dart SDK version that it supports.


### PR DESCRIPTION
## Description

Bumps all GitHub Actions to their latest majors and removes every action that still runs on Node 20 or older.

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/stale` | v10 | v11 | node24 |
| `invertase/github-action-dart-analyzer` | v3 | replaced with `melos analyze --fatal-infos --fatal-warnings` | was node20, no newer release exists |
| `actions-ecosystem/action-add-labels` | v1 | replaced with `gh api` | was node12, unmaintained |
| `actions-ecosystem/action-remove-labels` | v1 | replaced with `gh api` | was node12, unmaintained |

`actions/checkout@v7`, `dart-lang/setup-dart@v1`, `amannn/action-semantic-pull-request@v6`, `subosito/flutter-action@v2` and `bluefireteam/melos-action@v3` are already on their latest majors and on node24 (including the actions nested inside the two composite actions).

Notes:
- The dart-analyzer action ran `dart analyze` under the hood, so `melos analyze` is equivalent, it just drops the inline PR annotations.
- The label steps use the issues labels endpoint, which works for both issues and pull request comments, matching the previous behaviour. The remove step is a no-op when the label is not present.
- The `analyze` job currently fails on a pre-existing unused import that is being fixed in a separate PR.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [x] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
