### PR TITLE
feat(version): add workspaceTag option to tag lockstep releases with a single vX.Y.Z tag

### DIFF
--- a/docs/commands/version.mdx
+++ b/docs/commands/version.mdx
@@ -58,6 +58,19 @@ versioned together, `--no-dependent-versions` has no effect in `fixed` mode.
 If there are no versionable changes in any package, `melos version` does
 nothing, just like in `independent` mode.
 
+By default each package is still tagged individually, e.g. `foo-v1.2.3`. To
+tag each release with a single plain version tag for the whole workspace
+instead, e.g. `v1.2.3`, enable
+[`command/version/workspaceTag`](/configuration/overview#workspacetag):
+
+```yaml
+melos:
+  command:
+    version:
+      mode: fixed
+      workspaceTag: true
+```
+
 ## Hooks
 
 The `version` command supports the following hooks in addition to the

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -608,6 +608,29 @@ See the
 [version command documentation](/commands/version#fixed-versioning-mode) for
 more information.
 
+### workspaceTag
+
+Whether to tag releases with a single plain version tag for the whole
+workspace, e.g. `v1.2.3`, instead of one tag per package, e.g.
+`my_package-v1.2.3`. Defaults to `false`.
+
+This option is only supported in `fixed` [mode](#mode), since all packages
+share the same version there. When enabled, `melos version` creates one
+annotated tag per release containing the changelogs of all versioned packages,
+and determines the commits since the last release from the latest plain
+version tag. Existing tags prefixed with the package name are still recognized,
+so the option can be enabled in a workspace that was previously tagged per
+package. `melos publish` also creates the plain version tag when it tags
+published versions.
+
+```yaml
+melos:
+  command:
+    version:
+      mode: fixed
+      workspaceTag: true
+```
+
 ### fetchTags
 
 Whether to fetch tags from the `origin` remote before versioning. Defaults to

--- a/docs/guides/automated-releases.mdx
+++ b/docs/guides/automated-releases.mdx
@@ -47,7 +47,8 @@ steps:
 2. Load the commit history for each package. If the `--diff` option is
    specified, Melos will only load the specified commit. Otherwise it will load
    all commits since the last version tag (e.g. `foo-v1.0.0`, or `v1.0.0` for
-   the root package when `useRootAsPackage` is enabled).
+   the root package when `useRootAsPackage` is enabled and for all packages
+   when `workspaceTag` is enabled in fixed versioning mode).
 3. Parse commit messages as Conventional Commits. If a commit message does not
    follow the Conventional Commits specification, it will be ignored.
 4. Filter out commits with types that don't trigger a version bump. For example,

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -257,6 +257,10 @@
               "enum": ["independent", "fixed"],
               "description": "The mode in which packages in the workspace are versioned. In \"fixed\" mode (also known as lockstep versioning), every versioning run bumps all packages to the same new version, which is determined by the most significant change across the whole workspace.\n\nDefaults to \"independent\"."
             },
+            "workspaceTag": {
+              "type": "boolean",
+              "description": "Whether to tag releases with a single plain version tag for the whole workspace, e.g. \"v1.2.3\", instead of one tag per package, e.g. \"package_name-v1.2.3\". Only supported when \"mode\" is \"fixed\".\n\nDefaults to false."
+            },
             "fetchTags": {
               "type": "boolean",
               "description": "Whether to fetch tags from the origin remote before versioning.\n\nDefaults to true."

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -106,12 +106,6 @@ class VersionCommandConfigs {
       map: yaml,
       path: 'command/version',
     );
-    if ((workspaceTag ?? false) && mode != VersioningMode.fixed) {
-      throw MelosConfigException(
-        'The option "command/version/workspaceTag" can only be enabled when '
-        '"command/version/mode" is "fixed".',
-      );
-    }
 
     final workspaceChangelog = assertKeyIsA<bool?>(
       key: 'workspaceChangelog',

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -32,6 +32,7 @@ class VersionCommandConfigs {
     this.updateGitTagRefs = false,
     this.releaseUrl = false,
     this.mode = VersioningMode.independent,
+    this.workspaceTag = false,
     List<AggregateChangelogConfig>? aggregateChangelogs,
     this.fetchTags = true,
     this.hooks = VersionLifecycleHooks.empty,
@@ -99,6 +100,18 @@ class VersionCommandConfigs {
         'or "fixed" but got "$modeName".',
       ),
     };
+
+    final workspaceTag = assertKeyIsA<bool?>(
+      key: 'workspaceTag',
+      map: yaml,
+      path: 'command/version',
+    );
+    if ((workspaceTag ?? false) && mode != VersioningMode.fixed) {
+      throw MelosConfigException(
+        'The option "command/version/workspaceTag" can only be enabled when '
+        '"command/version/mode" is "fixed".',
+      );
+    }
 
     final workspaceChangelog = assertKeyIsA<bool?>(
       key: 'workspaceChangelog',
@@ -223,6 +236,7 @@ class VersionCommandConfigs {
       updateGitTagRefs: updateGitTagRefs ?? false,
       releaseUrl: releaseUrl ?? false,
       mode: mode,
+      workspaceTag: workspaceTag ?? false,
       aggregateChangelogs: aggregateChangelogs,
       fetchTags: fetchTags ?? true,
       hooks: hooks,
@@ -276,6 +290,14 @@ class VersionCommandConfigs {
   /// [VersioningMode.independent].
   final VersioningMode mode;
 
+  /// Whether to tag releases with a single plain version tag for the whole
+  /// workspace, e.g. `v1.2.3`, instead of one tag per package, e.g.
+  /// `package_name-v1.2.3`.
+  ///
+  /// Only supported in [VersioningMode.fixed] mode, since all packages share
+  /// the same version there. Defaults to `false`.
+  final bool workspaceTag;
+
   /// A list of changelogs configurations that will be used to generate
   /// changelogs which describe the changes in multiple packages.
   List<AggregateChangelogConfig> get aggregateChangelogs =>
@@ -307,6 +329,7 @@ class VersionCommandConfigs {
       'updateGitTagRefs': updateGitTagRefs,
       'smartDependents': smartDependents,
       'mode': mode.name,
+      'workspaceTag': workspaceTag,
       'aggregateChangelogs': aggregateChangelogs
           .map((config) => config.toJson())
           .toList(),
@@ -332,6 +355,7 @@ class VersionCommandConfigs {
       other.releaseUrl == releaseUrl &&
       other.smartDependents == smartDependents &&
       other.mode == mode &&
+      other.workspaceTag == workspaceTag &&
       const DeepCollectionEquality().equals(
         other.aggregateChangelogs,
         aggregateChangelogs,
@@ -353,6 +377,7 @@ class VersionCommandConfigs {
       releaseUrl.hashCode ^
       smartDependents.hashCode ^
       mode.hashCode ^
+      workspaceTag.hashCode ^
       const DeepCollectionEquality().hash(aggregateChangelogs) ^
       fetchTags.hashCode ^
       hooks.hashCode ^
@@ -372,6 +397,7 @@ VersionCommandConfigs(
   releaseUrl: $releaseUrl,
   smartDependents: $smartDependents,
   mode: ${mode.name},
+  workspaceTag: $workspaceTag,
   aggregateChangelogs: $aggregateChangelogs,
   fetchTags: $fetchTags,
   hooks: $hooks,

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -226,7 +226,11 @@ mixin _PublishMixin on _ExecMixin {
           ..newLine()
           ..log('Creating git tags for any versions not already created... ');
         await Future.forEach(unpublishedPackages, (package) async {
-          final tag = gitTagForPackage(package, package.version.toString());
+          final tag = gitTagForPackage(
+            package,
+            package.version.toString(),
+            workspaceTag: workspace.config.commands.version.workspaceTag,
+          );
           await gitTagCreate(
             tag,
             'Publish $tag.',

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -225,19 +225,37 @@ mixin _PublishMixin on _ExecMixin {
         logger
           ..newLine()
           ..log('Creating git tags for any versions not already created... ');
-        await Future.forEach(unpublishedPackages, (package) async {
-          final tag = gitTagForPackage(
-            package,
-            package.version.toString(),
-            workspaceTag: workspace.config.commands.version.workspaceTag,
-          );
-          await gitTagCreate(
-            tag,
-            'Publish $tag.',
-            workingDirectory: package.path,
-            logger: logger,
-          );
-        });
+        if (workspace.config.commands.version.workspaceTag) {
+          final versions = unpublishedPackages
+              .map((package) => package.version)
+              .toSet();
+          if (versions.length == 1) {
+            final tag = gitTagForVersion(versions.single.toString());
+            await gitTagCreate(
+              tag,
+              'Publish $tag.',
+              workingDirectory: workspace.path,
+              logger: logger,
+            );
+          } else {
+            logger.warning(
+              'Skipping git tag creation since the published packages have '
+              'different versions (${versions.join(', ')}), while '
+              '"command/version/workspaceTag" expects all packages to share '
+              'the same version.',
+            );
+          }
+        } else {
+          await Future.forEach(unpublishedPackages, (package) async {
+            final tag = gitTagForPackage(package, package.version.toString());
+            await gitTagCreate(
+              tag,
+              'Publish $tag.',
+              workingDirectory: package.path,
+              logger: logger,
+            );
+          });
+        }
       }
 
       updateRegistryProgress.finish(

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -999,13 +999,22 @@ mixin _VersionMixin on _RunMixin {
         workspace.config.commands.version.updateGitTagRefs) {
       final dependencyPackage = workspace.allPackages[dependencyName];
       final newVersion = dependencyVersion.min ?? dependencyVersion.max!;
-      if (dependencyPackage != null && dependencyPackage.isWorkspaceRoot) {
+      final workspaceTag = workspace.config.commands.version.workspaceTag;
+      if (dependencyPackage != null &&
+          gitPackageUsesPlainVersionTag(
+            dependencyPackage,
+            workspaceTag: workspaceTag,
+          )) {
         // Plain version tags carry no package name, so the ref is updated at
         // its exact location instead of by matching the tag name.
         updatedContents = _rewriteGitRefAtPath(
           pubspecContent: pubspecContent,
           path: [section, dependencyName, 'git', 'ref'],
-          ref: gitTagForPackage(dependencyPackage, newVersion.toString()),
+          ref: gitTagForPackage(
+            dependencyPackage,
+            newVersion.toString(),
+            workspaceTag: workspaceTag,
+          ),
         );
       } else {
         final rewritten = pubspecContent.replaceAllMapped(
@@ -1363,12 +1372,18 @@ mixin _VersionMixin on _RunMixin {
       final tag = gitTagForVersion(
         pendingPackageUpdates.first.nextVersion.toString(),
       );
-      await gitTagCreate(
+      final created = await gitTagCreate(
         tag,
         _workspaceReleaseNotes(pendingPackageUpdates),
         workingDirectory: workspace.path,
         logger: logger,
       );
+      if (!created) {
+        logger.warning(
+          'The git tag "$tag" was not created, most likely because it '
+          'already exists.',
+        );
+      }
       return;
     }
 

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -451,6 +451,7 @@ mixin _VersionMixin on _RunMixin {
 
     if (gitTag && gitCommit) {
       await _gitTagChanges(
+        workspace,
         pendingPackageUpdates,
         updateDependentsVersions: updateDependentsVersions,
       );
@@ -481,6 +482,21 @@ mixin _VersionMixin on _RunMixin {
         );
       } else if (repository is! SupportsManualRelease) {
         logger.warning('Repository does not support releases urls');
+      } else if (config.commands.version.workspaceTag) {
+        final workspaceVersion = pendingPackageUpdates.first.nextVersion;
+        final tag = gitTagForVersion(workspaceVersion.toString());
+        final releaseUrl = repository.releaseUrl(
+          tag: tag,
+          title: tag,
+          body: _workspaceReleaseNotes(pendingPackageUpdates),
+          isPreRelease: workspaceVersion.isPreRelease,
+        );
+
+        logger.success(
+          'Make sure you create a release for the new workspace version:'
+          '${ansiStylesDisabled ? '\n' : ' '}'
+          '${AnsiStyles.bgBlack.gray(link(releaseUrl, tag))}',
+        );
       } else {
         final pendingPackageReleases = pendingPackageUpdates
             .map((update) {
@@ -1281,6 +1297,7 @@ mixin _VersionMixin on _RunMixin {
       final commits = await gitCommitsForPackage(
         package,
         diff: diff,
+        workspaceTag: workspace.config.commands.version.workspaceTag,
         logger: logger,
       );
       final hasVersionableCommit = commits
@@ -1310,6 +1327,7 @@ mixin _VersionMixin on _RunMixin {
       final commits = await gitCommitsForPackage(
         package,
         diff: diff,
+        workspaceTag: workspace.config.commands.version.workspaceTag,
         logger: logger,
       );
 
@@ -1321,10 +1339,39 @@ mixin _VersionMixin on _RunMixin {
     return packageCommits;
   }
 
+  /// Release notes for a single workspace release, listing the changelog of
+  /// every versioned package under a heading with the package name.
+  String _workspaceReleaseNotes(
+    List<MelosPendingPackageUpdate> pendingPackageUpdates,
+  ) {
+    return pendingPackageUpdates
+        .map(
+          (update) =>
+              '# ${update.package.name}\n\n${update.changelog.markdown}',
+        )
+        .join('\n');
+  }
+
   Future<void> _gitTagChanges(
+    MelosWorkspace workspace,
     List<MelosPendingPackageUpdate> pendingPackageUpdates, {
     required bool updateDependentsVersions,
   }) async {
+    if (workspace.config.commands.version.workspaceTag) {
+      // All packages share the same version in fixed versioning mode, so a
+      // single plain version tag is created for the whole workspace.
+      final tag = gitTagForVersion(
+        pendingPackageUpdates.first.nextVersion.toString(),
+      );
+      await gitTagCreate(
+        tag,
+        _workspaceReleaseNotes(pendingPackageUpdates),
+        workingDirectory: workspace.path,
+        logger: logger,
+      );
+      return;
+    }
+
     await Future.forEach(pendingPackageUpdates, (pendingPackageUpdate) async {
       if (pendingPackageUpdate.reason == PackageUpdateReason.dependency &&
           !updateDependentsVersions) {

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -247,9 +247,17 @@ Future<bool> gitTagCreate(
     return false;
   }
 
-  final arguments = commitId != null && commitId.isNotEmpty
-      ? ['tag', '-a', tag, commitId, '-m', message]
-      : ['tag', '-a', tag, '-m', message];
+  // Git strips lines starting with `#` from the message by default, which
+  // would remove the markdown headings of the changelog.
+  final arguments = [
+    'tag',
+    '-a',
+    tag,
+    if (commitId != null && commitId.isNotEmpty) commitId,
+    '--cleanup=whitespace',
+    '-m',
+    message,
+  ];
 
   await gitExecuteCommand(
     arguments: arguments,

--- a/packages/melos/lib/src/common/git.dart
+++ b/packages/melos/lib/src/common/git.dart
@@ -50,17 +50,31 @@ String gitTagForVersion(
   return '$prefix$packageVersion';
 }
 
+/// Whether [package] is tagged with plain version tags, e.g. `v1.2.3`, instead
+/// of tags prefixed with the package name, e.g. `package_name-v1.2.3`.
+///
+/// This is the case for the workspace root package (included when
+/// `useRootAsPackage` is enabled) and for every package when the workspace is
+/// versioned in lockstep with a single [workspaceTag].
+bool gitPackageUsesPlainVersionTag(
+  Package package, {
+  required bool workspaceTag,
+}) {
+  return workspaceTag || package.isWorkspaceRoot;
+}
+
 /// Generate the git tag string for the specified package and version.
 ///
-/// The workspace root package (included when `useRootAsPackage` is enabled)
-/// uses plain version tags, e.g. `v1.2.3`, while all other packages use tags
-/// prefixed with their package name, e.g. `package_name-v1.2.3`.
+/// Packages for which [gitPackageUsesPlainVersionTag] is true use plain
+/// version tags, e.g. `v1.2.3`, while all other packages use tags prefixed
+/// with their package name, e.g. `package_name-v1.2.3`.
 String gitTagForPackage(
   Package package,
   String packageVersion, {
   String prefix = 'v',
+  bool workspaceTag = false,
 }) {
-  return package.isWorkspaceRoot
+  return gitPackageUsesPlainVersionTag(package, workspaceTag: workspaceTag)
       ? gitTagForVersion(packageVersion, prefix: prefix)
       : gitTagForPackageVersion(package.name, packageVersion, prefix: prefix);
 }
@@ -169,12 +183,13 @@ Future<List<String>> gitTagsForPackage(
   required MelosLogger logger,
   TagReleaseType tagReleaseType = TagReleaseType.all,
   String preid = 'dev',
+  bool workspaceTag = false,
 }) async {
-  // The workspace root package uses plain version tags, but tags prefixed with
-  // the package name are still matched to support tags created before plain
-  // version tags were introduced.
+  // Packages using plain version tags still match tags prefixed with the
+  // package name, to support tags created before plain version tags were
+  // introduced or enabled.
   final filterPatterns = [
-    if (package.isWorkspaceRoot)
+    if (gitPackageUsesPlainVersionTag(package, workspaceTag: workspaceTag))
       gitTagFilterPattern(null, tagReleaseType, preid: preid),
     gitTagFilterPattern(package.name, tagReleaseType, preid: preid),
   ];
@@ -261,14 +276,15 @@ Future<bool> gitTagCreate(
 ///       Note: If the current version is a prerelease then only prerelease tags
 ///       are requested.
 ///
-///       Note: The workspace root package can have both plain version tags and
-///       tags prefixed with the package name, in which case the tag with the
-///       highest version is used, preferring the plain version tag when both
-///       have the same version.
+///       Note: Packages using plain version tags can also have tags prefixed
+///       with the package name, in which case the tag with the highest version
+///       is used, preferring the plain version tag when both have the same
+///       version.
 Future<String?> gitLatestTagForPackage(
   Package package, {
   required MelosLogger logger,
   String preid = 'dev',
+  bool workspaceTag = false,
 }) async {
   // Package doesn't have a version, skip.
   if (package.version.toString() == '0.0.0') {
@@ -277,8 +293,8 @@ Future<String?> gitLatestTagForPackage(
 
   final currentVersion = package.version.toString();
   final currentVersionTags = [
-    gitTagForPackage(package, currentVersion),
-    if (package.isWorkspaceRoot)
+    gitTagForPackage(package, currentVersion, workspaceTag: workspaceTag),
+    if (gitPackageUsesPlainVersionTag(package, workspaceTag: workspaceTag))
       gitTagForPackageVersion(package.name, currentVersion),
   ];
   for (final currentVersionTag in currentVersionTags) {
@@ -304,13 +320,14 @@ Future<String?> gitLatestTagForPackage(
     package,
     tagReleaseType: tagReleaseType,
     preid: preid,
+    workspaceTag: workspaceTag,
     logger: logger,
   );
   if (tags.isEmpty) {
     return null;
   }
 
-  if (package.isWorkspaceRoot) {
+  if (gitPackageUsesPlainVersionTag(package, workspaceTag: workspaceTag)) {
     return _gitTagWithHighestVersion(tags, package);
   }
 
@@ -364,14 +381,19 @@ final _gitVersionRangeShortHandRegExp = RegExp(r'^.+\.{2,3}.+$');
 /// Optionally specify [diff] to start after a specified commit or tag.
 /// Defaults to the latest release tag.
 /// Diff also supports specifying a range of commits, e.g. `HEAD~5..HEAD`.
+///
+/// When [workspaceTag] is true, the latest release tag is a plain version tag
+/// shared by the whole workspace, see [gitPackageUsesPlainVersionTag].
 Future<List<GitCommit>> gitCommitsForPackage(
   Package package, {
   required MelosLogger logger,
   String? diff,
+  bool workspaceTag = false,
 }) async {
   final revisionRange = await _resolveRevisionRange(
     package,
     diff: diff,
+    workspaceTag: workspaceTag,
     logger: logger,
   );
 
@@ -516,6 +538,7 @@ Future<String> _resolveRevisionRange(
   Package package, {
   required String? diff,
   required MelosLogger logger,
+  bool workspaceTag = false,
 }) async {
   var revisionRange = diff?.trim();
   if (revisionRange != null) {
@@ -532,7 +555,11 @@ Future<String> _resolveRevisionRange(
   }
 
   if (revisionRange == null) {
-    final latestTag = await gitLatestTagForPackage(package, logger: logger);
+    final latestTag = await gitLatestTagForPackage(
+      package,
+      workspaceTag: workspaceTag,
+      logger: logger,
+    );
     // If no latest tag is found then we default to the entire git history.
     return latestTag != null ? '$latestTag...HEAD' : 'HEAD';
   }

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -28,9 +28,16 @@ mixin SupportsManualRelease on HostedGitRepository {
   Uri releaseUrlForUpdate(MelosPendingPackageUpdate pendingPackageUpdate) {
     final package = pendingPackageUpdate.package;
     final packageVersion = pendingPackageUpdate.nextVersion.toString();
+    final workspaceTag =
+        pendingPackageUpdate.workspace.config.commands.version.workspaceTag;
 
-    final tag = gitTagForPackage(package, packageVersion);
-    final title = package.isWorkspaceRoot
+    final tag = gitTagForPackage(
+      package,
+      packageVersion,
+      workspaceTag: workspaceTag,
+    );
+    final title =
+        gitPackageUsesPlainVersionTag(package, workspaceTag: workspaceTag)
         ? tag
         : gitReleaseTitleForPackageVersion(package.name, packageVersion);
     final body = pendingPackageUpdate.changelog.markdown;

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -674,6 +674,14 @@ class MelosWorkspaceConfig {
       );
     }
 
+    if (commands.version.workspaceTag &&
+        commands.version.mode != VersioningMode.fixed) {
+      throw MelosConfigException(
+        'commands/version/workspaceTag can only be enabled if '
+        'commands/version/mode is "fixed"',
+      );
+    }
+
     scripts.validate();
     _validatePhysicalWorkspace();
   }

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -2148,6 +2148,59 @@ dev_dependencies:
         expect(pubspecVersion(workspaceDir, 'a'), Version(1, 1, 0));
         expect(pubspecVersion(workspaceDir, 'b'), Version(1, 1, 0));
         expect(await _gitTags(workspaceDir), ['v1.1.0']);
+
+        // The tag message keeps the markdown headings of the release notes.
+        final tagMessage = await _gitTagMessage(workspaceDir, 'v1.1.0');
+        expect(tagMessage, contains('# a'));
+        expect(tagMessage, contains('# b'));
+        expect(tagMessage, contains('## 1.1.0'));
+        expect(tagMessage, contains('a new feature'));
+      });
+
+      test('updates git refs of dependents to the plain version tag', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _workspaceTagWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec(
+            'b',
+            version: Version(1, 0, 0),
+            dependencies: {
+              'a': GitDependency(
+                Uri.parse('https://github.com/invertase/melos.git'),
+                ref: 'v1.0.0',
+              ),
+            },
+          ),
+        );
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await _runGit(workspaceDir, ['tag', 'v1.0.0']);
+        File(
+          p.join(workspaceDir.path, 'packages', 'a', 'change.txt'),
+        ).writeAsStringSync('feat');
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'feat: a new feature']);
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.version(gitCommit: false, gitTag: false, force: true);
+
+        final pubspecB = File(
+          p.join(workspaceDir.path, 'packages/b/pubspec.yaml'),
+        ).readAsStringSync();
+        expect(pubspecB, contains('ref: v1.1.0'));
+        expect(pubspecB, isNot(contains('a-v1.1.0')));
       });
 
       test(
@@ -2521,6 +2574,7 @@ MelosWorkspaceConfig _workspaceTagWorkspaceConfigBuilder(String path) {
         fetchTags: false,
         mode: VersioningMode.fixed,
         workspaceTag: true,
+        updateGitTagRefs: true,
       ),
     ),
   );
@@ -2562,6 +2616,15 @@ Future<void> _runGit(Directory workspaceDir, List<String> args) async {
       'git ${args.join(' ')} failed:\n${result.stdout}\n${result.stderr}',
     );
   }
+}
+
+Future<String> _gitTagMessage(Directory workspaceDir, String tag) async {
+  final result = await Process.run(
+    'git',
+    ['tag', '-l', '--format=%(contents)', tag],
+    workingDirectory: workspaceDir.path,
+  );
+  return result.stdout as String;
 }
 
 Future<List<String>> _gitTags(Directory workspaceDir) async {

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -2087,6 +2087,138 @@ dev_dependencies:
       );
     });
 
+    group('workspaceTag', () {
+      Future<void> commitPackageChange(
+        Directory workspaceDir,
+        String packageName,
+        String message,
+      ) async {
+        File(
+          p.join(workspaceDir.path, 'packages', packageName, 'change.txt'),
+        ).writeAsStringSync(message);
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', message]);
+      }
+
+      Version pubspecVersion(Directory workspaceDir, String packageName) {
+        return Pubspec.parse(
+          File(
+            p.join(workspaceDir.path, 'packages', packageName, 'pubspec.yaml'),
+          ).readAsStringSync(),
+        ).version!;
+      }
+
+      Future<Directory> createWorkspace() async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _workspaceTagWorkspaceConfigBuilder,
+          workspacePackages: ['a', 'b'],
+          useLocalTmpDirectory: true,
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+        await createProject(
+          workspaceDir,
+          Pubspec('b', version: Version(1, 0, 0)),
+        );
+        await _runGit(workspaceDir, ['init']);
+        await _runGit(workspaceDir, ['config', 'user.name', 'Melos Test']);
+        await _runGit(
+          workspaceDir,
+          ['config', 'user.email', 'test@melos.invertase.dev'],
+        );
+        await _runGit(workspaceDir, ['config', 'commit.gpgsign', 'false']);
+        return workspaceDir;
+      }
+
+      test('creates a single plain version tag for the workspace', () async {
+        final workspaceDir = await createWorkspace();
+        await _runGit(workspaceDir, ['add', '.']);
+        await _runGit(workspaceDir, ['commit', '-m', 'chore: initial']);
+        await commitPackageChange(workspaceDir, 'a', 'feat: a new feature');
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        final melos = Melos(config: config, logger: logger);
+        await melos.bootstrap(offline: true);
+        await melos.version(force: true);
+
+        expect(pubspecVersion(workspaceDir, 'a'), Version(1, 1, 0));
+        expect(pubspecVersion(workspaceDir, 'b'), Version(1, 1, 0));
+        expect(await _gitTags(workspaceDir), ['v1.1.0']);
+      });
+
+      test(
+        'uses the plain version tag to determine the commits since the last '
+        'release',
+        () async {
+          final workspaceDir = await createWorkspace();
+          await commitPackageChange(workspaceDir, 'a', 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'v1.0.0']);
+          await commitPackageChange(workspaceDir, 'b', 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          // Only the fix after the workspace tag is considered, so the
+          // workspace is bumped with a patch instead of a minor.
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+        },
+      );
+
+      test(
+        'uses the tag with the highest version when tags of both formats '
+        'exist',
+        () async {
+          final workspaceDir = await createWorkspace();
+          await commitPackageChange(workspaceDir, 'a', 'feat: an old feature');
+          await _runGit(workspaceDir, ['tag', 'v0.8.0']);
+          await commitPackageChange(workspaceDir, 'a', 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'a-v0.9.0']);
+          await _runGit(workspaceDir, ['tag', 'b-v0.9.0']);
+          await commitPackageChange(workspaceDir, 'b', 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+        },
+      );
+
+      test(
+        'still recognizes tags prefixed with the package name',
+        () async {
+          final workspaceDir = await createWorkspace();
+          await commitPackageChange(workspaceDir, 'a', 'feat: a new feature');
+          await _runGit(workspaceDir, ['tag', 'a-v1.0.0']);
+          await _runGit(workspaceDir, ['tag', 'b-v1.0.0']);
+          await commitPackageChange(workspaceDir, 'b', 'fix: a bug fix');
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+          final melos = Melos(config: config, logger: logger);
+          await melos.bootstrap(offline: true);
+          await melos.version(gitCommit: false, gitTag: false, force: true);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          expect(pubspecVersion(workspaceDir, 'b'), Version(1, 0, 1));
+        },
+      );
+    });
+
     group('useRootAsPackage', () {
       void setRootVersion(Directory workspaceDir, Version version) {
         final pubspecFile = File(p.join(workspaceDir.path, 'pubspec.yaml'));
@@ -2375,6 +2507,23 @@ dev_dependencies:
       );
     });
   });
+}
+
+MelosWorkspaceConfig _workspaceTagWorkspaceConfigBuilder(String path) {
+  return MelosWorkspaceConfig(
+    path: path,
+    name: 'test_workspace',
+    packages: [
+      createGlob('packages/**', currentDirectoryPath: path),
+    ],
+    commands: const CommandConfigs(
+      version: VersionCommandConfigs(
+        fetchTags: false,
+        mode: VersioningMode.fixed,
+        workspaceTag: true,
+      ),
+    ),
+  );
 }
 
 MelosWorkspaceConfig _useRootAsPackageWorkspaceConfigBuilder(String path) {

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -163,18 +163,47 @@ void main() {
 
       test('throws if workspaceTag is enabled outside of fixed mode', () {
         expect(
-          () => VersionCommandConfigs.fromYaml(
-            const {'workspaceTag': true},
-            workspacePath: '.',
+          () => MelosWorkspaceConfig(
+            name: 'melos_test',
+            packages: const [],
+            commands: const CommandConfigs(
+              version: VersionCommandConfigs(workspaceTag: true),
+            ),
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
         );
         expect(
-          () => VersionCommandConfigs.fromYaml(
-            const {'mode': 'independent', 'workspaceTag': true},
-            workspacePath: '.',
+          () => MelosWorkspaceConfig.fromYaml(
+            const {
+              'name': 'melos_test',
+              'melos': {
+                'command': {
+                  'version': {'mode': 'independent', 'workspaceTag': true},
+                },
+              },
+            },
+            path: testWorkspacePath,
           ),
           throwsMelosConfigException(),
+        );
+      });
+
+      test('accepts workspaceTag in fixed mode', () async {
+        final workspace = await createTemporaryWorkspace(workspacePackages: []);
+        expect(
+          MelosWorkspaceConfig(
+            name: 'melos_test',
+            packages: const [],
+            commands: const CommandConfigs(
+              version: VersionCommandConfigs(
+                mode: VersioningMode.fixed,
+                workspaceTag: true,
+              ),
+            ),
+            path: workspace.path,
+          ).commands.version.workspaceTag,
+          isTrue,
         );
       });
 

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -151,6 +151,43 @@ void main() {
         );
       });
 
+      test('throws if workspaceTag is not a bool', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'mode': 'fixed', 'workspaceTag': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('throws if workspaceTag is enabled outside of fixed mode', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'workspaceTag': true},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'mode': 'independent', 'workspaceTag': true},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('workspaceTag defaults to false', () {
+        expect(
+          VersionCommandConfigs.fromYaml(
+            const {'mode': 'fixed'},
+            workspacePath: '.',
+          ).workspaceTag,
+          isFalse,
+        );
+      });
+
       test('can decode values', () {
         expect(
           VersionCommandConfigs.fromYaml(
@@ -162,6 +199,7 @@ void main() {
               'linkToCommits': true,
               'updateGitTagRefs': true,
               'mode': 'fixed',
+              'workspaceTag': true,
               'workspaceChangelog': true,
               'changelogs': [
                 {
@@ -180,6 +218,7 @@ void main() {
             linkToCommits: true,
             updateGitTagRefs: true,
             mode: VersioningMode.fixed,
+            workspaceTag: true,
             aggregateChangelogs: [
               AggregateChangelogConfig.workspace(),
               AggregateChangelogConfig(


### PR DESCRIPTION
## Description

Recreated from #1069, which was accidentally merged into the branch of #1071 instead of `main`. Stacked on #1072, so merge that one first (GitHub retargets this PR to `main` once #1072 is merged). The `analyze` job will stay red until #1071 is merged.

Adds an opt-in `command/version/workspaceTag` option (default `false`, only allowed together with `mode: fixed`) that tags lockstep releases with a single plain version tag for the whole workspace, `v1.2.3`, instead of one `package_name-v1.2.3` tag per package.

```yaml
melos:
  command:
    version:
      mode: fixed
      workspaceTag: true
```

When enabled:

- `melos version` creates one annotated `vX.Y.Z` tag at the workspace root. The tag message lists the changelog of every versioned package under a heading with the package name.
- Commits since the last release are determined from the latest plain version tag. Tags prefixed with the package name are still recognized, so the option can be turned on in a workspace that was previously tagged per package. When tags of both formats exist, the one with the highest version is used, and the plain `vX.Y.Z` tag is preferred when both have the same version (same rule as for the root package in #1072).
- `--release-url` prints a single release link for the workspace tag, with the same release notes as the tag message.
- `melos publish --git-tag-version` creates the plain version tag for published versions.
- Enabling it in `independent` mode is a configuration error, since packages do not share a version there.

Also updates the JSON schema, the configuration and version command docs, and the automated releases guide.

Tests: config parsing (invalid type, wrong mode, default, decode) in `workspace_config_test.dart`, and a `workspaceTag` group in `version_test.dart` covering tag creation, commit range from a plain tag, the highest version rule across both tag formats, and the legacy per-package tag fallback.

### Review follow-ups

- `git tag -m` strips lines starting with `#` by default, which removed the `# package` and `## x.y.z` headings from tag messages. `gitTagCreate` now passes `--cleanup=whitespace`, and a test asserts the headings survive in the workspace tag message.
- `melos version` warns when the workspace tag already exists instead of skipping silently.
- `melos publish --git-tag-version` with `workspaceTag` only creates the `vX.Y.Z` tag when all published packages share one version, and warns otherwise, so a package at a diverged version cannot produce a stray workspace level tag.
- The `workspaceTag` requires `mode: fixed` check moved from `VersionCommandConfigs.fromYaml` to `MelosWorkspaceConfig._validate`, so programmatic construction of the config is validated too.
- `releaseUrlForUpdate` and the `updateGitTagRefs` rewrite are `workspaceTag` aware: release titles use the plain tag and git refs of dependents are rewritten to `vX.Y.Z` (covered by a new test where `b` depends on `a` through a git ref).

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
