### PR TITLE
chore: constrain the platform dependency to below 3.2.0

### DIFF
--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -37,7 +37,10 @@ dependencies:
   meta: ^1.16.0
   mustache_template: ^2.0.0
   path: ^1.9.0
-  platform: ^3.1.6
+  # Version 3.2.0 deprecates the APIs that Melos uses, in favour of
+  # `NativePlatform`, and requires Dart 3.10. Raise this constraint and migrate
+  # to `NativePlatform` when the minimum Dart SDK is bumped past 3.10.
+  platform: ">=3.1.6 <3.2.0"
   pool: ^1.5.1
   prompts: ^2.0.0
   pub_semver: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,11 @@ melos:
         meta: ^1.16.0
         mustache_template: ^2.0.0
         path: ^1.9.0
-        platform: ^3.1.6
+        # Version 3.2.0 deprecates the APIs that Melos uses, in favour of
+        # `NativePlatform`, and requires Dart 3.10. Raise this constraint and
+        # migrate to `NativePlatform` when the minimum Dart SDK is bumped past
+        # 3.10.
+        platform: ">=3.1.6 <3.2.0"
         pool: ^1.5.1
         prompts: ^2.0.0
         pub_semver: ^2.2.0


### PR DESCRIPTION
The `platform` package deprecated `LocalPlatform`, `FakePlatform` and the members of `Platform` in version 3.2.0, in favour of `NativePlatform` and, for tests, `TestNativePlatform`.

No lockfile is committed and the constraint was `^3.1.6`, so every fresh resolution picks 3.2.0, which makes the analyze job fail with 48 diagnostics, as it runs `melos analyze --fatal-infos --fatal-warnings`. This is currently failing on every branch, not only on new pull requests.

Migrating to `NativePlatform` is not possible yet: version 3.2.0 requires Dart 3.10, while Melos supports Dart 3.9 and has a `dart_version` job that guards it. So the constraint is lowered to below 3.2.0 instead, which keeps the deprecated but still working APIs of 3.1.6, where they produce no diagnostics.

Both pubspecs carry a note that the constraint has to be raised, and the migration to `NativePlatform` done, once the minimum Dart SDK of Melos is bumped past 3.10:

```yaml
  # Version 3.2.0 deprecates the APIs that Melos uses, in favour of
  # `NativePlatform`, and requires Dart 3.10. Raise this constraint and migrate
  # to `NativePlatform` when the minimum Dart SDK is bumped past 3.10.
  platform: ">=3.1.6 <3.2.0"
```

The migration itself is a small change, for whoever picks it up later: `currentPlatform` becomes a `NativePlatform` that falls back to `NativePlatform.current!`, every member Melos reads is available on it, and the tests construct a `TestNativePlatform` instead of a `FakePlatform`, with a helper for the ones that add a variable to the environment of the current platform, since the new test platform is immutable.

### Verification

`melos analyze --fatal-infos --fatal-warnings` passes with no issues once `platform` resolves to 3.1.6 again.
