### PR TITLE
feat(version): use plain vX.Y.Z tags for the root package when useRootAsPackage is enabled

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -94,6 +94,12 @@ For non-monorepo projects, you can use an empty workspace with
 This allows you to leverage Melos features like `melos version`,
 `melos publish`, and `melos run` on a single package project.
 
+**Git tags:**
+The root package uses plain version tags, e.g. `v1.2.3`, instead of tags
+prefixed with the package name, e.g. `my_package-v1.2.3`, that all other
+packages use. Existing root package tags prefixed with the package name are
+still recognized when determining the commits since the last release.
+
 **Note:** While we recommend keeping the root directory focused on workspace
 configuration for monorepos, this option provides flexibility for existing
 project structures and enables single package usage.

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -98,8 +98,9 @@ This allows you to leverage Melos features like `melos version`,
 The root package uses plain version tags, e.g. `v1.2.3`, instead of tags
 prefixed with the package name, e.g. `my_package-v1.2.3`, that all other
 packages use. Existing root package tags prefixed with the package name are
-still recognized when determining the commits since the last release, and if
-tags of both formats exist the one with the highest version is used.
+still recognized when determining the commits since the last release. If tags
+of both formats exist, the one with the highest version is used, and the plain
+version tag is preferred when both have the same version.
 
 **Note:** While we recommend keeping the root directory focused on workspace
 configuration for monorepos, this option provides flexibility for existing

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -98,7 +98,8 @@ This allows you to leverage Melos features like `melos version`,
 The root package uses plain version tags, e.g. `v1.2.3`, instead of tags
 prefixed with the package name, e.g. `my_package-v1.2.3`, that all other
 packages use. Existing root package tags prefixed with the package name are
-still recognized when determining the commits since the last release.
+still recognized when determining the commits since the last release, and if
+tags of both formats exist the one with the highest version is used.
 
 **Note:** While we recommend keeping the root directory focused on workspace
 configuration for monorepos, this option provides flexibility for existing

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -46,7 +46,8 @@ steps:
 1. Apply [filters](/filters) to the list of workspace packages.
 2. Load the commit history for each package. If the `--diff` option is
    specified, Melos will only load the specified commit. Otherwise it will load
-   all commits since the last version tag (e.g. `foo-v1.0.0`).
+   all commits since the last version tag (e.g. `foo-v1.0.0`, or `v1.0.0` for
+   the root package when `useRootAsPackage` is enabled).
 3. Parse commit messages as Conventional Commits. If a commit message does not
    follow the Conventional Commits specification, it will be ignored.
 4. Filter out commits with types that don't trigger a version bump. For example,

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -226,10 +226,7 @@ mixin _PublishMixin on _ExecMixin {
           ..newLine()
           ..log('Creating git tags for any versions not already created... ');
         await Future.forEach(unpublishedPackages, (package) async {
-          final tag = gitTagForPackageVersion(
-            package.name,
-            package.version.toString(),
-          );
+          final tag = gitTagForPackage(package, package.version.toString());
           await gitTagCreate(
             tag,
             'Publish $tag.',

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -981,13 +981,23 @@ mixin _VersionMixin on _RunMixin {
       );
     } else if (isGitDependency &&
         workspace.config.commands.version.updateGitTagRefs) {
-      final rewritten = pubspecContent.replaceAllMapped(
-        dependencyTagReplaceRegex(dependencyName),
-        (match) =>
-            '${match.group(1)}$dependencyName-'
-            'v${dependencyVersion.min ?? dependencyVersion.max!}',
-      );
-      updatedContents = rewritten == pubspecContent ? null : rewritten;
+      final dependencyPackage = workspace.allPackages[dependencyName];
+      final newVersion = dependencyVersion.min ?? dependencyVersion.max!;
+      if (dependencyPackage != null && dependencyPackage.isWorkspaceRoot) {
+        // Plain version tags carry no package name, so the ref is updated at
+        // its exact location instead of by matching the tag name.
+        updatedContents = _rewriteGitRefAtPath(
+          pubspecContent: pubspecContent,
+          path: [section, dependencyName, 'git', 'ref'],
+          ref: gitTagForPackage(dependencyPackage, newVersion.toString()),
+        );
+      } else {
+        final rewritten = pubspecContent.replaceAllMapped(
+          dependencyTagReplaceRegex(dependencyName),
+          (match) => '${match.group(1)}$dependencyName-v$newVersion',
+        );
+        updatedContents = rewritten == pubspecContent ? null : rewritten;
+      }
     } else {
       updatedContents = _rewriteDependencyVersionAtPath(
         pubspecContent: pubspecContent,
@@ -1008,6 +1018,26 @@ mixin _VersionMixin on _RunMixin {
     }
 
     await writeTextFileAsync(pubspecPath, updatedContents);
+  }
+
+  /// Returns [pubspecContent] rewritten so that the git ref scalar at [path]
+  /// is set to [ref], or `null` if [path] doesn't point to a string scalar.
+  String? _rewriteGitRefAtPath({
+    required String pubspecContent,
+    required List<Object> path,
+    required String ref,
+  }) {
+    final editor = YamlEditor(pubspecContent);
+    final currentNode = editor.parseAt(
+      path,
+      orElse: () => wrapAsYamlNode(null),
+    );
+    if (currentNode.value is! String) {
+      return null;
+    }
+
+    editor.update(path, ref);
+    return editor.toString();
   }
 
   /// Returns [pubspecContent] rewritten so that the version constraint
@@ -1308,12 +1338,18 @@ mixin _VersionMixin on _RunMixin {
         pendingPackageUpdate.nextVersion.toString(),
       );
 
-      await gitTagCreate(
+      final created = await gitTagCreate(
         tag,
         pendingPackageUpdate.changelog.markdown,
         workingDirectory: pendingPackageUpdate.package.path,
         logger: logger,
       );
+      if (!created) {
+        logger.warning(
+          'The git tag "$tag" was not created, most likely because it '
+          'already exists.',
+        );
+      }
     });
   }
 

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -1302,9 +1302,9 @@ mixin _VersionMixin on _RunMixin {
       }
 
       // TODO '--tag-version-prefix' support (if we decide to support it later)
-      // would pass prefix named arg to gitTagForPackageVersion:
-      final tag = gitTagForPackageVersion(
-        pendingPackageUpdate.package.name,
+      // would pass prefix named arg to gitTagForPackage:
+      final tag = gitTagForPackage(
+        pendingPackageUpdate.package,
         pendingPackageUpdate.nextVersion.toString(),
       );
 

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:pub_semver/pub_semver.dart';
+
 import '../logging.dart';
 import '../package.dart';
 import 'git_commit.dart';
@@ -61,6 +63,53 @@ String gitTagForPackage(
   return package.isWorkspaceRoot
       ? gitTagForVersion(packageVersion, prefix: prefix)
       : gitTagForPackageVersion(package.name, packageVersion, prefix: prefix);
+}
+
+/// Parses the version from a [tag] of [package], which is either a plain
+/// version tag, e.g. `v1.2.3`, or a tag prefixed with the package name, e.g.
+/// `package_name-v1.2.3`.
+///
+/// Returns `null` if the tag does not contain a valid version.
+Version? gitVersionFromTag(
+  String tag,
+  Package package, {
+  String prefix = 'v',
+}) {
+  final packagePrefix = '${package.name}-$prefix';
+  final String versionString;
+  if (tag.startsWith(packagePrefix)) {
+    versionString = tag.substring(packagePrefix.length);
+  } else if (tag.startsWith(prefix)) {
+    versionString = tag.substring(prefix.length);
+  } else {
+    return null;
+  }
+
+  try {
+    return Version.parse(versionString);
+  } on FormatException {
+    return null;
+  }
+}
+
+/// Returns the tag with the highest version among [tags].
+///
+/// When multiple tags have the same version, the first one in [tags] wins, so
+/// pass tags sorted by creation date descending to prefer the newest tag.
+String? _gitTagWithHighestVersion(List<String> tags, Package package) {
+  String? highestTag;
+  Version? highestVersion;
+  for (final tag in tags) {
+    final version = gitVersionFromTag(tag, package);
+    if (version == null) {
+      continue;
+    }
+    if (highestVersion == null || version > highestVersion) {
+      highestTag = tag;
+      highestVersion = version;
+    }
+  }
+  return highestTag;
 }
 
 /// Generate a git release title for the specified package name and version.
@@ -206,6 +255,10 @@ Future<bool> gitTagCreate(
 ///
 ///       Note: If the current version is a prerelease then only prerelease tags
 ///       are requested.
+///
+///       Note: The workspace root package can have both plain version tags and
+///       tags prefixed with the package name, in which case the tag with the
+///       highest version is used.
 Future<String?> gitLatestTagForPackage(
   Package package, {
   required MelosLogger logger,
@@ -249,6 +302,10 @@ Future<String?> gitLatestTagForPackage(
   );
   if (tags.isEmpty) {
     return null;
+  }
+
+  if (package.isWorkspaceRoot) {
+    return _gitTagWithHighestVersion(tags, package) ?? tags.first;
   }
 
   return tags.first;

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -94,19 +94,24 @@ Version? gitVersionFromTag(
 
 /// Returns the tag with the highest version among [tags].
 ///
-/// When multiple tags have the same version, the first one in [tags] wins, so
-/// pass tags sorted by creation date descending to prefer the newest tag.
+/// When a plain version tag and a tag prefixed with the package name have the
+/// same version, the plain version tag wins.
 String? _gitTagWithHighestVersion(List<String> tags, Package package) {
   String? highestTag;
   Version? highestVersion;
+  var highestIsPlain = false;
   for (final tag in tags) {
     final version = gitVersionFromTag(tag, package);
     if (version == null) {
       continue;
     }
-    if (highestVersion == null || version > highestVersion) {
+    final isPlain = !tag.startsWith('${package.name}-');
+    if (highestVersion == null ||
+        version > highestVersion ||
+        (version == highestVersion && isPlain && !highestIsPlain)) {
       highestTag = tag;
       highestVersion = version;
+      highestIsPlain = isPlain;
     }
   }
   return highestTag;
@@ -258,7 +263,8 @@ Future<bool> gitTagCreate(
 ///
 ///       Note: The workspace root package can have both plain version tags and
 ///       tags prefixed with the package name, in which case the tag with the
-///       highest version is used.
+///       highest version is used, preferring the plain version tag when both
+///       have the same version.
 Future<String?> gitLatestTagForPackage(
   Package package, {
   required MelosLogger logger,

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -311,7 +311,7 @@ Future<String?> gitLatestTagForPackage(
   }
 
   if (package.isWorkspaceRoot) {
-    return _gitTagWithHighestVersion(tags, package) ?? tags.first;
+    return _gitTagWithHighestVersion(tags, package);
   }
 
   return tags.first;

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -13,15 +13,21 @@ enum TagReleaseType {
 
 /// Generate a filter pattern for a package name, useful for listing tags for a
 /// package.
+///
+/// When [packageName] is `null` the pattern matches plain version tags without
+/// a package name, e.g. `v1.2.3`, as used by the workspace root package.
 String gitTagFilterPattern(
-  String packageName,
+  String? packageName,
   TagReleaseType tagReleaseType, {
   String preid = 'dev',
   String prefix = 'v',
 }) {
+  final tagPrefix = packageName == null
+      ? '$prefix[0-9]'
+      : '$packageName-$prefix';
   return tagReleaseType == TagReleaseType.prerelease
-      ? '$packageName-$prefix*-$preid.*'
-      : '$packageName-$prefix*';
+      ? '$tagPrefix*-$preid.*'
+      : '$tagPrefix*';
 }
 
 /// Generate a git tag string for the specified package name and version.
@@ -31,6 +37,30 @@ String gitTagForPackageVersion(
   String prefix = 'v',
 }) {
   return '$packageName-$prefix$packageVersion';
+}
+
+/// Generate a plain git tag string for the specified version, without a
+/// package name, e.g. `v1.2.3`.
+String gitTagForVersion(
+  String packageVersion, {
+  String prefix = 'v',
+}) {
+  return '$prefix$packageVersion';
+}
+
+/// Generate the git tag string for the specified package and version.
+///
+/// The workspace root package (included when `useRootAsPackage` is enabled)
+/// uses plain version tags, e.g. `v1.2.3`, while all other packages use tags
+/// prefixed with their package name, e.g. `package_name-v1.2.3`.
+String gitTagForPackage(
+  Package package,
+  String packageVersion, {
+  String prefix = 'v',
+}) {
+  return package.isWorkspaceRoot
+      ? gitTagForVersion(packageVersion, prefix: prefix)
+      : gitTagForPackageVersion(package.name, packageVersion, prefix: prefix);
 }
 
 /// Generate a git release title for the specified package name and version.
@@ -86,13 +116,16 @@ Future<List<String>> gitTagsForPackage(
   TagReleaseType tagReleaseType = TagReleaseType.all,
   String preid = 'dev',
 }) async {
-  final filterPattern = gitTagFilterPattern(
-    package.name,
-    tagReleaseType,
-    preid: preid,
-  );
+  // The workspace root package uses plain version tags, but tags prefixed with
+  // the package name are still matched to support tags created before plain
+  // version tags were introduced.
+  final filterPatterns = [
+    if (package.isWorkspaceRoot)
+      gitTagFilterPattern(null, tagReleaseType, preid: preid),
+    gitTagFilterPattern(package.name, tagReleaseType, preid: preid),
+  ];
   final processResult = await gitExecuteCommand(
-    arguments: ['tag', '-l', '--sort=-creatordate', filterPattern],
+    arguments: ['tag', '-l', '--sort=-creatordate', ...filterPatterns],
     workingDirectory: package.path,
     logger: logger,
   );
@@ -183,20 +216,24 @@ Future<String?> gitLatestTagForPackage(
     return null;
   }
 
-  final currentVersionTag = gitTagForPackageVersion(
-    package.name,
-    package.version.toString(),
-  );
-  if (await gitTagExists(
-    currentVersionTag,
-    workingDirectory: package.path,
-    logger: logger,
-  )) {
-    logger.trace(
-      '[GIT] Found a git tag for the latest ${package.name} version '
-      '(${package.version}).',
-    );
-    return currentVersionTag;
+  final currentVersion = package.version.toString();
+  final currentVersionTags = [
+    gitTagForPackage(package, currentVersion),
+    if (package.isWorkspaceRoot)
+      gitTagForPackageVersion(package.name, currentVersion),
+  ];
+  for (final currentVersionTag in currentVersionTags) {
+    if (await gitTagExists(
+      currentVersionTag,
+      workingDirectory: package.path,
+      logger: logger,
+    )) {
+      logger.trace(
+        '[GIT] Found a git tag for the latest ${package.name} version '
+        '(${package.version}).',
+      );
+      return currentVersionTag;
+    }
   }
 
   // If the current version is a prerelease then only prerelease tags are

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -26,11 +26,14 @@ mixin SupportsManualRelease on HostedGitRepository {
   /// Returns the URL to the prefilled release creation page for the release
   /// of a package.
   Uri releaseUrlForUpdate(MelosPendingPackageUpdate pendingPackageUpdate) {
-    final packageName = pendingPackageUpdate.package.name;
+    final package = pendingPackageUpdate.package;
     final packageVersion = pendingPackageUpdate.nextVersion.toString();
 
-    final tag = gitTagForPackageVersion(packageName, packageVersion);
-    final title = gitReleaseTitleForPackageVersion(packageName, packageVersion);
+    final tag = gitTagForPackage(package, packageVersion);
+    final title = gitReleaseTitleForPackageVersion(
+      package.name,
+      packageVersion,
+    );
     final body = pendingPackageUpdate.changelog.markdown;
     final isPreRelease = pendingPackageUpdate.nextVersion.isPreRelease;
 

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -30,10 +30,9 @@ mixin SupportsManualRelease on HostedGitRepository {
     final packageVersion = pendingPackageUpdate.nextVersion.toString();
 
     final tag = gitTagForPackage(package, packageVersion);
-    final title = gitReleaseTitleForPackageVersion(
-      package.name,
-      packageVersion,
-    );
+    final title = package.isWorkspaceRoot
+        ? tag
+        : gitReleaseTitleForPackageVersion(package.name, packageVersion);
     final body = pendingPackageUpdate.changelog.markdown;
     final isPreRelease = pendingPackageUpdate.nextVersion.isPreRelease;
 

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -1071,6 +1071,10 @@ class Package {
   /// e.g. "packages/firebase_database".
   final String pathRelativeToWorkspace;
 
+  /// Whether this package is the root package of the workspace, which is only
+  /// part of the workspace packages when `useRootAsPackage` is enabled.
+  bool get isWorkspaceRoot => pathRelativeToWorkspace == '.';
+
   late final allDependenciesInWorkspace = {
     ...dependenciesInWorkspace,
     ...devDependenciesInWorkspace,

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -2244,6 +2244,41 @@ dev_dependencies:
       );
 
       test(
+        'prefers the plain root package tag when tags of both formats have '
+        'the same version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: an old feature');
+          await _runGit(workspaceDir, ['tag', 'v0.9.0']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'workspace-v0.9.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // The plain version tag is preferred even though the tag prefixed
+          // with the package name is newer, so the feature after the plain
+          // tag is included.
+          expect(rootVersion(workspaceDir), Version(1, 1, 0));
+        },
+      );
+
+      test(
         'still recognizes root package tags prefixed with the package name',
         () async {
           final workspaceDir = await createTemporaryWorkspace(

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import '../utils.dart';
 
@@ -1148,27 +1149,6 @@ dev_dependencies:
     );
 
     group('fixed mode', () {
-      Future<void> runGit(Directory workspaceDir, List<String> args) async {
-        final result = await Process.run(
-          'git',
-          [
-            '-c',
-            'user.name=Melos Test',
-            '-c',
-            'user.email=test@melos.invertase.dev',
-            '-c',
-            'commit.gpgsign=false',
-            ...args,
-          ],
-          workingDirectory: workspaceDir.path,
-        );
-        if (result.exitCode != 0) {
-          throw Exception(
-            'git ${args.join(' ')} failed:\n${result.stdout}\n${result.stderr}',
-          );
-        }
-      }
-
       Future<void> commitPackageChange(
         Directory workspaceDir,
         String packageName,
@@ -1177,8 +1157,8 @@ dev_dependencies:
         File(
           p.join(workspaceDir.path, 'packages', packageName, 'change.txt'),
         ).writeAsStringSync(message);
-        await runGit(workspaceDir, ['add', '.']);
-        await runGit(workspaceDir, ['commit', '-m', message]);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', message]);
       }
 
       Version pubspecVersion(Directory workspaceDir, String packageName) {
@@ -1224,9 +1204,9 @@ dev_dependencies:
               },
             ),
           );
-          await runGit(workspaceDir, ['init']);
-          await runGit(workspaceDir, ['add', '.']);
-          await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+          await _runGit(workspaceDir, ['init']);
+          await _runGit(workspaceDir, ['add', '.']);
+          await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
           await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
           await commitPackageChange(workspaceDir, 'b', 'feat: a new feature');
 
@@ -1296,9 +1276,9 @@ dev_dependencies:
           workspaceDir,
           Pubspec('b', version: Version(1, 0, 0)),
         );
-        await runGit(workspaceDir, ['init']);
-        await runGit(workspaceDir, ['add', '.']);
-        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
         await commitPackageChange(workspaceDir, 'a', 'feat!: breaking change');
 
         final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
@@ -1327,9 +1307,9 @@ dev_dependencies:
           workspaceDir,
           Pubspec('b', version: Version(2, 3, 0)),
         );
-        await runGit(workspaceDir, ['init']);
-        await runGit(workspaceDir, ['add', '.']);
-        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
         await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
 
         final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
@@ -1464,9 +1444,9 @@ dev_dependencies:
           workspaceDir,
           Pubspec('b', version: Version(1, 0, 0), publishTo: 'none'),
         );
-        await runGit(workspaceDir, ['init']);
-        await runGit(workspaceDir, ['add', '.']);
-        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
         await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
 
         final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
@@ -1593,9 +1573,9 @@ dev_dependencies:
             },
           ),
         );
-        await runGit(workspaceDir, ['init']);
-        await runGit(workspaceDir, ['add', '.']);
-        await runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
         await commitPackageChange(workspaceDir, 'a', 'fix: a bug fix');
         await commitPackageChange(workspaceDir, 'core', 'feat!: breaking');
 
@@ -2106,7 +2086,178 @@ dev_dependencies:
         },
       );
     });
+
+    group('useRootAsPackage', () {
+      void setRootVersion(Directory workspaceDir, Version version) {
+        final pubspecFile = File(p.join(workspaceDir.path, 'pubspec.yaml'));
+        final editor = YamlEditor(pubspecFile.readAsStringSync())
+          ..update(['version'], version.toString());
+        pubspecFile.writeAsStringSync(editor.toString());
+      }
+
+      Future<void> commitRootChange(
+        Directory workspaceDir,
+        String message,
+      ) async {
+        File(
+          p.join(workspaceDir.path, 'change.txt'),
+        ).writeAsStringSync(message);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', message]);
+      }
+
+      Version rootVersion(Directory workspaceDir) {
+        return Pubspec.parse(
+          File(p.join(workspaceDir.path, 'pubspec.yaml')).readAsStringSync(),
+        ).version!;
+      }
+
+      test('creates plain version tags for the root package', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+          workspacePackages: ['a'],
+          useLocalTmpDirectory: true,
+        );
+        setRootVersion(workspaceDir, Version(1, 0, 0));
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['config', 'user.name', 'Melos Test']);
+        await _runGit(
+          workspaceDir,
+          ['config', 'user.email', 'test@melos.invertase.dev'],
+        );
+        await _runGit(workspaceDir, ['config', 'commit.gpgsign', 'false']);
+        await commitRootChange(workspaceDir, 'feat: a new feature');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(force: true);
+
+        expect(rootVersion(workspaceDir), Version(1, 1, 0));
+        final tags = await _gitTags(workspaceDir);
+        expect(tags, contains('v1.1.0'));
+        expect(tags, contains('a-v1.1.0'));
+        expect(tags, isNot(contains('workspace-v1.1.0')));
+      });
+
+      test(
+        'uses plain version tags to determine the commits since the last '
+        'release of the root package',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'v1.0.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // Only the fix after the plain version tag is considered, so the
+          // root package is bumped with a patch instead of a minor.
+          expect(rootVersion(workspaceDir), Version(1, 0, 1));
+        },
+      );
+
+      test(
+        'still recognizes root package tags prefixed with the package name',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'workspace-v1.0.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          expect(rootVersion(workspaceDir), Version(1, 0, 1));
+        },
+      );
+    });
   });
+}
+
+MelosWorkspaceConfig _useRootAsPackageWorkspaceConfigBuilder(String path) {
+  return MelosWorkspaceConfig(
+    path: path,
+    name: 'test_workspace',
+    packages: [
+      createGlob('packages/**', currentDirectoryPath: path),
+    ],
+    useRootAsPackage: true,
+    commands: const CommandConfigs(
+      version: VersionCommandConfigs(
+        fetchTags: false,
+      ),
+    ),
+  );
+}
+
+Future<void> _runGit(Directory workspaceDir, List<String> args) async {
+  final result = await Process.run(
+    'git',
+    [
+      '-c',
+      'user.name=Melos Test',
+      '-c',
+      'user.email=test@melos.invertase.dev',
+      '-c',
+      'commit.gpgsign=false',
+      ...args,
+    ],
+    workingDirectory: workspaceDir.path,
+  );
+  if (result.exitCode != 0) {
+    throw Exception(
+      'git ${args.join(' ')} failed:\n${result.stdout}\n${result.stderr}',
+    );
+  }
+}
+
+Future<List<String>> _gitTags(Directory workspaceDir) async {
+  final result = await Process.run(
+    'git',
+    ['tag', '-l'],
+    workingDirectory: workspaceDir.path,
+  );
+  return (result.stdout as String)
+      .split('\n')
+      .map((tag) => tag.trim())
+      .where((tag) => tag.isNotEmpty)
+      .toList();
 }
 
 MelosWorkspaceConfig _smartDependentsWorkspaceConfigBuilder(String path) {

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -2279,6 +2279,73 @@ dev_dependencies:
       );
 
       test(
+        'ignores tags that do not contain a version for the root package',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'v8_dart-v0.9.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // The tag does not belong to the root package, so the whole history
+          // is considered and the feature causes a minor bump.
+          expect(rootVersion(workspaceDir), Version(1, 1, 0));
+        },
+      );
+
+      test('warns when the root package tag already exists', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+          workspacePackages: ['a'],
+          useLocalTmpDirectory: true,
+        );
+        setRootVersion(workspaceDir, Version(1, 0, 0));
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['config', 'user.name', 'Melos Test']);
+        await _runGit(
+          workspaceDir,
+          ['config', 'user.email', 'test@melos.invertase.dev'],
+        );
+        await _runGit(workspaceDir, ['config', 'commit.gpgsign', 'false']);
+        await commitRootChange(workspaceDir, 'chore: initial');
+        await _runGit(workspaceDir, ['tag', 'v1.0.0']);
+        await commitRootChange(workspaceDir, 'feat: a new feature');
+        await _runGit(workspaceDir, ['tag', 'v1.1.0']);
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(force: true);
+
+        expect(
+          logger.output,
+          contains('The git tag "v1.1.0" was not created'),
+        );
+      });
+
+      test(
         'still recognizes root package tags prefixed with the package name',
         () async {
           final workspaceDir = await createTemporaryWorkspace(
@@ -2321,6 +2388,7 @@ MelosWorkspaceConfig _useRootAsPackageWorkspaceConfigBuilder(String path) {
     commands: const CommandConfigs(
       version: VersionCommandConfigs(
         fetchTags: false,
+        updateGitTagRefs: true,
       ),
     ),
   );

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -2179,6 +2179,71 @@ dev_dependencies:
       );
 
       test(
+        'uses the root package tag with the highest version when tags of '
+        'both formats exist',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: an old feature');
+          await _runGit(workspaceDir, ['tag', 'v0.8.0']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'workspace-v0.9.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // The tag prefixed with the package name has the highest version,
+          // so only the fix after it is considered.
+          expect(rootVersion(workspaceDir), Version(1, 0, 1));
+        },
+      );
+
+      test(
+        'prefers the plain root package tag when it has the highest version',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _useRootAsPackageWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+          setRootVersion(workspaceDir, Version(1, 0, 0));
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+          await _runGit(workspaceDir, ['init']);
+          await commitRootChange(workspaceDir, 'feat: an old feature');
+          await _runGit(workspaceDir, ['tag', 'workspace-v0.8.0']);
+          await commitRootChange(workspaceDir, 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'v0.9.0']);
+          await commitRootChange(workspaceDir, 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          expect(rootVersion(workspaceDir), Version(1, 0, 1));
+        },
+      );
+
+      test(
         'still recognizes root package tags prefixed with the package name',
         () async {
           final workspaceDir = await createTemporaryWorkspace(

--- a/packages/melos/test/git_repository_test.dart
+++ b/packages/melos/test/git_repository_test.dart
@@ -1,7 +1,34 @@
+import 'package:melos/melos.dart';
 import 'package:melos/src/common/git_repository.dart';
+import 'package:melos/src/common/pending_package_update.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+import 'utils.dart';
+
 void main() {
+  group('releaseUrlForUpdate', () {
+    test('uses the plain version tag as title for the root package', () async {
+      final workspace = await createTemporaryMelosWorkspace(
+        workspacePackages: ['a'],
+      );
+      final update = MelosPendingPackageUpdate.manual(
+        workspace,
+        workspace.rootPackage,
+        const [],
+        Version(1, 2, 3),
+        logger: TestLogger().toMelosLogger(),
+      );
+      final url = GitHubRepository(
+        owner: 'invertase',
+        name: 'melos',
+      ).releaseUrlForUpdate(update);
+
+      expect(url.queryParameters['tag'], 'v1.2.3');
+      expect(url.queryParameters['title'], 'v1.2.3');
+    });
+  });
+
   group('GitHubRepository', () {
     group('fromUrl', () {
       test('parse GitHub repository URL correctly', () {

--- a/packages/melos/test/git_test.dart
+++ b/packages/melos/test/git_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/git.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -41,6 +42,38 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    group('gitVersionFromTag', () {
+      late Package package;
+
+      setUp(() async {
+        final workspace = await createTemporaryMelosWorkspace(
+          workspacePackages: ['a'],
+        );
+        package = workspace.rootPackage;
+      });
+
+      test('parses plain version tags', () {
+        expect(gitVersionFromTag('v1.2.3', package), Version(1, 2, 3));
+        expect(
+          gitVersionFromTag('v1.2.3-dev.1', package),
+          Version.parse('1.2.3-dev.1'),
+        );
+      });
+
+      test('parses tags prefixed with the package name', () {
+        expect(
+          gitVersionFromTag('${package.name}-v1.2.3', package),
+          Version(1, 2, 3),
+        );
+      });
+
+      test('returns null for tags without a valid version', () {
+        expect(gitVersionFromTag('other-v1.2.3', package), isNull);
+        expect(gitVersionFromTag('v1.2', package), isNull);
+        expect(gitVersionFromTag('release', package), isNull);
+      });
     });
 
     test('gitExecuteCommand throws a ProcessException on error', () async {


### PR DESCRIPTION
## Description

Recreated from #1068, which was accidentally merged into the branch of #1071 instead of `main`. The `analyze` job will stay red until #1071 is merged.

When `useRootAsPackage: true` is set, the workspace root package now uses plain version tags (`v1.2.3`) instead of tags prefixed with the package name (`my_app-v1.2.3`). All other packages keep their `package_name-vX.Y.Z` tags.

- Adds `Package.isWorkspaceRoot` and `gitTagForPackage`, which `melos version`, `melos publish` and the GitHub release URL now use to build the tag name.
- Tag lookup for the root package (`gitTagsForPackage`, `gitLatestTagForPackage`) matches both plain tags and the old `package_name-vX.Y.Z` form, so repositories that already have root tags in the old format keep computing changelogs from the correct commit range.
- When tags of both formats exist, the tag with the highest version is used (parsed with `gitVersionFromTag`). If both formats have the same version, the plain `vX.Y.Z` tag is preferred; creation time is never used as a tiebreak.
- The plain tag filter is `v[0-9]*` so packages whose names start with `v` (for example `video_player-v1.0.0`) are not matched.
- Docs updated in the `useRootAsPackage` section and the automated releases guide.
- Tests: new `useRootAsPackage` group in `version_test.dart` covering tag creation, plain tag lookup, the highest version rule in both directions, the same-version preference for the plain tag, and the legacy tag fallback, plus `gitVersionFromTag` unit tests in `git_test.dart`.

### Review follow-ups

- When no candidate tag contains a parseable version (for example a sibling package named `v8_dart` whose `v8_dart-v1.0.0` tag matches the `v[0-9]*` filter), the lookup now returns no tag instead of falling back to the newest unrelated tag, so the whole history is used as before.
- `melos version` now warns when a tag could not be created because it already exists, instead of skipping silently.
- `updateGitTagRefs` rewrites git refs of dependents through the exact YAML path (`git.ref`) and `gitTagForPackage` for packages using plain tags, so refs become `vX.Y.Z` rather than `name-vX.Y.Z`. Note that the root package currently has no dependents in the workspace graph (`resolveRootPackage` builds a separate package map), so this path only becomes reachable with the `workspaceTag` PR.
- The prefilled release title for the root package is the plain tag (`v1.2.3`) instead of `my_app v1.2.3`, matching the tag.

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
