### PR TITLE
fix: respect sdkPath when resolving and launching the local Melos installation

### DIFF
--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -60,6 +60,12 @@ melos:
   sdkPath: .fvm/flutter_sdk
 ```
 
+When the configured SDK is not the first entry on the `PATH`, Melos relaunches
+itself with the SDK's `bin` directory prepended to the `PATH`. This ensures
+that the local installation of Melos in the workspace is also resolved and run
+with the configured SDK, even when no system-wide Dart or Flutter SDK is
+installed.
+
 ## useRootAsPackage
 
 Whether to include the repository root as a package in the workspace.

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -60,11 +60,9 @@ melos:
   sdkPath: .fvm/flutter_sdk
 ```
 
-When the configured SDK is not the first entry on the `PATH`, Melos relaunches
-itself with the SDK's `bin` directory prepended to the `PATH`. This ensures
-that the local installation of Melos in the workspace is also resolved and run
-with the configured SDK, even when no system-wide Dart or Flutter SDK is
-installed.
+The configured SDK is also used to resolve the dependencies of, and run, the
+local installation of Melos in the workspace, so no system-wide Dart or Flutter
+SDK is required.
 
 ## useRootAsPackage
 

--- a/packages/melos/bin/melos.dart
+++ b/packages/melos/bin/melos.dart
@@ -1,11 +1,17 @@
 import 'package:cli_launcher/cli_launcher.dart';
 import 'package:melos/src/command_runner.dart';
+import 'package:melos/src/sdk_launcher.dart';
 
-Future<void> main(List<String> arguments) async => launchExecutable(
-  arguments,
-  LaunchConfig(
-    name: ExecutableName('melos'),
-    launchFromSelf: false,
-    entrypoint: melosEntryPoint,
-  ),
-);
+Future<void> main(List<String> arguments) async {
+  if (await relaunchWithConfiguredSdk(arguments)) {
+    return;
+  }
+  return launchExecutable(
+    arguments,
+    LaunchConfig(
+      name: ExecutableName('melos'),
+      launchFromSelf: false,
+      entrypoint: melosEntryPoint,
+    ),
+  );
+}

--- a/packages/melos/bin/melos.dart
+++ b/packages/melos/bin/melos.dart
@@ -2,16 +2,13 @@ import 'package:cli_launcher/cli_launcher.dart';
 import 'package:melos/src/command_runner.dart';
 import 'package:melos/src/sdk_launcher.dart';
 
-Future<void> main(List<String> arguments) async {
-  if (await relaunchWithConfiguredSdk(arguments)) {
-    return;
-  }
-  return launchExecutable(
-    arguments,
-    LaunchConfig(
-      name: ExecutableName('melos'),
-      launchFromSelf: false,
-      entrypoint: melosEntryPoint,
-    ),
-  );
-}
+Future<void> main(List<String> arguments) async => launchExecutable(
+  arguments,
+  LaunchConfig(
+    name: ExecutableName('melos'),
+    launchFromSelf: false,
+    entrypoint: melosEntryPoint,
+    resolveLocalLaunchConfig: (context) =>
+        resolveLocalLaunchConfig(arguments, context),
+  ),
+);

--- a/packages/melos/lib/src/sdk_launcher.dart
+++ b/packages/melos/lib/src/sdk_launcher.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:collection/collection.dart';
+import 'package:cli_launcher/cli_launcher.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
@@ -12,137 +12,54 @@ import 'common/platform.dart';
 import 'common/utils.dart';
 import 'workspace.dart';
 
-/// Relaunches Melos with the configured Dart/Flutter SDK first on the `PATH`
-/// when Melos was not started with that SDK.
+/// Resolves the [LocalLaunchConfig] that `cli_launcher` uses to resolve the
+/// dependencies of, and launch, the local installation of Melos in the
+/// workspace.
 ///
-/// Before Melos reads the workspace configuration, `cli_launcher` resolves the
-/// local installation of Melos by running `dart`/`flutter` from the `PATH`.
-/// Without this relaunch, the `sdkPath` option is ignored for those
-/// invocations, which fail when no system-wide SDK is installed.
-///
-/// Returns `true` when Melos was relaunched, in which case [exitCode] has
-/// already been set from the relaunched process.
-Future<bool> relaunchWithConfiguredSdk(List<String> arguments) async {
-  final SdkRelaunch? relaunch;
-  try {
-    final sdkPath = await resolveLaunchSdkPath(arguments);
-    relaunch = sdkPath == null
-        ? null
-        : planSdkRelaunch(arguments, sdkPath: sdkPath);
-  } on Exception {
-    // Problems with the configuration are reported by Melos once it runs.
-    return false;
-  }
-  if (relaunch == null) {
-    return false;
-  }
-
-  final process = await Process.start(
-    relaunch.executable,
-    relaunch.arguments,
-    environment: relaunch.environment,
-    mode: ProcessStartMode.inheritStdio,
+/// This happens before Melos reads the workspace configuration, so the SDK
+/// path is resolved here separately. Without it, `cli_launcher` would use the
+/// `dart`/`flutter` tools from the `PATH` regardless of the configured SDK,
+/// which fails when no system-wide SDK is installed.
+Future<LocalLaunchConfig> resolveLocalLaunchConfig(
+  List<String> arguments,
+  LaunchContext context,
+) async {
+  return LocalLaunchConfig(
+    sdkPath: resolveLaunchSdkPath(
+      arguments,
+      workspaceRoot: context.localInstallation?.lockFileRoot,
+    ),
   );
-  exitCode = await process.exitCode;
-  return true;
 }
 
 /// Resolves the SDK path that Melos should be launched with, using the same
 /// precedence as [resolveSdkPath].
 ///
 /// Returns `null` when no SDK path is configured, when the special value
-/// [autoSdkPathOptionValue] is used, or when [current] is not inside a
-/// workspace.
+/// [autoSdkPathOptionValue] is used, or when there is no [workspaceRoot].
+///
+/// Also returns `null` when the SDK has no `bin` directory, so that the
+/// invalid path is reported by Melos instead of failing the launch.
 @visibleForTesting
-Future<String?> resolveLaunchSdkPath(
+String? resolveLaunchSdkPath(
   List<String> arguments, {
-  Directory? current,
-}) async {
-  final workspaceRoot = _findWorkspaceRoot(current ?? Directory.current);
+  required Directory? workspaceRoot,
+}) {
   if (workspaceRoot == null) {
     return null;
   }
-  return resolveSdkPath(
+  final sdkPath = resolveSdkPath(
     configSdkPath: _configSdkPath(workspaceRoot),
     envSdkPath:
         currentPlatform.environment[EnvironmentVariableKey.melosSdkPath],
     commandSdkPath: _commandLineSdkPath(arguments),
     workspacePath: workspaceRoot.path,
   );
-}
-
-/// Plans how to relaunch Melos with the SDK at [sdkPath] first on the `PATH`.
-///
-/// Returns `null` when no relaunch is needed because the SDK is already first
-/// on the `PATH`, or when a relaunch is not possible because the SDK has no
-/// `bin` directory or the running script cannot be located.
-@visibleForTesting
-SdkRelaunch? planSdkRelaunch(
-  List<String> arguments, {
-  required String sdkPath,
-}) {
-  final sdkBinPath = p.join(sdkPath, 'bin');
-  if (!dirExists(sdkBinPath)) {
+  if (sdkPath == null || !dirExists(p.join(sdkPath, 'bin'))) {
     return null;
   }
-
-  final platform = currentPlatform;
-  final pathKey = platform.environment.keys.firstWhere(
-    (key) => key.toUpperCase() == EnvironmentVariableKey.path,
-    orElse: () => EnvironmentVariableKey.path,
-  );
-  final currentPath = platform.environment[pathKey] ?? '';
-  final firstPathEntry = currentPath.split(pathEnvVarSeparator).firstOrNull;
-  if (firstPathEntry != null && p.equals(firstPathEntry, sdkBinPath)) {
-    return null;
-  }
-
-  final script = platform.script;
-  if (script.scheme != 'file') {
-    return null;
-  }
-  final scriptPath = script.toFilePath();
-  final executable = platform.resolvedExecutable;
-  final isStandaloneExecutable = p.equals(scriptPath, executable);
-
-  return SdkRelaunch(
-    executable: executable,
-    arguments: [
-      if (!isStandaloneExecutable) ...[
-        ...platform.executableArguments.whereNot(_isInternalVmArgument),
-        scriptPath,
-      ],
-      ...arguments,
-    ],
-    environment: {
-      pathKey: addToPathEnvVar(
-        directory: sdkBinPath,
-        currentPath: currentPath,
-        prepend: true,
-      ),
-    },
-  );
+  return sdkPath;
 }
-
-/// The process invocation used to relaunch Melos with a configured SDK.
-@immutable
-class SdkRelaunch {
-  const SdkRelaunch({
-    required this.executable,
-    required this.arguments,
-    required this.environment,
-  });
-
-  final String executable;
-  final List<String> arguments;
-  final Map<String, String> environment;
-}
-
-/// The `dart` executable passes these arguments to the VM to describe itself.
-/// They must not be forwarded, since they would describe the wrong process.
-bool _isInternalVmArgument(String argument) =>
-    argument.startsWith('--resolved_executable_name=') ||
-    argument.startsWith('--executable_name=');
 
 String? _commandLineSdkPath(List<String> arguments) {
   final parser = ArgParser(allowTrailingOptions: false)
@@ -156,56 +73,7 @@ String? _commandLineSdkPath(List<String> arguments) {
 }
 
 String? _configSdkPath(Directory workspaceRoot) {
-  final melosSection = _loadPubspec(workspaceRoot)?['melos'];
-  if (melosSection is! Map) {
-    return null;
-  }
-  final sdkPath = melosSection['sdkPath'];
-  return sdkPath is String ? sdkPath : null;
-}
-
-/// Finds the root of the workspace that [start] is part of, mirroring how
-/// `cli_launcher` finds the local installation of Melos.
-///
-/// The root is the closest ancestor whose `pubspec.yaml` depends on `melos`.
-/// If that package is a workspace member, the root is the closest ancestor
-/// with a `workspace` section instead.
-Directory? _findWorkspaceRoot(Directory start) {
-  for (final directory in _ancestors(start)) {
-    final pubspec = _loadPubspec(directory);
-    if (pubspec == null || !_dependsOnMelos(pubspec)) {
-      continue;
-    }
-    if (pubspec['resolution'] != 'workspace') {
-      return directory;
-    }
-    return _ancestors(directory.parent).firstWhereOrNull(
-      (ancestor) => _loadPubspec(ancestor)?['workspace'] is List,
-    );
-  }
-  return null;
-}
-
-Iterable<Directory> _ancestors(Directory start) sync* {
-  var current = start;
-  while (true) {
-    yield current;
-    final parent = current.parent;
-    if (parent.path == current.path) {
-      return;
-    }
-    current = parent;
-  }
-}
-
-bool _dependsOnMelos(Map<Object?, Object?> pubspec) {
-  return [pubspec['dependencies'], pubspec['dev_dependencies']].any(
-    (dependencies) => dependencies is Map && dependencies.containsKey('melos'),
-  );
-}
-
-Map<Object?, Object?>? _loadPubspec(Directory directory) {
-  final pubspecFile = File(pubspecPathForDirectory(directory.path));
+  final pubspecFile = File(pubspecPathForDirectory(workspaceRoot.path));
   if (!pubspecFile.existsSync()) {
     return null;
   }
@@ -213,5 +81,13 @@ Map<Object?, Object?>? _loadPubspec(Directory directory) {
     pubspecFile.readAsStringSync(),
     sourceUrl: pubspecFile.uri,
   );
-  return pubspec is Map ? pubspec : null;
+  if (pubspec is! Map) {
+    return null;
+  }
+  final melosSection = pubspec['melos'];
+  if (melosSection is! Map) {
+    return null;
+  }
+  final sdkPath = melosSection['sdkPath'];
+  return sdkPath is String ? sdkPath : null;
 }

--- a/packages/melos/lib/src/sdk_launcher.dart
+++ b/packages/melos/lib/src/sdk_launcher.dart
@@ -1,0 +1,217 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'common/environment_variable_key.dart';
+import 'common/io.dart';
+import 'common/platform.dart';
+import 'common/utils.dart';
+import 'workspace.dart';
+
+/// Relaunches Melos with the configured Dart/Flutter SDK first on the `PATH`
+/// when Melos was not started with that SDK.
+///
+/// Before Melos reads the workspace configuration, `cli_launcher` resolves the
+/// local installation of Melos by running `dart`/`flutter` from the `PATH`.
+/// Without this relaunch, the `sdkPath` option is ignored for those
+/// invocations, which fail when no system-wide SDK is installed.
+///
+/// Returns `true` when Melos was relaunched, in which case [exitCode] has
+/// already been set from the relaunched process.
+Future<bool> relaunchWithConfiguredSdk(List<String> arguments) async {
+  final SdkRelaunch? relaunch;
+  try {
+    final sdkPath = await resolveLaunchSdkPath(arguments);
+    relaunch = sdkPath == null
+        ? null
+        : planSdkRelaunch(arguments, sdkPath: sdkPath);
+  } on Exception {
+    // Problems with the configuration are reported by Melos once it runs.
+    return false;
+  }
+  if (relaunch == null) {
+    return false;
+  }
+
+  final process = await Process.start(
+    relaunch.executable,
+    relaunch.arguments,
+    environment: relaunch.environment,
+    mode: ProcessStartMode.inheritStdio,
+  );
+  exitCode = await process.exitCode;
+  return true;
+}
+
+/// Resolves the SDK path that Melos should be launched with, using the same
+/// precedence as [resolveSdkPath].
+///
+/// Returns `null` when no SDK path is configured, when the special value
+/// [autoSdkPathOptionValue] is used, or when [current] is not inside a
+/// workspace.
+@visibleForTesting
+Future<String?> resolveLaunchSdkPath(
+  List<String> arguments, {
+  Directory? current,
+}) async {
+  final workspaceRoot = _findWorkspaceRoot(current ?? Directory.current);
+  if (workspaceRoot == null) {
+    return null;
+  }
+  return resolveSdkPath(
+    configSdkPath: _configSdkPath(workspaceRoot),
+    envSdkPath:
+        currentPlatform.environment[EnvironmentVariableKey.melosSdkPath],
+    commandSdkPath: _commandLineSdkPath(arguments),
+    workspacePath: workspaceRoot.path,
+  );
+}
+
+/// Plans how to relaunch Melos with the SDK at [sdkPath] first on the `PATH`.
+///
+/// Returns `null` when no relaunch is needed because the SDK is already first
+/// on the `PATH`, or when a relaunch is not possible because the SDK has no
+/// `bin` directory or the running script cannot be located.
+@visibleForTesting
+SdkRelaunch? planSdkRelaunch(
+  List<String> arguments, {
+  required String sdkPath,
+}) {
+  final sdkBinPath = p.join(sdkPath, 'bin');
+  if (!dirExists(sdkBinPath)) {
+    return null;
+  }
+
+  final platform = currentPlatform;
+  final pathKey = platform.environment.keys.firstWhere(
+    (key) => key.toUpperCase() == EnvironmentVariableKey.path,
+    orElse: () => EnvironmentVariableKey.path,
+  );
+  final currentPath = platform.environment[pathKey] ?? '';
+  final firstPathEntry = currentPath.split(pathEnvVarSeparator).firstOrNull;
+  if (firstPathEntry != null && p.equals(firstPathEntry, sdkBinPath)) {
+    return null;
+  }
+
+  final script = platform.script;
+  if (script.scheme != 'file') {
+    return null;
+  }
+  final scriptPath = script.toFilePath();
+  final executable = platform.resolvedExecutable;
+  final isStandaloneExecutable = p.equals(scriptPath, executable);
+
+  return SdkRelaunch(
+    executable: executable,
+    arguments: [
+      if (!isStandaloneExecutable) ...[
+        ...platform.executableArguments.whereNot(_isInternalVmArgument),
+        scriptPath,
+      ],
+      ...arguments,
+    ],
+    environment: {
+      pathKey: addToPathEnvVar(
+        directory: sdkBinPath,
+        currentPath: currentPath,
+        prepend: true,
+      ),
+    },
+  );
+}
+
+/// The process invocation used to relaunch Melos with a configured SDK.
+@immutable
+class SdkRelaunch {
+  const SdkRelaunch({
+    required this.executable,
+    required this.arguments,
+    required this.environment,
+  });
+
+  final String executable;
+  final List<String> arguments;
+  final Map<String, String> environment;
+}
+
+/// The `dart` executable passes these arguments to the VM to describe itself.
+/// They must not be forwarded, since they would describe the wrong process.
+bool _isInternalVmArgument(String argument) =>
+    argument.startsWith('--resolved_executable_name=') ||
+    argument.startsWith('--executable_name=');
+
+String? _commandLineSdkPath(List<String> arguments) {
+  final parser = ArgParser(allowTrailingOptions: false)
+    ..addFlag(globalOptionVerbose, negatable: false)
+    ..addOption(globalOptionSdkPath);
+  try {
+    return parser.parse(arguments)[globalOptionSdkPath] as String?;
+  } on FormatException {
+    return null;
+  }
+}
+
+String? _configSdkPath(Directory workspaceRoot) {
+  final melosSection = _loadPubspec(workspaceRoot)?['melos'];
+  if (melosSection is! Map) {
+    return null;
+  }
+  final sdkPath = melosSection['sdkPath'];
+  return sdkPath is String ? sdkPath : null;
+}
+
+/// Finds the root of the workspace that [start] is part of, mirroring how
+/// `cli_launcher` finds the local installation of Melos.
+///
+/// The root is the closest ancestor whose `pubspec.yaml` depends on `melos`.
+/// If that package is a workspace member, the root is the closest ancestor
+/// with a `workspace` section instead.
+Directory? _findWorkspaceRoot(Directory start) {
+  for (final directory in _ancestors(start)) {
+    final pubspec = _loadPubspec(directory);
+    if (pubspec == null || !_dependsOnMelos(pubspec)) {
+      continue;
+    }
+    if (pubspec['resolution'] != 'workspace') {
+      return directory;
+    }
+    return _ancestors(directory.parent).firstWhereOrNull(
+      (ancestor) => _loadPubspec(ancestor)?['workspace'] is List,
+    );
+  }
+  return null;
+}
+
+Iterable<Directory> _ancestors(Directory start) sync* {
+  var current = start;
+  while (true) {
+    yield current;
+    final parent = current.parent;
+    if (parent.path == current.path) {
+      return;
+    }
+    current = parent;
+  }
+}
+
+bool _dependsOnMelos(Map<Object?, Object?> pubspec) {
+  return [pubspec['dependencies'], pubspec['dev_dependencies']].any(
+    (dependencies) => dependencies is Map && dependencies.containsKey('melos'),
+  );
+}
+
+Map<Object?, Object?>? _loadPubspec(Directory directory) {
+  final pubspecFile = File(pubspecPathForDirectory(directory.path));
+  if (!pubspecFile.existsSync()) {
+    return null;
+  }
+  final pubspec = loadYaml(
+    pubspecFile.readAsStringSync(),
+    sourceUrl: pubspecFile.uri,
+  );
+  return pubspec is Map ? pubspec : null;
+}

--- a/packages/melos/lib/src/workspace.dart
+++ b/packages/melos/lib/src/workspace.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'command_configs/command_configs.dart';
@@ -217,7 +216,6 @@ class MelosWorkspace {
 /// from the config file.
 ///
 /// Relative paths are resolved relative to the workspace path.
-@visibleForTesting
 String? resolveSdkPath({
   required String? configSdkPath,
   required String? envSdkPath,

--- a/packages/melos/pubspec.yaml
+++ b/packages/melos/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   ansi_styles: ^0.3.2+1
   args: ^2.7.0
   async: ^2.13.0
-  cli_launcher: ^0.3.3+2
+  cli_launcher: ^0.3.4
   cli_util: ">=0.5.0 <0.7.0"
   collection: ^1.19.0
   conventional_commit: ^0.6.1+1

--- a/packages/melos/test/sdk_launcher_test.dart
+++ b/packages/melos/test/sdk_launcher_test.dart
@@ -1,10 +1,9 @@
-import 'dart:async';
 import 'dart:io';
 
+import 'package:cli_launcher/cli_launcher.dart';
 import 'package:melos/melos.dart';
 import 'package:melos/src/common/environment_variable_key.dart';
 import 'package:melos/src/common/io.dart';
-import 'package:melos/src/common/platform.dart';
 import 'package:melos/src/sdk_launcher.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart' show FakePlatform;
@@ -13,91 +12,71 @@ import 'package:test/test.dart';
 import 'mock_env.dart';
 import 'utils.dart';
 
-final _pathSeparator = Platform.isWindows ? ';' : ':';
-
-FakePlatform _fakePlatform({
-  required Map<String, String> environment,
-  Uri? script,
-  String? resolvedExecutable,
-  List<String> executableArguments = const [],
-}) {
+FakePlatform _platformWithEnvironment(Map<String, String> environment) {
   return FakePlatform(
     operatingSystem: Platform.operatingSystem,
     environment: environment,
-    script: script,
-    resolvedExecutable: resolvedExecutable,
-    executableArguments: executableArguments,
   );
 }
 
-T _withPlatform<T>(FakePlatform platform, T Function() body) {
-  return runZoned(body, zoneValues: {currentPlatformZoneKey: platform});
-}
-
 void main() {
+  Future<Directory> createWorkspace({String? sdkPath}) {
+    return createTemporaryWorkspace(
+      workspacePackages: ['a'],
+      configBuilder: (path) => MelosWorkspaceConfig(
+        path: path,
+        name: 'test_workspace',
+        packages: const [],
+        sdkPath: sdkPath,
+      ),
+    );
+  }
+
+  /// Creates an SDK directory with a `bin` directory at [sdkPath], resolved
+  /// relative to [workspace], and returns its absolute path.
+  String createSdk(Directory workspace, String sdkPath) {
+    final absoluteSdkPath = p.join(workspace.path, sdkPath);
+    ensureDir(p.join(absoluteSdkPath, 'bin'));
+    return absoluteSdkPath;
+  }
+
   group('resolveLaunchSdkPath', () {
-    Future<Directory> createWorkspace({String? sdkPath}) {
-      return createTemporaryWorkspace(
-        workspacePackages: ['a'],
-        configBuilder: (path) => MelosWorkspaceConfig(
-          path: path,
-          name: 'test_workspace',
-          packages: const [],
-          sdkPath: sdkPath,
-        ),
-      );
-    }
-
-    test('returns null outside of a workspace', () async {
-      final directory = createTestTempDir();
-
-      expect(await resolveLaunchSdkPath([], current: directory), isNull);
+    test('returns null without a workspace root', () {
+      expect(resolveLaunchSdkPath([], workspaceRoot: null), isNull);
     });
 
     test('returns null when no sdk path is configured', () async {
       final workspace = await createWorkspace();
 
-      expect(await resolveLaunchSdkPath([], current: workspace), isNull);
+      expect(resolveLaunchSdkPath([], workspaceRoot: workspace), isNull);
     });
 
     test(
       'resolves sdkPath from the root pubspec relative to the workspace',
       () async {
         final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+        final sdkPath = createSdk(workspace, '.fvm/flutter_sdk');
 
-        expect(
-          await resolveLaunchSdkPath([], current: workspace),
-          p.join(workspace.path, '.fvm', 'flutter_sdk'),
-        );
+        expect(resolveLaunchSdkPath([], workspaceRoot: workspace), sdkPath);
       },
     );
-
-    test('finds the workspace root from a nested directory', () async {
-      final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
-      final packageDirectory = Directory(
-        p.join(workspace.path, 'packages', 'a'),
-      );
-
-      expect(
-        await resolveLaunchSdkPath([], current: packageDirectory),
-        p.join(workspace.path, '.fvm', 'flutter_sdk'),
-      );
-    });
 
     test(
       'the environment variable has precedence over the root pubspec',
       withMockPlatform(
         () async {
           final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+          createSdk(workspace, '.fvm/flutter_sdk');
+          final envSdkPath = createSdk(workspace, 'env_sdk');
 
           expect(
-            await resolveLaunchSdkPath([], current: workspace),
-            p.join(workspace.path, 'env_sdk'),
+            resolveLaunchSdkPath([], workspaceRoot: workspace),
+            envSdkPath,
           );
         },
-        platform: _fakePlatform(
-          environment: {EnvironmentVariableKey.melosSdkPath: 'env_sdk'},
-        ),
+        platform: _platformWithEnvironment({
+          EnvironmentVariableKey.melosSdkPath: 'env_sdk',
+        }),
       ),
     );
 
@@ -106,186 +85,86 @@ void main() {
       withMockPlatform(
         () async {
           final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+          createSdk(workspace, '.fvm/flutter_sdk');
+          createSdk(workspace, 'env_sdk');
+          final commandSdkPath = createSdk(workspace, 'command_sdk');
 
           expect(
-            await resolveLaunchSdkPath(
+            resolveLaunchSdkPath(
               ['--sdk-path', 'command_sdk', 'bootstrap'],
-              current: workspace,
+              workspaceRoot: workspace,
             ),
-            p.join(workspace.path, 'command_sdk'),
+            commandSdkPath,
           );
           expect(
-            await resolveLaunchSdkPath(
+            resolveLaunchSdkPath(
               ['--verbose', '--sdk-path=command_sdk', 'bootstrap'],
-              current: workspace,
+              workspaceRoot: workspace,
             ),
-            p.join(workspace.path, 'command_sdk'),
+            commandSdkPath,
           );
         },
-        platform: _fakePlatform(
-          environment: {EnvironmentVariableKey.melosSdkPath: 'env_sdk'},
-        ),
+        platform: _platformWithEnvironment({
+          EnvironmentVariableKey.melosSdkPath: 'env_sdk',
+        }),
       ),
     );
 
     test('returns null when the special value "auto" is used', () async {
       final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+      createSdk(workspace, '.fvm/flutter_sdk');
 
       expect(
-        await resolveLaunchSdkPath(
+        resolveLaunchSdkPath(
           ['--sdk-path', 'auto', 'bootstrap'],
-          current: workspace,
+          workspaceRoot: workspace,
         ),
         isNull,
       );
     });
 
     test('keeps absolute sdk paths as is', () async {
-      final absoluteSdkPath = p.normalize(p.absolute('sdks', 'flutter'));
-      final workspace = await createWorkspace(sdkPath: absoluteSdkPath);
+      final sdkDirectory = createTestTempDir();
+      ensureDir(p.join(sdkDirectory.path, 'bin'));
+      final workspace = await createWorkspace(sdkPath: sdkDirectory.path);
 
       expect(
-        await resolveLaunchSdkPath([], current: workspace),
-        absoluteSdkPath,
+        resolveLaunchSdkPath([], workspaceRoot: workspace),
+        sdkDirectory.path,
       );
+    });
+
+    test('returns null when the sdk has no bin directory', () async {
+      final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+
+      expect(resolveLaunchSdkPath([], workspaceRoot: workspace), isNull);
     });
   });
 
-  group('planSdkRelaunch', () {
-    late Directory sdkDirectory;
-    late String sdkBinPath;
-
-    setUp(() {
-      sdkDirectory = createTestTempDir();
-      sdkBinPath = p.join(sdkDirectory.path, 'bin');
-      ensureDir(sdkBinPath);
-    });
-
-    const arguments = ['bootstrap', '--no-enforce-lockfile'];
-    final script = Uri.file(p.absolute('bin', 'melos.dart-3.9.0.snapshot'));
-    final executable = p.absolute('sdk', 'bin', 'dart');
-
-    test('returns null when the sdk has no bin directory', () {
-      final platform = _fakePlatform(
-        environment: {EnvironmentVariableKey.path: '/usr/bin'},
-        script: script,
-        resolvedExecutable: executable,
-      );
-
-      expect(
-        _withPlatform(
-          platform,
-          () => planSdkRelaunch(
-            arguments,
-            sdkPath: p.join(sdkDirectory.path, 'missing'),
-          ),
+  group('resolveLocalLaunchConfig', () {
+    test('uses the lock file root of the local installation', () async {
+      final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+      final sdkPath = createSdk(workspace, '.fvm/flutter_sdk');
+      final context = LaunchContext(
+        directory: Directory(p.join(workspace.path, 'packages', 'a')),
+        localInstallation: ExecutableInstallation(
+          name: ExecutableName('melos'),
+          isSelf: false,
+          packageRoot: workspace,
         ),
-        isNull,
       );
+
+      final config = await resolveLocalLaunchConfig(['bootstrap'], context);
+
+      expect(config.sdkPath, sdkPath);
     });
 
-    test(
-      'returns null when the sdk bin directory is already first on the PATH',
-      () {
-        final platform = _fakePlatform(
-          environment: {
-            EnvironmentVariableKey.path: '$sdkBinPath$_pathSeparator/usr/bin',
-          },
-          script: script,
-          resolvedExecutable: executable,
-        );
+    test('has no sdk path without a local installation', () async {
+      final context = LaunchContext(directory: createTestTempDir());
 
-        expect(
-          _withPlatform(
-            platform,
-            () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
-          ),
-          isNull,
-        );
-      },
-    );
+      final config = await resolveLocalLaunchConfig(['bootstrap'], context);
 
-    test('relaunches the running script with the sdk first on the PATH', () {
-      final platform = _fakePlatform(
-        environment: {
-          EnvironmentVariableKey.path: '/usr/bin',
-          'HOME': '/home/user',
-        },
-        script: script,
-        resolvedExecutable: executable,
-        executableArguments: [
-          '--resolved_executable_name=$executable',
-          '--executable_name=$executable',
-          '--packages=.dart_tool/package_config.json',
-          '--enable-asserts',
-        ],
-      );
-
-      final relaunch = _withPlatform(
-        platform,
-        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
-      );
-
-      expect(relaunch, isNotNull);
-      expect(relaunch!.executable, executable);
-      expect(relaunch.arguments, [
-        '--packages=.dart_tool/package_config.json',
-        '--enable-asserts',
-        script.toFilePath(),
-        ...arguments,
-      ]);
-      expect(relaunch.environment, {
-        EnvironmentVariableKey.path: '$sdkBinPath$_pathSeparator/usr/bin',
-      });
-    });
-
-    test('uses the same PATH key as the parent environment', () {
-      final platform = _fakePlatform(
-        environment: {'Path': '/usr/bin'},
-        script: script,
-        resolvedExecutable: executable,
-      );
-
-      final relaunch = _withPlatform(
-        platform,
-        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
-      );
-
-      expect(relaunch!.environment.keys, ['Path']);
-      expect(relaunch.environment['Path'], startsWith(sdkBinPath));
-    });
-
-    test('does not pass the script to a standalone executable', () {
-      final standaloneExecutable = p.absolute('melos', 'bin', 'melos');
-      final platform = _fakePlatform(
-        environment: {EnvironmentVariableKey.path: '/usr/bin'},
-        script: Uri.file(standaloneExecutable),
-        resolvedExecutable: standaloneExecutable,
-      );
-
-      final relaunch = _withPlatform(
-        platform,
-        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
-      );
-
-      expect(relaunch!.executable, standaloneExecutable);
-      expect(relaunch.arguments, arguments);
-    });
-
-    test('returns null when the running script is not a file', () {
-      final platform = _fakePlatform(
-        environment: {EnvironmentVariableKey.path: '/usr/bin'},
-        script: Uri.parse('data:application/dart;charset=utf-8,void%20main'),
-        resolvedExecutable: executable,
-      );
-
-      expect(
-        _withPlatform(
-          platform,
-          () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
-        ),
-        isNull,
-      );
+      expect(config.sdkPath, isNull);
     });
   });
 }

--- a/packages/melos/test/sdk_launcher_test.dart
+++ b/packages/melos/test/sdk_launcher_test.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:melos/melos.dart';
+import 'package:melos/src/common/environment_variable_key.dart';
+import 'package:melos/src/common/io.dart';
+import 'package:melos/src/common/platform.dart';
+import 'package:melos/src/sdk_launcher.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart' show FakePlatform;
+import 'package:test/test.dart';
+
+import 'mock_env.dart';
+import 'utils.dart';
+
+final _pathSeparator = Platform.isWindows ? ';' : ':';
+
+FakePlatform _fakePlatform({
+  required Map<String, String> environment,
+  Uri? script,
+  String? resolvedExecutable,
+  List<String> executableArguments = const [],
+}) {
+  return FakePlatform(
+    operatingSystem: Platform.operatingSystem,
+    environment: environment,
+    script: script,
+    resolvedExecutable: resolvedExecutable,
+    executableArguments: executableArguments,
+  );
+}
+
+T _withPlatform<T>(FakePlatform platform, T Function() body) {
+  return runZoned(body, zoneValues: {currentPlatformZoneKey: platform});
+}
+
+void main() {
+  group('resolveLaunchSdkPath', () {
+    Future<Directory> createWorkspace({String? sdkPath}) {
+      return createTemporaryWorkspace(
+        workspacePackages: ['a'],
+        configBuilder: (path) => MelosWorkspaceConfig(
+          path: path,
+          name: 'test_workspace',
+          packages: const [],
+          sdkPath: sdkPath,
+        ),
+      );
+    }
+
+    test('returns null outside of a workspace', () async {
+      final directory = createTestTempDir();
+
+      expect(await resolveLaunchSdkPath([], current: directory), isNull);
+    });
+
+    test('returns null when no sdk path is configured', () async {
+      final workspace = await createWorkspace();
+
+      expect(await resolveLaunchSdkPath([], current: workspace), isNull);
+    });
+
+    test(
+      'resolves sdkPath from the root pubspec relative to the workspace',
+      () async {
+        final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+
+        expect(
+          await resolveLaunchSdkPath([], current: workspace),
+          p.join(workspace.path, '.fvm', 'flutter_sdk'),
+        );
+      },
+    );
+
+    test('finds the workspace root from a nested directory', () async {
+      final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+      final packageDirectory = Directory(
+        p.join(workspace.path, 'packages', 'a'),
+      );
+
+      expect(
+        await resolveLaunchSdkPath([], current: packageDirectory),
+        p.join(workspace.path, '.fvm', 'flutter_sdk'),
+      );
+    });
+
+    test(
+      'the environment variable has precedence over the root pubspec',
+      withMockPlatform(
+        () async {
+          final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+
+          expect(
+            await resolveLaunchSdkPath([], current: workspace),
+            p.join(workspace.path, 'env_sdk'),
+          );
+        },
+        platform: _fakePlatform(
+          environment: {EnvironmentVariableKey.melosSdkPath: 'env_sdk'},
+        ),
+      ),
+    );
+
+    test(
+      'the command line option has precedence over the environment variable',
+      withMockPlatform(
+        () async {
+          final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+
+          expect(
+            await resolveLaunchSdkPath(
+              ['--sdk-path', 'command_sdk', 'bootstrap'],
+              current: workspace,
+            ),
+            p.join(workspace.path, 'command_sdk'),
+          );
+          expect(
+            await resolveLaunchSdkPath(
+              ['--verbose', '--sdk-path=command_sdk', 'bootstrap'],
+              current: workspace,
+            ),
+            p.join(workspace.path, 'command_sdk'),
+          );
+        },
+        platform: _fakePlatform(
+          environment: {EnvironmentVariableKey.melosSdkPath: 'env_sdk'},
+        ),
+      ),
+    );
+
+    test('returns null when the special value "auto" is used', () async {
+      final workspace = await createWorkspace(sdkPath: '.fvm/flutter_sdk');
+
+      expect(
+        await resolveLaunchSdkPath(
+          ['--sdk-path', 'auto', 'bootstrap'],
+          current: workspace,
+        ),
+        isNull,
+      );
+    });
+
+    test('keeps absolute sdk paths as is', () async {
+      final absoluteSdkPath = p.normalize(p.absolute('sdks', 'flutter'));
+      final workspace = await createWorkspace(sdkPath: absoluteSdkPath);
+
+      expect(
+        await resolveLaunchSdkPath([], current: workspace),
+        absoluteSdkPath,
+      );
+    });
+  });
+
+  group('planSdkRelaunch', () {
+    late Directory sdkDirectory;
+    late String sdkBinPath;
+
+    setUp(() {
+      sdkDirectory = createTestTempDir();
+      sdkBinPath = p.join(sdkDirectory.path, 'bin');
+      ensureDir(sdkBinPath);
+    });
+
+    const arguments = ['bootstrap', '--no-enforce-lockfile'];
+    final script = Uri.file(p.absolute('bin', 'melos.dart-3.9.0.snapshot'));
+    final executable = p.absolute('sdk', 'bin', 'dart');
+
+    test('returns null when the sdk has no bin directory', () {
+      final platform = _fakePlatform(
+        environment: {EnvironmentVariableKey.path: '/usr/bin'},
+        script: script,
+        resolvedExecutable: executable,
+      );
+
+      expect(
+        _withPlatform(
+          platform,
+          () => planSdkRelaunch(
+            arguments,
+            sdkPath: p.join(sdkDirectory.path, 'missing'),
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test(
+      'returns null when the sdk bin directory is already first on the PATH',
+      () {
+        final platform = _fakePlatform(
+          environment: {
+            EnvironmentVariableKey.path: '$sdkBinPath$_pathSeparator/usr/bin',
+          },
+          script: script,
+          resolvedExecutable: executable,
+        );
+
+        expect(
+          _withPlatform(
+            platform,
+            () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test('relaunches the running script with the sdk first on the PATH', () {
+      final platform = _fakePlatform(
+        environment: {
+          EnvironmentVariableKey.path: '/usr/bin',
+          'HOME': '/home/user',
+        },
+        script: script,
+        resolvedExecutable: executable,
+        executableArguments: [
+          '--resolved_executable_name=$executable',
+          '--executable_name=$executable',
+          '--packages=.dart_tool/package_config.json',
+          '--enable-asserts',
+        ],
+      );
+
+      final relaunch = _withPlatform(
+        platform,
+        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
+      );
+
+      expect(relaunch, isNotNull);
+      expect(relaunch!.executable, executable);
+      expect(relaunch.arguments, [
+        '--packages=.dart_tool/package_config.json',
+        '--enable-asserts',
+        script.toFilePath(),
+        ...arguments,
+      ]);
+      expect(relaunch.environment, {
+        EnvironmentVariableKey.path: '$sdkBinPath$_pathSeparator/usr/bin',
+      });
+    });
+
+    test('uses the same PATH key as the parent environment', () {
+      final platform = _fakePlatform(
+        environment: {'Path': '/usr/bin'},
+        script: script,
+        resolvedExecutable: executable,
+      );
+
+      final relaunch = _withPlatform(
+        platform,
+        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
+      );
+
+      expect(relaunch!.environment.keys, ['Path']);
+      expect(relaunch.environment['Path'], startsWith(sdkBinPath));
+    });
+
+    test('does not pass the script to a standalone executable', () {
+      final standaloneExecutable = p.absolute('melos', 'bin', 'melos');
+      final platform = _fakePlatform(
+        environment: {EnvironmentVariableKey.path: '/usr/bin'},
+        script: Uri.file(standaloneExecutable),
+        resolvedExecutable: standaloneExecutable,
+      );
+
+      final relaunch = _withPlatform(
+        platform,
+        () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
+      );
+
+      expect(relaunch!.executable, standaloneExecutable);
+      expect(relaunch.arguments, arguments);
+    });
+
+    test('returns null when the running script is not a file', () {
+      final platform = _fakePlatform(
+        environment: {EnvironmentVariableKey.path: '/usr/bin'},
+        script: Uri.parse('data:application/dart;charset=utf-8,void%20main'),
+        resolvedExecutable: executable,
+      );
+
+      expect(
+        _withPlatform(
+          platform,
+          () => planSdkRelaunch(arguments, sdkPath: sdkDirectory.path),
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ melos:
       dependencies:
         ansi_styles: ^0.3.2+1
         args: ^2.7.0
-        cli_launcher: ^0.3.3+2
+        cli_launcher: ^0.3.4
         cli_util: ">=0.5.0 <0.7.0"
         collection: ^1.19.0
         file: ^7.0.1


### PR DESCRIPTION
## Description

Fixes #616

This depends on the `sdkPath` option added to `LocalLaunchConfig` in blaugold/cli_launcher#26, which was released in `cli_launcher` 0.3.4, so the `cli_launcher` constraint is bumped to `^0.3.4`.

Since Melos 3.2.0 the executable is started through `cli_launcher`, which looks for a local installation of Melos in the workspace and, when one is found, runs `dart`/`flutter pub get` and relaunches Melos via `dart run` or `flutter pub run`. All of this happens before Melos reads the workspace configuration, so the `sdkPath` option (as well as `MELOS_SDK_PATH` and `--sdk-path`) was ignored for those invocations. They simply used whatever `dart`/`flutter` was first on the `PATH`, which fails when no system-wide Flutter SDK is installed (for example when managing Flutter with FVM), or picks up the wrong SDK when one is.

This change resolves the SDK path with the same precedence as before (`--sdk-path`, then `MELOS_SDK_PATH`, then `sdkPath` in the root `pubspec.yaml`) in the `resolveLocalLaunchConfig` hook of `cli_launcher`, using the lock file root of the local installation as the workspace root. The resolved path is passed to `cli_launcher` as `LocalLaunchConfig.sdkPath`, which makes it take the `dart`/`flutter` tools from that SDK and prepend its `bin` directory to the `PATH` of the processes it starts. No SDK path is passed when the value is `auto`, when there is no local installation, or when the SDK has no `bin` directory, in which case Melos reports the invalid path as before.

Verified with a workspace containing a Flutter package and `sdkPath` set, run with a `PATH` that only contains a plain Dart SDK and no `flutter`:

- Before: `ProcessException: No such file or directory  Command: flutter pub run melos:melos ...`
- After: `cli_launcher` logs `Using SDK at <sdkPath>.` and the command succeeds.

Dependency resolution, analysis and the `sdk_launcher` and workspace tests pass against the published `cli_launcher` 0.3.4.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore

