### PR TITLE
fix: rename dependency toJson extensions to toYaml to avoid being shadowed by pubspec_parse 1.6.0

### DIFF
--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -165,9 +165,9 @@ class BootstrapCommandConfigs {
       'enforceLockfile': enforceLockfile,
       if (pubGetArgs.isNotEmpty) 'pubGetArgs': pubGetArgs,
       if (environment != null) 'environment': environment!.toJson(),
-      if (dependencies != null) 'dependencies': dependencies!.toJson(),
+      if (dependencies != null) 'dependencies': dependencies!.toYaml(),
       if (devDependencies != null)
-        'dev_dependencies': devDependencies!.toJson(),
+        'dev_dependencies': devDependencies!.toYaml(),
       if (dependencyOverridePaths.isNotEmpty)
         'dependencyOverridePaths': dependencyOverridePaths
             .map((path) => path.toString())

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -400,7 +400,7 @@ mixin _BootstrapMixin on _CleanMixin {
       pubspecEditor.update(
         [pubspecKey, entry.key],
         wrapAsYamlNode(
-          entry.value.toJson(),
+          entry.value.toYaml(),
           collectionStyle: CollectionStyle.BLOCK,
         ),
       );

--- a/packages/melos/lib/src/commands/clean.dart
+++ b/packages/melos/lib/src/commands/clean.dart
@@ -165,7 +165,7 @@ String? _mergeMelosPubspecOverrides(
             pubspecOverridesEditor.update(
               ['dependency_overrides', packageName],
               wrapAsYamlNode(
-                newRef!.toJson(),
+                newRef!.toYaml(),
                 collectionStyle: CollectionStyle.BLOCK,
               ),
             );
@@ -197,7 +197,7 @@ String? _mergeMelosPubspecOverrides(
           {
             'dependency_overrides': {
               for (final dependencyOverride in melosDependencyOverrides.entries)
-                dependencyOverride.key: dependencyOverride.value.toJson(),
+                dependencyOverride.key: dependencyOverride.value.toYaml(),
             },
           },
           collectionStyle: CollectionStyle.BLOCK,
@@ -210,7 +210,7 @@ String? _mergeMelosPubspecOverrides(
           wrapAsYamlNode(
             {
               for (final dependencyOverride in melosDependencyOverrides.entries)
-                dependencyOverride.key: dependencyOverride.value.toJson(),
+                dependencyOverride.key: dependencyOverride.value.toYaml(),
             },
             collectionStyle: CollectionStyle.BLOCK,
           ),
@@ -220,7 +220,7 @@ String? _mergeMelosPubspecOverrides(
           pubspecOverridesEditor.update(
             ['dependency_overrides', dependencyOverride.key],
             wrapAsYamlNode(
-              dependencyOverride.value.toJson(),
+              dependencyOverride.value.toYaml(),
               collectionStyle: CollectionStyle.BLOCK,
             ),
           );

--- a/packages/melos/lib/src/common/extensions/dependency.dart
+++ b/packages/melos/lib/src/common/extensions/dependency.dart
@@ -9,16 +9,21 @@ extension DependencyExtension on Dependency {
     return null;
   }
 
-  Object toJson() {
+  /// Converts this dependency to the value used for it in a `pubspec.yaml`
+  /// file, inlining the version or url where pub allows it.
+  ///
+  /// This intentionally differs from `Dependency.toJson` in `pubspec_parse`,
+  /// which always produces a map.
+  Object toYaml() {
     final self = this;
     if (self is PathDependency) {
-      return self.toJson();
+      return self.toYaml();
     } else if (self is HostedDependency) {
-      return self.toJson();
+      return self.toYaml();
     } else if (self is GitDependency) {
-      return self.toJson();
+      return self.toYaml();
     } else if (self is SdkDependency) {
-      return self.toJson();
+      return self.toYaml();
     } else {
       throw UnimplementedError();
     }
@@ -26,7 +31,7 @@ extension DependencyExtension on Dependency {
 }
 
 extension PathDependencyExtension on PathDependency {
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toYaml() {
     return {
       'path': path,
     };
@@ -34,7 +39,7 @@ extension PathDependencyExtension on PathDependency {
 }
 
 extension HostedDependencyExtension on HostedDependency {
-  Object toJson() {
+  Object toYaml() {
     return _inlineVersion
         ? version.toString()
         : {
@@ -53,7 +58,7 @@ extension HostedDependencyExtension on HostedDependency {
 }
 
 extension GitDependencyExtension on GitDependency {
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toYaml() {
     return {
       'git': _inlineUrl
           ? url.toString()
@@ -73,7 +78,7 @@ extension GitDependencyExtension on GitDependency {
 }
 
 extension SdkDependencyExtension on SdkDependency {
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toYaml() {
     return {
       'sdk': sdk,
       'version': version.toString(),
@@ -82,7 +87,7 @@ extension SdkDependencyExtension on SdkDependency {
 }
 
 extension DependencyMapExtension on Map<String, Dependency> {
-  Map<String, Object?> toJson() {
-    return map((key, value) => MapEntry(key, value.toJson()));
+  Map<String, Object?> toYaml() {
+    return map((key, value) => MapEntry(key, value.toYaml()));
   }
 }

--- a/packages/melos/test/pubspec_extension.dart
+++ b/packages/melos/test/pubspec_extension.dart
@@ -86,13 +86,13 @@ extension PubspecExtension on Pubspec {
       'workspace': workspace,
       'resolution': resolution,
       'dependencies': dependencies.map(
-        (key, value) => MapEntry(key, value.toJson()),
+        (key, value) => MapEntry(key, value.toYaml()),
       ),
       'dev_dependencies': devDependencies.map(
-        (key, value) => MapEntry(key, value.toJson()),
+        (key, value) => MapEntry(key, value.toYaml()),
       ),
       'dependency_overrides': dependencyOverrides.map(
-        (key, value) => MapEntry(key, value.toJson()),
+        (key, value) => MapEntry(key, value.toYaml()),
       ),
       'flutter': flutter,
     }..removeWhere((_, value) => value == null);


### PR DESCRIPTION
## Description

`pubspec_parse` 1.6.0 (published 2026-08-28) added instance `toJson()` methods to the `Dependency` classes. Instance members take precedence over extension members, so melos's `toJson()` extensions in `lib/src/common/extensions/dependency.dart` are silently shadowed and no longer used. The upstream format always produces a map, while melos inlines the version or git url where pub allows it, so `melos bootstrap` and `melos version` now write dependency entries like `{version: ^1.21.0}` instead of `^1.21.0`, and the constraint rewriting in `melos version` fails with "Failed to update dependency ...".

Since `pubspec_parse: ^1.5.0` resolves to 1.6.0 on a fresh `pub get` and no lockfile is tracked, this currently breaks CI on `main` (three tests fail on every platform: `bootstrap correctly inlines shared dependencies`, `fixed mode bumps all packages to the same version based on the most significant change` and `smart-dependents versions dependents whose declared constraint does not allow the updated version`), and it also produced the "unused import" analyzer warning for `test/pubspec_extension.dart`.

This renames the melos extensions to `toYaml()` (on `Dependency`, its subclasses and `Map<String, Dependency>`) and updates the call sites in `bootstrap.dart`, `clean.dart`, the bootstrap command config and the test pubspec extension. No behavior change with `pubspec_parse` < 1.6.0.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore