### PR TITLE
feat: add --no-pub flag to bootstrap, test and analyze commands

### DIFF
--- a/docs/commands/analyze.mdx
+++ b/docs/commands/analyze.mdx
@@ -50,6 +50,15 @@ This option configures the melos analyze command to ignore warnings, allowing th
 melos analyze --no-fatal-warnings
 ```
 
+## --no-pub
+Skips the implicit `pub get` that `flutter analyze` runs before analyzing a
+package, by passing `--no-pub` to it. This has no effect on Dart-only packages,
+since `dart analyze` never runs `pub get`.
+
+```bash
+melos analyze --no-pub
+```
+
 ## concurrency (-c)
 
 Defines the max concurrency value of how many packages will execute the command in at any one time. Defaults to `1`.

--- a/docs/commands/bootstrap.mdx
+++ b/docs/commands/bootstrap.mdx
@@ -90,6 +90,10 @@ melos bootstrap --diff="main"
   files if `enforce-lockfile` is configured in the root `pubspec.yaml` file.
 - The `--offline` flag is used to only resolve dependencies from the local
   cache by running `pub get` with the `--offline` flag.
+- The `--no-pub` flag skips running `pub get` entirely. Shared dependencies,
+  dependency overrides and IDE files are still applied, which is useful when
+  you want to update the workspace `pubspec.yaml` files without resolving
+  dependencies right away.
 
 
 In addition to the above flags, the `melos bootstrap` command supports a few

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -21,6 +21,14 @@ class AnalyzeCommand extends MelosCommand {
           'Enables or disables treating warnings as fatal errors. '
           'When enabled, any warning will cause the command to fail.',
     );
+
+    argParser.addFlag(
+      'no-pub',
+      negatable: false,
+      help:
+          'Run `flutter analyze` with --no-pub to skip the implicit pub get. '
+          'Has no effect on `dart analyze`, which never runs pub get.',
+    );
   }
 
   @override
@@ -37,6 +45,7 @@ class AnalyzeCommand extends MelosCommand {
     final fatalInfos = argResults?['fatal-infos'] as bool;
     final fatalWarnings = argResults!.optional('fatal-warnings') as bool?;
     final concurrency = int.parse(argResults!['concurrency'] as String);
+    final noPub = argResults!['no-pub'] as bool;
 
     final melos = Melos(logger: logger, config: config);
 
@@ -46,6 +55,7 @@ class AnalyzeCommand extends MelosCommand {
       concurrency: concurrency,
       fatalInfos: fatalInfos,
       fatalWarnings: fatalWarnings,
+      noPub: noPub,
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -26,6 +26,13 @@ class BootstrapCommand extends MelosCommand {
           'Run pub get with --offline to resolve dependencies from local '
           'cache.',
     );
+    argParser.addFlag(
+      'no-pub',
+      negatable: false,
+      help:
+          'Skip running pub get. Shared dependencies, dependency overrides '
+          'and IDE files are still applied.',
+    );
   }
 
   @override
@@ -48,6 +55,7 @@ class BootstrapCommand extends MelosCommand {
       enforceLockfile: argResults?['enforce-lockfile'] as bool?,
       noExample: argResults?['no-example'] as bool,
       offline: argResults?['offline'] as bool,
+      noPub: argResults?['no-pub'] as bool,
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/test.dart
+++ b/packages/melos/lib/src/command_runner/test.dart
@@ -5,6 +5,13 @@ class TestCommand extends MelosCommand {
   TestCommand(super.config) {
     setupPackageFilterParser();
     argParser.addOption('concurrency', defaultsTo: '1', abbr: 'c');
+    argParser.addFlag(
+      'no-pub',
+      negatable: false,
+      help:
+          'Run `flutter test` with --no-pub to skip the implicit pub get. '
+          'Has no effect on `dart test`, which does not support the flag.',
+    );
   }
 
   @override
@@ -19,6 +26,7 @@ class TestCommand extends MelosCommand {
   @override
   Future<void> run() async {
     final concurrency = int.parse(argResults!['concurrency'] as String);
+    final noPub = argResults!['no-pub'] as bool;
 
     final melos = Melos(logger: logger, config: config);
 
@@ -26,6 +34,7 @@ class TestCommand extends MelosCommand {
       global: global,
       packageFilters: parsePackageFilters(config.path),
       concurrency: concurrency,
+      noPub: noPub,
     );
   }
 }

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -7,6 +7,7 @@ mixin _AnalyzeMixin on _Melos {
     bool fatalInfos = true,
     bool? fatalWarnings,
     int concurrency = 1,
+    bool noPub = false,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -20,6 +21,7 @@ mixin _AnalyzeMixin on _Melos {
       fatalInfos: fatalInfos,
       fatalWarnings: fatalWarnings,
       concurrency: concurrency,
+      noPub: noPub,
     );
   }
 
@@ -29,6 +31,7 @@ mixin _AnalyzeMixin on _Melos {
     required bool fatalInfos,
     bool? fatalWarnings,
     required int concurrency,
+    required bool noPub,
   }) async {
     final failures = <String, int?>{};
     final pool = Pool(concurrency);
@@ -37,6 +40,7 @@ mixin _AnalyzeMixin on _Melos {
       fatalInfos: fatalInfos,
       fatalWarnings: fatalWarnings,
       concurrency: concurrency,
+      noPub: noPub,
     ).join(' ');
     final useGroupBuffer = concurrency != 1 && packages.length != 1;
     final dartPackageCount = packages.where((e) => !e.isFlutterPackage).length;
@@ -59,6 +63,7 @@ mixin _AnalyzeMixin on _Melos {
         fatalInfos: fatalInfos,
         fatalWarnings: fatalWarnings,
         concurrency: concurrency,
+        noPub: noPub,
         isFlutter: true,
       ).join(' ');
       logger
@@ -81,6 +86,7 @@ mixin _AnalyzeMixin on _Melos {
           workspace: workspace,
           fatalInfos: fatalInfos,
           fatalWarnings: fatalWarnings,
+          noPub: noPub,
         ),
         group: group,
       );
@@ -129,6 +135,7 @@ mixin _AnalyzeMixin on _Melos {
     bool? fatalWarnings,
     bool isFlutter = false,
     int concurrency = 1,
+    bool noPub = false,
   }) {
     final useFlutter = package?.isFlutterPackage ?? isFlutter;
     final options = _getAnalyzeOptionsArgs(
@@ -136,6 +143,7 @@ mixin _AnalyzeMixin on _Melos {
       fatalWarnings: fatalWarnings,
       concurrency: concurrency,
       isFlutter: useFlutter,
+      noPub: noPub,
     );
     return <String>[
       if (useFlutter)
@@ -152,6 +160,7 @@ mixin _AnalyzeMixin on _Melos {
     required bool? fatalWarnings,
     required int concurrency,
     required bool isFlutter,
+    required bool noPub,
   }) {
     final options = <String>[];
 
@@ -167,6 +176,10 @@ mixin _AnalyzeMixin on _Melos {
 
     if (concurrency > 1) {
       options.add('--concurrency $concurrency');
+    }
+
+    if (noPub && isFlutter) {
+      options.add('--no-pub');
     }
 
     return options.join(' ');

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -7,6 +7,7 @@ mixin _BootstrapMixin on _CleanMixin {
     bool noExample = false,
     bool? enforceLockfile,
     bool offline = false,
+    bool noPub = false,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -73,17 +74,23 @@ mixin _BootstrapMixin on _CleanMixin {
             workspace,
           );
 
-          logger.log(
-            'Running "$pubCommandForLogging" in workspace...',
-          );
+          if (noPub) {
+            logger.log(
+              'Skipping "$pubCommandForLogging" in workspace (--no-pub)...',
+            );
+          } else {
+            logger.log(
+              'Running "$pubCommandForLogging" in workspace...',
+            );
 
-          await _runPubGetForWorkspace(
-            workspace,
-            noExample: noExample,
-            runOffline: runOffline,
-            enforceLockfile: shouldEnforceLockfile,
-            pubGetArgs: pubGetArgs,
-          );
+            await _runPubGetForWorkspace(
+              workspace,
+              noExample: noExample,
+              runOffline: runOffline,
+              enforceLockfile: shouldEnforceLockfile,
+              pubGetArgs: pubGetArgs,
+            );
+          }
 
           logger
             ..child(successLabel, prefix: '> ')

--- a/packages/melos/lib/src/commands/test.dart
+++ b/packages/melos/lib/src/commands/test.dart
@@ -5,6 +5,7 @@ mixin _TestMixin on _Melos {
     GlobalOptions? global,
     PackageFilters? packageFilters,
     int concurrency = 1,
+    bool noPub = false,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -14,13 +15,19 @@ mixin _TestMixin on _Melos {
       (pkg) => Directory(p.join(pkg.path, 'test')).existsSync(),
     );
 
-    await _testForAllPackages(workspace, packages, concurrency: concurrency);
+    await _testForAllPackages(
+      workspace,
+      packages,
+      concurrency: concurrency,
+      noPub: noPub,
+    );
   }
 
   Future<void> _testForAllPackages(
     MelosWorkspace workspace,
     Iterable<Package> packages, {
     required int concurrency,
+    required bool noPub,
   }) async {
     if (packages.isEmpty) {
       logger.command('melos test', withDollarSign: true);
@@ -33,6 +40,7 @@ mixin _TestMixin on _Melos {
     final testArgsString = _getTestArgs(
       workspace: workspace,
       concurrency: concurrency,
+      noPub: noPub,
     ).join(' ');
     final useGroupBuffer = concurrency != 1 && packages.length != 1;
     final dartPackageCount = packages.where((e) => !e.isFlutterPackage).length;
@@ -50,8 +58,14 @@ mixin _TestMixin on _Melos {
     }
 
     if (flutterPackageCount > 0) {
+      final flutterTestArgsString = _getTestArgs(
+        workspace: workspace,
+        concurrency: concurrency,
+        noPub: noPub,
+        isFlutter: true,
+      ).join(' ');
       logger
-          .child(targetStyle(testArgsString.replaceFirst('dart', 'flutter')))
+          .child(targetStyle(flutterTestArgsString))
           .child('$runningLabel (in $flutterPackageCount packages)')
           .newLine();
     }
@@ -69,6 +83,7 @@ mixin _TestMixin on _Melos {
           package: package,
           workspace: workspace,
           concurrency: concurrency,
+          noPub: noPub,
         ),
         group: group,
       );
@@ -114,10 +129,17 @@ mixin _TestMixin on _Melos {
     required MelosWorkspace workspace,
     Package? package,
     int concurrency = 1,
+    bool noPub = false,
+    bool isFlutter = false,
   }) {
-    final options = _getOptionsArgs(concurrency);
+    final useFlutter = package?.isFlutterPackage ?? isFlutter;
+    final options = _getOptionsArgs(
+      concurrency: concurrency,
+      noPub: noPub,
+      isFlutter: useFlutter,
+    );
     return <String>[
-      if (package?.isFlutterPackage ?? false)
+      if (useFlutter)
         workspace.sdkTool('flutter')
       else
         workspace.sdkTool('dart'),
@@ -126,10 +148,19 @@ mixin _TestMixin on _Melos {
     ];
   }
 
-  String _getOptionsArgs(int concurrency) {
+  String _getOptionsArgs({
+    required int concurrency,
+    required bool noPub,
+    required bool isFlutter,
+  }) {
     final options = <String>[];
     if (concurrency > 1) {
       options.add('--concurrency=$concurrency');
+    }
+    // `dart test` has no `--no-pub` flag, see
+    // https://github.com/dart-lang/sdk/issues/45307.
+    if (noPub && isFlutter) {
+      options.add('--no-pub');
     }
     return options.join(' ');
   }

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -427,6 +427,42 @@ ${'-' * terminalWidth}
       },
     );
 
+    test('should pass --no-pub only to flutter analyze', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a', 'b'],
+      );
+
+      await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {
+            'flutter': SdkDependency('flutter'),
+          },
+        ),
+      );
+
+      await createProject(workspaceDir, Pubspec('b'));
+
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+
+      final melos = Melos(
+        logger: logger,
+        config: config,
+      );
+      await melos.analyze(noPub: true);
+
+      final output = logger.output.removeAnsiCodes();
+
+      expect(output, contains('flutter analyze --fatal-infos --no-pub'));
+
+      final dartRegex = RegExp(
+        r'\$ melos analyze\s+└> dart analyze --fatal-infos\s',
+      );
+      expect(dartRegex.hasMatch(output), isTrue);
+      expect(output, isNot(contains('dart analyze --fatal-infos --no-pub')));
+    });
+
     test('should run analysis using dart', () async {
       final workspaceDir = await createTemporaryWorkspace(
         workspacePackages: ['a'],

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -1516,6 +1516,101 @@ Generating IntelliJ IDE files...
       );
     });
   });
+
+  group('melos bs --no-pub', () {
+    test('should skip pub get', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a'],
+      );
+      await createProject(
+        workspaceDir,
+        Pubspec('a'),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(logger: logger, config: config);
+
+      await runMelosBootstrap(melos, logger, noPub: true);
+
+      expect(
+        logger.output,
+        ignoringAnsii(
+          '''
+melos bootstrap
+  └> ${workspaceDir.path}
+
+Skipping "dart pub get" in workspace (--no-pub)...
+  > SUCCESS
+
+Generating IntelliJ IDE files...
+  > SUCCESS
+
+ -> 1 packages bootstrapped
+''',
+        ),
+      );
+      expect(
+        File(p.join(workspaceDir.path, 'pubspec.lock')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test('should still apply shared dependencies', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a'],
+        configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+          createYamlMap(
+            {
+              'melos': {
+                'command': {
+                  'bootstrap': {
+                    'dependencies': {
+                      'flame': '^1.21.0',
+                    },
+                  },
+                },
+              },
+            },
+            defaults: configMapDefaults,
+          ),
+          path: path,
+        ),
+      );
+
+      final pkgA = await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {
+            'flame': HostedDependency(version: VersionConstraint.any),
+          },
+        ),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(logger: logger, config: config);
+
+      await runMelosBootstrap(melos, logger, noPub: true);
+
+      final pubspecContent = _pubspecContent(pkgA);
+      expect(
+        (pubspecContent['dependencies']! as YamlMap)['flame'],
+        '^1.21.0',
+      );
+      expect(
+        logger.output,
+        ignoringAnsii(
+          contains('Skipping "dart pub get" in workspace (--no-pub)...'),
+        ),
+      );
+      expect(
+        File(p.join(workspaceDir.path, 'pubspec.lock')).existsSync(),
+        isFalse,
+      );
+    });
+  });
 }
 
 Future<void> runMelosBootstrap(
@@ -1523,11 +1618,13 @@ Future<void> runMelosBootstrap(
   TestLogger logger, {
   bool? enforceLockfile,
   bool offline = false,
+  bool noPub = false,
 }) async {
   try {
     await melos.bootstrap(
       enforceLockfile: enforceLockfile,
       offline: offline,
+      noPub: noPub,
     );
   } on BootstrapException {
     // ignore: avoid_print

--- a/packages/melos/test/commands/test_test.dart
+++ b/packages/melos/test/commands/test_test.dart
@@ -99,6 +99,47 @@ void main() {
 
       exitCode = previousExitCode;
     });
+    test('passes --no-pub only to flutter test', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: ['a', 'b'],
+      );
+
+      final aDir = await createProject(
+        workspaceDir,
+        Pubspec(
+          'a',
+          dependencies: {
+            'flutter': SdkDependency('flutter'),
+          },
+        ),
+      );
+      writeTextFile(
+        p.join(aDir.path, 'test', 'a_test.dart'),
+        '',
+        recursive: true,
+      );
+
+      final bDir = await createProject(workspaceDir, Pubspec('b'));
+      writeTextFile(
+        p.join(bDir.path, 'test', 'b_test.dart'),
+        '',
+        recursive: true,
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final melos = Melos(logger: logger, config: config);
+
+      final previousExitCode = exitCode;
+      await melos.test(noPub: true);
+      exitCode = previousExitCode;
+
+      final output = logger.output.removeAnsiCodes();
+
+      expect(output, contains('flutter test --no-pub'));
+      expect(output, isNot(contains('dart test --no-pub')));
+    });
+
     test(
       'correctly detects a flutter package inside a pub workspace',
       () async {


### PR DESCRIPTION
## Description

Closes #815.

Adds a `--no-pub` flag to the commands where Melos, or the tools it invokes, run `pub get`:

- `melos bootstrap --no-pub` skips the workspace `pub get` entirely. Shared dependencies, dependency overrides, IDE files and lifecycle hooks are still applied, so it can be used to update the workspace `pubspec.yaml` files without resolving dependencies right away.
- `melos test --no-pub` passes `--no-pub` to `flutter test` for Flutter packages, which otherwise runs an implicit `pub get` for every package. It is not passed to `dart test`, which has no such flag (see https://github.com/dart-lang/sdk/issues/45307).
- `melos analyze --no-pub` passes `--no-pub` to `flutter analyze` for Flutter packages. `dart analyze` never runs `pub get`, so nothing is passed there.

The `melos test` log line for Flutter packages is now built from the real Flutter arguments instead of a string replacement on the Dart arguments, so it reflects the `--no-pub` flag.

Not covered by this PR: the `pub get` that `cli_launcher` runs before relaunching a local Melos installation when `pubspec.lock` is older than `pubspec.yaml`. `cli_launcher` 0.3.3+2 only exposes `pubGetArgs`, there is no way to skip that `pub get`, and `dart run` would resolve dependencies implicitly in that situation anyway.

Docs for the `bootstrap` and `analyze` commands are updated. There is no docs page for `melos test` yet, so only the `--help` text describes the flag there.

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [x] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
