### PR TITLE
fix(deps): Support cli_util 0.6 and pub_updater 0.6

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   args: ^2.7.0
   async: ^2.13.0
   cli_launcher: ^0.3.3+2
-  cli_util: ^0.5.0
+  cli_util: ">=0.5.0 <0.7.0"
   collection: ^1.19.0
   conventional_commit: ^0.6.1+1
   file: ^7.0.1
@@ -41,7 +41,7 @@ dependencies:
   pool: ^1.5.1
   prompts: ^2.0.0
   pub_semver: ^2.2.0
-  pub_updater: ^0.5.0
+  pub_updater: ">=0.5.0 <0.7.0"
   pubspec_parse: ^1.5.0
   string_scanner: ^1.4.1
   # TODO: Bump to ^7.0.1 once the Dart SDK floor is raised to ^3.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ melos:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
         cli_launcher: ^0.3.3+2
-        cli_util: ^0.5.0
+        cli_util: ">=0.5.0 <0.7.0"
         collection: ^1.19.0
         file: ^7.0.1
         glob: ^2.1.3
@@ -45,7 +45,7 @@ melos:
         pool: ^1.5.1
         prompts: ^2.0.0
         pub_semver: ^2.2.0
-        pub_updater: ^0.5.0
+        pub_updater: ">=0.5.0 <0.7.0"
         pubspec_parse: ^1.5.0
         string_scanner: ^1.4.1
         yaml: ^3.1.3


### PR DESCRIPTION
## Description

- Updates `package:cli_util` constraint to allow `0.6.x` versions.
  No changes affect `melos`, so both minor versions can be supported.
- Updates `package:pub_updater` constraint to allow `0.6.x` versions.
  No changes affect `melos`, so both minor versions can be supported.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [x] 🗑️ `chore` -- Chore
