### PR TITLE
feat(config): allow every command line option to be configured

### DIFF
--- a/docs/commands/run.mdx
+++ b/docs/commands/run.mdx
@@ -32,6 +32,10 @@ applied.
 melos run <name> --no-select
 ```
 
+To skip the prompt for every run, set
+[`command/run/noSelect`](/configuration/overview#noselect) in the workspace
+configuration.
+
 ## --list
 
 Displays all scripts defined in the Melos workspace.

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -329,6 +329,20 @@ Define custom scripts that can be executed in the workspace via the
 
 Learn more about defining scripts [here](/configuration/scripts).
 
+## command
+
+Configuration for the individual Melos commands, grouped per command under
+`command/<command name>`.
+
+Every command line option of a command can be given a default here, so it does
+not have to be typed out on every run. Options that select what a single
+invocation does rather than how the command behaves are not configurable: the
+[package filters](/filters), `melos init`, `melos run --list/--json/--group`,
+`melos list --cycles`, and `melos version --prerelease/--graduate/--manual-version`.
+
+An option passed on the command line always takes precedence over its
+configured default.
+
 ## command/bootstrap
 
 Configuration for the `bootstrap` command.
@@ -392,6 +406,20 @@ The default is `false`.
 
 To temporarily override this `melos bootstrap --no-enforce-lockfile / --enforce-lockfile` can be
 used.
+
+### noExample
+
+Whether to run `pub get` with the `--no-example` option, so the `example`
+directory of a package is not resolved.
+
+The default is `false`, which is the same as `melos bootstrap --no-example`.
+
+### noPub
+
+Whether to skip running `pub get` entirely. Shared dependencies, dependency
+overrides, IDE files and lifecycle hooks are still applied.
+
+The default is `false`, the same as `melos bootstrap --no-pub`.
 
 ### pubGetArgs
 
@@ -710,3 +738,275 @@ instead of being listed in a single flat list:
 
 This setting can be overridden per run with the `--[no-]group-commits` flag on
 `melos version`.
+
+### updateChangelog
+
+Whether to update the `CHANGELOG.md` files of the versioned packages.
+
+The default is `true`, the same as `melos version --changelog`.
+
+### updateDependentsConstraints
+
+Whether to update the dependency version constraints of packages that depend on
+any of the packages that are versioned.
+
+The default is `true`, the same as `melos version --dependent-constraints`.
+
+### updateDependentsVersions
+
+Whether to make a new patch version and changelog entry in packages that are
+updated because of [updateDependentsConstraints](#updatedependentsconstraints).
+
+Only usable with `updateDependentsConstraints` enabled. The default is `true`,
+the same as `melos version --dependent-versions`.
+
+### gitTagVersion
+
+Whether to tag the release.
+
+The default is `true`, the same as `melos version --git-tag-version`.
+
+### gitCommitVersion
+
+Whether to commit the changes made to the `pubspec.yaml` and changelog files.
+Disabling this also disables [gitTagVersion](#gittagversion).
+
+The default is `true`, the same as `melos version --git-commit-version`.
+
+### force
+
+Whether to skip the confirmation prompt.
+
+The default is `false`, the same as `melos version --yes`.
+
+### versionPrivatePackages
+
+Whether to also version private packages, which are skipped by default.
+
+The default is `false`, the same as `melos version --all`.
+
+### preid
+
+The prerelease identifier to use when versioning packages as a prerelease, e.g.
+a `nullsafety` preid results in a version in the `1.0.0-1.0.nullsafety.0`
+format.
+
+Same as `melos version --preid`.
+
+### dependentPreid
+
+The same as [preid](#preid), but only applied to packages that are versioned
+because of a change in a dependency version. Falls back to `preid` when not
+set.
+
+Same as `melos version --dependent-preid`.
+
+## command/analyze
+
+Configuration for the `analyze` command.
+
+```yaml
+melos:
+  command:
+    analyze:
+      concurrency: 4
+      fatalInfos: false
+      fatalWarnings: true
+      noPub: true
+```
+
+### concurrency
+
+The number of packages to analyze concurrently. The default is `1`.
+
+### fatalInfos
+
+Whether info level issues are treated as fatal errors. The default is `true`.
+
+### fatalWarnings
+
+Whether warnings are treated as fatal errors. Not set by default, which leaves
+the behavior to the Dart or Flutter SDK.
+
+### noPub
+
+Whether `--no-pub` is passed to `flutter analyze`, to skip the implicit
+`pub get`. It has no effect on `dart analyze`, which never runs `pub get`.
+
+The default is `false`.
+
+## command/exec
+
+Configuration for the `exec` command. These options are also used as the
+defaults for the `exec` options of [scripts](/configuration/scripts).
+
+```yaml
+melos:
+  command:
+    exec:
+      concurrency: 4
+      failFast: true
+      orderDependents: true
+      groupLogs: true
+```
+
+### concurrency
+
+The number of packages to run the command in concurrently. The default is the
+number of processors on the machine.
+
+### failFast
+
+Whether to stop executing the command in further packages as soon as it fails
+in one package. The default is `false`.
+
+### orderDependents
+
+Whether to order the execution of the command based on the dependency graph of
+the packages. The default is `false`.
+
+### groupLogs
+
+Whether the output of each package is buffered and printed grouped per package,
+instead of being streamed and interleaved. The default is `false`.
+
+## command/format
+
+Configuration for the `format` command.
+
+```yaml
+melos:
+  command:
+    format:
+      concurrency: 4
+      setExitIfChanged: true
+      output: none
+      lineLength: 120
+```
+
+### concurrency
+
+The number of packages to format concurrently. The default is `1`.
+
+### setExitIfChanged
+
+Whether to return exit code 1 if there are any formatting changes. The default
+is `false`.
+
+### output
+
+Where `dart format` writes its output to, one of `json`, `none`, `show` or
+`write`. The default is `write`.
+
+### lineLength
+
+The line length to format the code to.
+
+## command/list
+
+Configuration for the `list` and `changed` commands.
+
+```yaml
+melos:
+  command:
+    list:
+      long: true
+      relativePaths: true
+      format: json
+```
+
+### long
+
+Whether to show extended information. The default is `false`.
+
+### relativePaths
+
+Whether to print package paths relative to the root of the workspace. The
+default is `false`.
+
+### format
+
+The output format, one of `column`, `parsable`, `json`, `graph`, `gviz` or
+`mermaid`. The default is `column`.
+
+## command/publish
+
+Configuration for the `publish` command.
+
+```yaml
+melos:
+  command:
+    publish:
+      dryRun: false
+      gitTagVersion: true
+      force: true
+      skipValidation: true
+      pubServer: https://pub.flutter-io.cn
+```
+
+### dryRun
+
+Whether packages are validated but not actually published. The default is
+`true`.
+
+### gitTagVersion
+
+Whether to add any missing git tags for the release. Tags are only created when
+`dryRun` is disabled. The default is `false`.
+
+### force
+
+Whether to skip the confirmation prompt when `dryRun` is disabled. The default
+is `false`, the same as `melos publish --yes`.
+
+### skipValidation
+
+Whether to publish without validation and resolution, forwarded to
+`dart pub publish --skip-validation`. The default is `false`.
+
+### pubServer
+
+The URL of the package server to publish to. When not set, the per-package
+`publish_to` field in the `pubspec.yaml` is used.
+
+## command/run
+
+Configuration for the `run` command.
+
+```yaml
+melos:
+  command:
+    run:
+      noSelect: true
+```
+
+### noSelect
+
+Whether to skip the prompt that asks which package to run a script in, when the
+script defines [packageFilters](/configuration/scripts#packagefilters). The
+filters themselves are still applied.
+
+The default is `false`.
+
+## command/test
+
+Configuration for the `test` command.
+
+```yaml
+melos:
+  command:
+    test:
+      concurrency: 4
+      noPub: true
+```
+
+### concurrency
+
+The number of packages to run tests in concurrently. The default is `1`.
+
+### noPub
+
+Whether `--no-pub` is passed to `flutter test`, to skip the implicit `pub get`.
+It has no effect on `dart test`, which does not support the flag.
+
+The default is `false`.

--- a/melos.yaml.schema.json
+++ b/melos.yaml.schema.json
@@ -165,6 +165,21 @@
               "type": "boolean",
               "description": "Whether `pubspec.lock` is enforced when running `pub get` or not.\nUseful when you want to ensure the same versions of dependencies are used across different environments/machines.\n\nDefaults to false."
             },
+            "noExample": {
+              "type": "boolean",
+              "description": "Whether `pub get` is run with `--no-example`, so the example directory of a package is not resolved.\n\nDefaults to false."
+            },
+            "noPub": {
+              "type": "boolean",
+              "description": "Whether to skip running `pub get`. Shared dependencies, dependency overrides and IDE files are still applied.\n\nDefaults to false."
+            },
+            "pubGetArgs": {
+              "type": "array",
+              "description": "Additional arguments to pass to `pub get` during bootstrapping.",
+              "items": {
+                "type": "string"
+              }
+            },
             "hooks": {
               "description": "Hooks to run at certain points of the command lifecycle.",
               "allOf": [{ "$ref": "#/$defs/commonHooks" }]
@@ -199,6 +214,26 @@
           "description": "The publish command configuration.",
           "additionalProperties": false,
           "properties": {
+            "dryRun": {
+              "type": "boolean",
+              "description": "Whether packages are validated but not actually published.\n\nDefaults to true."
+            },
+            "gitTagVersion": {
+              "type": "boolean",
+              "description": "Whether to add any missing tags for the published release. Tags are only created when `dryRun` is disabled.\n\nDefaults to false."
+            },
+            "force": {
+              "type": "boolean",
+              "description": "Whether to skip the confirmation prompt when `dryRun` is disabled.\n\nDefaults to false."
+            },
+            "skipValidation": {
+              "type": "boolean",
+              "description": "Whether packages are published without validation and resolution, forwarded to `dart pub publish --skip-validation`.\n\nDefaults to false."
+            },
+            "pubServer": {
+              "type": "string",
+              "description": "The URL of the package server to publish to. When not set, the per-package `publish_to` field is used."
+            },
             "hooks": {
               "type": "object",
               "description": "Hooks to run at certain points of the command lifecycle.",
@@ -220,6 +255,42 @@
           "description": "The version command configuration.",
           "additionalProperties": false,
           "properties": {
+            "updateChangelog": {
+              "type": "boolean",
+              "description": "Whether to update the CHANGELOG.md files of the versioned packages.\n\nDefaults to true."
+            },
+            "updateDependentsConstraints": {
+              "type": "boolean",
+              "description": "Whether to update the dependency version constraints of packages that depend on any of the packages that are versioned.\n\nDefaults to true."
+            },
+            "updateDependentsVersions": {
+              "type": "boolean",
+              "description": "Whether to make a new patch version and changelog entry in packages that are updated because of `updateDependentsConstraints`.\n\nDefaults to true."
+            },
+            "gitTagVersion": {
+              "type": "boolean",
+              "description": "Whether to tag the release.\n\nDefaults to true."
+            },
+            "gitCommitVersion": {
+              "type": "boolean",
+              "description": "Whether to commit the changes made to the pubspec.yaml and changelog files. Disabling this also disables `gitTagVersion`.\n\nDefaults to true."
+            },
+            "force": {
+              "type": "boolean",
+              "description": "Whether to skip the confirmation prompt.\n\nDefaults to false."
+            },
+            "versionPrivatePackages": {
+              "type": "boolean",
+              "description": "Whether to also version private packages, which are skipped by default.\n\nDefaults to false."
+            },
+            "preid": {
+              "type": "string",
+              "description": "The prerelease identifier to use when versioning packages as a prerelease."
+            },
+            "dependentPreid": {
+              "type": "string",
+              "description": "The prerelease identifier to use for packages that are versioned because of a change in a dependency version. Falls back to `preid`."
+            },
             "message": {
               "type": "string",
               "description": "A custom header for the generated CHANGELOG.md."
@@ -302,6 +373,123 @@
             "hooks": {
               "description": "Hooks to run at certain points of the command lifecycle.",
               "allOf": [{ "$ref": "#/$defs/commonHooks" }]
+            }
+          }
+        }
+,
+        "analyze": {
+          "type": "object",
+          "description": "The analyze command configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "concurrency": {
+              "type": "integer",
+              "description": "The number of packages to analyze concurrently.\n\nDefaults to 1."
+            },
+            "fatalInfos": {
+              "type": "boolean",
+              "description": "Whether info level issues are treated as fatal errors.\n\nDefaults to true."
+            },
+            "fatalWarnings": {
+              "type": "boolean",
+              "description": "Whether warnings are treated as fatal errors."
+            },
+            "noPub": {
+              "type": "boolean",
+              "description": "Whether `--no-pub` is passed to `flutter analyze`, to skip the implicit pub get. Has no effect on `dart analyze`.\n\nDefaults to false."
+            }
+          }
+        },
+        "exec": {
+          "type": "object",
+          "description": "The exec command configuration. Also used as the defaults for the exec options of scripts.",
+          "additionalProperties": false,
+          "properties": {
+            "concurrency": {
+              "type": "integer",
+              "description": "The number of packages to run the command in concurrently.\n\nDefaults to the number of processors."
+            },
+            "failFast": {
+              "type": "boolean",
+              "description": "Whether to stop executing the command in further packages as soon as it fails in one package.\n\nDefaults to false."
+            },
+            "orderDependents": {
+              "type": "boolean",
+              "description": "Whether to order the execution of the command based on the dependency graph of the packages.\n\nDefaults to false."
+            },
+            "groupLogs": {
+              "type": "boolean",
+              "description": "Whether the output of each package is buffered and printed grouped per package.\n\nDefaults to false."
+            }
+          }
+        },
+        "format": {
+          "type": "object",
+          "description": "The format command configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "concurrency": {
+              "type": "integer",
+              "description": "The number of packages to format concurrently.\n\nDefaults to 1."
+            },
+            "setExitIfChanged": {
+              "type": "boolean",
+              "description": "Whether to return exit code 1 if there are any formatting changes.\n\nDefaults to false."
+            },
+            "output": {
+              "type": "string",
+              "enum": ["json", "none", "show", "write"],
+              "description": "Where `dart format` writes its output to.\n\nDefaults to write."
+            },
+            "lineLength": {
+              "type": "integer",
+              "description": "The line length to format the code to."
+            }
+          }
+        },
+        "list": {
+          "type": "object",
+          "description": "The list and changed command configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "long": {
+              "type": "boolean",
+              "description": "Whether to show extended information.\n\nDefaults to false."
+            },
+            "relativePaths": {
+              "type": "boolean",
+              "description": "Whether to print package paths relative to the root of the workspace.\n\nDefaults to false."
+            },
+            "format": {
+              "type": "string",
+              "enum": ["column", "parsable", "json", "graph", "gviz", "mermaid"],
+              "description": "The output format.\n\nDefaults to column."
+            }
+          }
+        },
+        "run": {
+          "type": "object",
+          "description": "The run command configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "noSelect": {
+              "type": "boolean",
+              "description": "Whether to skip the prompt that asks which package to run a script in, when the script defines packageFilters.\n\nDefaults to false."
+            }
+          }
+        },
+        "test": {
+          "type": "object",
+          "description": "The test command configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "concurrency": {
+              "type": "integer",
+              "description": "The number of packages to run tests in concurrently.\n\nDefaults to 1."
+            },
+            "noPub": {
+              "type": "boolean",
+              "description": "Whether `--no-pub` is passed to `flutter test`, to skip the implicit pub get. Has no effect on `dart test`.\n\nDefaults to false."
             }
           }
         }

--- a/packages/melos/lib/melos.dart
+++ b/packages/melos/lib/melos.dart
@@ -1,14 +1,21 @@
 export 'src/command_configs/command_configs.dart'
     show
+        AnalyzeCommandConfigs,
         BootstrapCommandConfigs,
         CleanCommandConfigs,
+        CommandConfigs,
+        ExecCommandConfigs,
+        FormatCommandConfigs,
+        ListCommandConfigs,
+        PublishCommandConfigs,
+        RunCommandConfigs,
+        TestCommandConfigs,
         VersionCommandConfigs,
         VersioningMode;
 export 'src/commands/runner.dart'
     show
         BootstrapException,
         FixedVersioningException,
-        ListOutputKind,
         Melos,
         NoPackageFoundScriptException,
         NoScriptException,
@@ -22,6 +29,7 @@ export 'src/common/changelog.dart'
         MarkdownStringBufferExtension;
 export 'src/common/exception.dart' show CancelledException, MelosException;
 export 'src/common/io.dart' show IOException;
+export 'src/common/list_output_kind.dart' show ListOutputKind;
 export 'src/common/pub_config.dart' show PubClientConfig;
 export 'src/common/validation.dart' show MelosConfigException;
 export 'src/common/versioning.dart' show ManualVersionChange, SemverReleaseType;

--- a/packages/melos/lib/src/command_configs/analyze.dart
+++ b/packages/melos/lib/src/command_configs/analyze.dart
@@ -1,0 +1,106 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+
+/// Configurations for `melos analyze`.
+@immutable
+class AnalyzeCommandConfigs {
+  const AnalyzeCommandConfigs({
+    this.concurrency,
+    this.fatalInfos,
+    this.fatalWarnings,
+    this.noPub,
+  });
+
+  factory AnalyzeCommandConfigs.fromYaml(Map<Object?, Object?> yaml) {
+    final concurrency = assertKeyIsA<int?>(
+      key: 'concurrency',
+      map: yaml,
+      path: 'command/analyze',
+    );
+
+    final fatalInfos = assertKeyIsA<bool?>(
+      key: 'fatalInfos',
+      map: yaml,
+      path: 'command/analyze',
+    );
+
+    final fatalWarnings = assertKeyIsA<bool?>(
+      key: 'fatalWarnings',
+      map: yaml,
+      path: 'command/analyze',
+    );
+
+    final noPub = assertKeyIsA<bool?>(
+      key: 'noPub',
+      map: yaml,
+      path: 'command/analyze',
+    );
+
+    return AnalyzeCommandConfigs(
+      concurrency: concurrency,
+      fatalInfos: fatalInfos,
+      fatalWarnings: fatalWarnings,
+      noPub: noPub,
+    );
+  }
+
+  static const AnalyzeCommandConfigs empty = AnalyzeCommandConfigs();
+
+  /// The number of packages to analyze concurrently.
+  ///
+  /// The default is `1`.
+  final int? concurrency;
+
+  /// Whether info level issues are treated as fatal errors.
+  ///
+  /// The default is `true`.
+  final bool? fatalInfos;
+
+  /// Whether warnings are treated as fatal errors.
+  final bool? fatalWarnings;
+
+  /// Whether `--no-pub` is passed to `flutter analyze`, to skip the implicit
+  /// `pub get`. Has no effect on `dart analyze`.
+  ///
+  /// The default is `false`.
+  final bool? noPub;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (concurrency != null) 'concurrency': concurrency,
+      if (fatalInfos != null) 'fatalInfos': fatalInfos,
+      if (fatalWarnings != null) 'fatalWarnings': fatalWarnings,
+      if (noPub != null) 'noPub': noPub,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnalyzeCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.concurrency == concurrency &&
+      other.fatalInfos == fatalInfos &&
+      other.fatalWarnings == fatalWarnings &&
+      other.noPub == noPub;
+
+  @override
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    concurrency,
+    fatalInfos,
+    fatalWarnings,
+    noPub,
+  ]);
+
+  @override
+  String toString() {
+    return '''
+AnalyzeCommandConfigs(
+  concurrency: $concurrency,
+  fatalInfos: $fatalInfos,
+  fatalWarnings: $fatalWarnings,
+  noPub: $noPub,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/bootstrap.dart
+++ b/packages/melos/lib/src/command_configs/bootstrap.dart
@@ -17,6 +17,8 @@ class BootstrapCommandConfigs {
     this.runPubGetInParallel = true,
     this.runPubGetOffline = false,
     this.enforceLockfile = false,
+    this.noExample = false,
+    this.noPub = false,
     this.pubGetArgs = const [],
     this.environment,
     this.dependencies,
@@ -48,6 +50,22 @@ class BootstrapCommandConfigs {
     final enforceLockfile =
         assertKeyIsA<bool?>(
           key: 'enforceLockfile',
+          map: yaml,
+          path: 'command/bootstrap',
+        ) ??
+        false;
+
+    final noExample =
+        assertKeyIsA<bool?>(
+          key: 'noExample',
+          map: yaml,
+          path: 'command/bootstrap',
+        ) ??
+        false;
+
+    final noPub =
+        assertKeyIsA<bool?>(
+          key: 'noPub',
           map: yaml,
           path: 'command/bootstrap',
         ) ??
@@ -99,6 +117,8 @@ class BootstrapCommandConfigs {
       runPubGetInParallel: runPubGetInParallel,
       runPubGetOffline: runPubGetOffline,
       enforceLockfile: enforceLockfile,
+      noExample: noExample,
+      noPub: noPub,
       pubGetArgs: pubGetArgs,
       environment: environment.isEmpty ? null : environment,
       dependencies: dependencies.isEmpty ? null : dependencies,
@@ -133,6 +153,17 @@ class BootstrapCommandConfigs {
   /// The default is `false`.
   final bool enforceLockfile;
 
+  /// Whether `pub get` is run without the `example` directory of a package.
+  ///
+  /// The default is `false`.
+  final bool noExample;
+
+  /// Whether to skip running `pub get`. Shared dependencies, dependency
+  /// overrides and IDE files are still applied.
+  ///
+  /// The default is `false`.
+  final bool noPub;
+
   /// Additional arguments to pass to `pub get` during bootstrapping.
   final List<String> pubGetArgs;
 
@@ -163,6 +194,8 @@ class BootstrapCommandConfigs {
       'runPubGetInParallel': runPubGetInParallel,
       'runPubGetOffline': runPubGetOffline,
       'enforceLockfile': enforceLockfile,
+      'noExample': noExample,
+      'noPub': noPub,
       if (pubGetArgs.isNotEmpty) 'pubGetArgs': pubGetArgs,
       if (environment != null) 'environment': environment!.toJson(),
       if (dependencies != null) 'dependencies': dependencies!.toYaml(),
@@ -183,6 +216,8 @@ class BootstrapCommandConfigs {
       other.runPubGetInParallel == runPubGetInParallel &&
       other.runPubGetOffline == runPubGetOffline &&
       other.enforceLockfile == enforceLockfile &&
+      other.noExample == noExample &&
+      other.noPub == noPub &&
       const ListEquality<String>().equals(other.pubGetArgs, pubGetArgs) &&
       // Extracting equality from environment here as it does not implement ==
       other.environment.sdkConstraint == environment.sdkConstraint &&
@@ -198,22 +233,23 @@ class BootstrapCommandConfigs {
       other.hooks == hooks;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      runPubGetInParallel.hashCode ^
-      runPubGetOffline.hashCode ^
-      enforceLockfile.hashCode ^
-      const ListEquality<String>().hash(pubGetArgs) ^
-      // Extracting hashCode from environment here as it does not implement
-      // hashCode
-      environment.sdkConstraint.hashCode ^
-      const DeepCollectionEquality().hash(environment) ^
-      const DeepCollectionEquality().hash(dependencies) ^
-      const DeepCollectionEquality().hash(devDependencies) ^
-      const DeepCollectionEquality(
-        GlobEquality(),
-      ).hash(dependencyOverridePaths) ^
-      hooks.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    runPubGetInParallel,
+    runPubGetOffline,
+    enforceLockfile,
+    noExample,
+    noPub,
+    const ListEquality<String>().hash(pubGetArgs),
+    // Extracting hashCode from environment here as it does not implement
+    // hashCode
+    environment.sdkConstraint,
+    const DeepCollectionEquality().hash(environment),
+    const DeepCollectionEquality().hash(dependencies),
+    const DeepCollectionEquality().hash(devDependencies),
+    const DeepCollectionEquality(GlobEquality()).hash(dependencyOverridePaths),
+    hooks,
+  ]);
 
   @override
   String toString() {
@@ -222,6 +258,8 @@ BootstrapCommandConfigs(
   runPubGetInParallel: $runPubGetInParallel,
   runPubGetOffline: $runPubGetOffline,
   enforceLockfile: $enforceLockfile,
+  noExample: $noExample,
+  noPub: $noPub,
   pubGetArgs: $pubGetArgs,
   environment: $environment,
   dependencies: $dependencies,

--- a/packages/melos/lib/src/command_configs/clean.dart
+++ b/packages/melos/lib/src/command_configs/clean.dart
@@ -45,7 +45,7 @@ class CleanCommandConfigs {
       other.hooks == hooks;
 
   @override
-  int get hashCode => runtimeType.hashCode ^ hooks.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, hooks]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/command_configs/command_configs.dart
+++ b/packages/melos/lib/src/command_configs/command_configs.dart
@@ -2,22 +2,39 @@ import 'package:meta/meta.dart';
 
 import '../common/utils.dart';
 import '../common/validation.dart';
+import 'analyze.dart';
 import 'bootstrap.dart';
 import 'clean.dart';
+import 'exec.dart';
 import 'format.dart';
+import 'list.dart';
 import 'publish.dart';
+import 'run.dart';
+import 'test.dart';
 import 'version.dart';
 
+export 'analyze.dart';
 export 'bootstrap.dart';
 export 'clean.dart';
+export 'exec.dart';
+export 'format.dart';
+export 'list.dart';
+export 'publish.dart';
+export 'run.dart';
+export 'test.dart';
 export 'version.dart';
 
 /// Melos command-specific configurations.
 @immutable
 class CommandConfigs {
   const CommandConfigs({
+    this.analyze = AnalyzeCommandConfigs.empty,
     this.bootstrap = BootstrapCommandConfigs.empty,
     this.clean = CleanCommandConfigs.empty,
+    this.exec = ExecCommandConfigs.empty,
+    this.list = ListCommandConfigs.empty,
+    this.run = RunCommandConfigs.empty,
+    this.test = TestCommandConfigs.empty,
     this.version = VersionCommandConfigs.empty,
     this.publish = PublishCommandConfigs.empty,
     this.format = FormatCommandConfigs.empty,
@@ -28,6 +45,12 @@ class CommandConfigs {
     required String workspacePath,
     bool repositoryIsConfigured = false,
   }) {
+    final analyzeMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'analyze',
+      map: yaml,
+      path: 'command',
+    );
+
     final bootstrapMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'bootstrap',
       map: yaml,
@@ -36,6 +59,30 @@ class CommandConfigs {
 
     final cleanMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'clean',
+      map: yaml,
+      path: 'command',
+    );
+
+    final execMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'exec',
+      map: yaml,
+      path: 'command',
+    );
+
+    final listMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'list',
+      map: yaml,
+      path: 'command',
+    );
+
+    final runMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'run',
+      map: yaml,
+      path: 'command',
+    );
+
+    final testMap = assertKeyIsA<Map<Object?, Object?>?>(
+      key: 'test',
       map: yaml,
       path: 'command',
     );
@@ -59,6 +106,7 @@ class CommandConfigs {
     );
 
     return CommandConfigs(
+      analyze: AnalyzeCommandConfigs.fromYaml(analyzeMap ?? const {}),
       bootstrap: BootstrapCommandConfigs.fromYaml(
         bootstrapMap ?? const {},
         workspacePath: workspacePath,
@@ -67,6 +115,10 @@ class CommandConfigs {
         cleanMap ?? const {},
         workspacePath: workspacePath,
       ),
+      exec: ExecCommandConfigs.fromYaml(execMap ?? const {}),
+      list: ListCommandConfigs.fromYaml(listMap ?? const {}),
+      run: RunCommandConfigs.fromYaml(runMap ?? const {}),
+      test: TestCommandConfigs.fromYaml(testMap ?? const {}),
       version: VersionCommandConfigs.fromYaml(
         versionMap ?? const {},
         workspacePath: workspacePath,
@@ -83,16 +135,26 @@ class CommandConfigs {
 
   static const CommandConfigs empty = CommandConfigs();
 
+  final AnalyzeCommandConfigs analyze;
   final BootstrapCommandConfigs bootstrap;
   final CleanCommandConfigs clean;
+  final ExecCommandConfigs exec;
+  final ListCommandConfigs list;
+  final RunCommandConfigs run;
+  final TestCommandConfigs test;
   final VersionCommandConfigs version;
   final PublishCommandConfigs publish;
   final FormatCommandConfigs format;
 
   Map<String, Object?> toJson() {
     return {
+      'analyze': analyze.toJson(),
       'bootstrap': bootstrap.toJson(),
       'clean': clean.toJson(),
+      'exec': exec.toJson(),
+      'list': list.toJson(),
+      'run': run.toJson(),
+      'test': test.toJson(),
       'version': version.toJson(),
       'publish': publish.toJson(),
       'format': format.toJson(),
@@ -103,28 +165,43 @@ class CommandConfigs {
   bool operator ==(Object other) =>
       other is CommandConfigs &&
       runtimeType == other.runtimeType &&
+      other.analyze == analyze &&
       other.bootstrap == bootstrap &&
       other.clean == clean &&
+      other.exec == exec &&
+      other.list == list &&
+      other.run == run &&
+      other.test == test &&
       other.version == version &&
       other.publish == publish &&
       other.format == format;
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     runtimeType,
+    analyze,
     bootstrap,
     clean,
+    exec,
+    list,
+    run,
+    test,
     version,
     publish,
     format,
-  );
+  ]);
 
   @override
   String toString() {
     return '''
 CommandConfigs(
+  analyze: ${analyze.toString().indent('  ')},
   bootstrap: ${bootstrap.toString().indent('  ')},
   clean: ${clean.toString().indent('  ')},
+  exec: ${exec.toString().indent('  ')},
+  list: ${list.toString().indent('  ')},
+  run: ${run.toString().indent('  ')},
+  test: ${test.toString().indent('  ')},
   version: ${version.toString().indent('  ')},
   publish: ${publish.toString().indent('  ')},
   format: ${format.toString().indent('  ')},

--- a/packages/melos/lib/src/command_configs/exec.dart
+++ b/packages/melos/lib/src/command_configs/exec.dart
@@ -1,0 +1,110 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+
+/// Configurations for `melos exec`.
+@immutable
+class ExecCommandConfigs {
+  const ExecCommandConfigs({
+    this.concurrency,
+    this.failFast,
+    this.orderDependents,
+    this.groupLogs,
+  });
+
+  factory ExecCommandConfigs.fromYaml(Map<Object?, Object?> yaml) {
+    final concurrency = assertKeyIsA<int?>(
+      key: 'concurrency',
+      map: yaml,
+      path: 'command/exec',
+    );
+
+    final failFast = assertKeyIsA<bool?>(
+      key: 'failFast',
+      map: yaml,
+      path: 'command/exec',
+    );
+
+    final orderDependents = assertKeyIsA<bool?>(
+      key: 'orderDependents',
+      map: yaml,
+      path: 'command/exec',
+    );
+
+    final groupLogs = assertKeyIsA<bool?>(
+      key: 'groupLogs',
+      map: yaml,
+      path: 'command/exec',
+    );
+
+    return ExecCommandConfigs(
+      concurrency: concurrency,
+      failFast: failFast,
+      orderDependents: orderDependents,
+      groupLogs: groupLogs,
+    );
+  }
+
+  static const ExecCommandConfigs empty = ExecCommandConfigs();
+
+  /// The number of packages to run the command in concurrently.
+  ///
+  /// The default is the number of processors on the machine.
+  final int? concurrency;
+
+  /// Whether to stop executing the command in further packages as soon as it
+  /// fails in one package.
+  ///
+  /// The default is `false`.
+  final bool? failFast;
+
+  /// Whether to order the execution of the command based on the dependency
+  /// graph of the packages.
+  ///
+  /// The default is `false`.
+  final bool? orderDependents;
+
+  /// Whether the output of each package is buffered and printed grouped per
+  /// package, instead of being streamed and interleaved.
+  ///
+  /// The default is `false`.
+  final bool? groupLogs;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (concurrency != null) 'concurrency': concurrency,
+      if (failFast != null) 'failFast': failFast,
+      if (orderDependents != null) 'orderDependents': orderDependents,
+      if (groupLogs != null) 'groupLogs': groupLogs,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ExecCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.concurrency == concurrency &&
+      other.failFast == failFast &&
+      other.orderDependents == orderDependents &&
+      other.groupLogs == groupLogs;
+
+  @override
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    concurrency,
+    failFast,
+    orderDependents,
+    groupLogs,
+  ]);
+
+  @override
+  String toString() {
+    return '''
+ExecCommandConfigs(
+  concurrency: $concurrency,
+  failFast: $failFast,
+  orderDependents: $orderDependents,
+  groupLogs: $groupLogs,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/format.dart
+++ b/packages/melos/lib/src/command_configs/format.dart
@@ -6,15 +6,29 @@ import '../common/validation.dart';
 @immutable
 class FormatCommandConfigs {
   const FormatCommandConfigs({
+    this.concurrency,
     this.setExitIfChanged,
+    this.output,
     this.lineLength,
   });
 
   factory FormatCommandConfigs.fromYaml(
     Map<Object?, Object?> yaml,
   ) {
+    final concurrency = assertKeyIsA<int?>(
+      key: 'concurrency',
+      map: yaml,
+      path: 'command/format',
+    );
+
     final setExitIfChanged = assertKeyIsA<bool?>(
       key: 'setExitIfChanged',
+      map: yaml,
+      path: 'command/format',
+    );
+
+    final output = assertKeyIsA<String?>(
+      key: 'output',
       map: yaml,
       path: 'command/format',
     );
@@ -26,23 +40,35 @@ class FormatCommandConfigs {
     );
 
     return FormatCommandConfigs(
+      concurrency: concurrency,
       setExitIfChanged: setExitIfChanged,
+      output: output,
       lineLength: lineLength,
     );
   }
 
   static const FormatCommandConfigs empty = FormatCommandConfigs();
 
+  /// The number of packages to format concurrently.
+  ///
+  /// The default is `1`.
+  final int? concurrency;
+
   /// Declares if `--set-exit-if-changed` flag is passed
   /// to the `dart format` command.
   final bool? setExitIfChanged;
+
+  /// Where the `dart format` command writes its output to.
+  final String? output;
 
   /// The `--line-length` passed to the `dart format` command.
   final int? lineLength;
 
   Map<String, Object?> toJson() {
     return {
+      if (concurrency != null) 'concurrency': concurrency,
       if (lineLength != null) 'lineLength': lineLength,
+      if (output != null) 'output': output,
       if (setExitIfChanged != null) 'setExitIfChanged': setExitIfChanged,
     };
   }
@@ -51,18 +77,27 @@ class FormatCommandConfigs {
   bool operator ==(Object other) =>
       other is FormatCommandConfigs &&
       other.runtimeType == runtimeType &&
+      other.concurrency == concurrency &&
       other.setExitIfChanged == setExitIfChanged &&
+      other.output == output &&
       other.lineLength == lineLength;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^ setExitIfChanged.hashCode ^ lineLength.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    concurrency,
+    setExitIfChanged,
+    output,
+    lineLength,
+  ]);
 
   @override
   String toString() {
     return '''
 FormatCommandConfigs(
+  concurrency: $concurrency,
   setExitIfChanged: $setExitIfChanged,
+  output: $output,
   lineLength: $lineLength,
 )''';
   }

--- a/packages/melos/lib/src/command_configs/list.dart
+++ b/packages/melos/lib/src/command_configs/list.dart
@@ -1,0 +1,110 @@
+import 'package:meta/meta.dart';
+
+import '../common/list_output_kind.dart';
+import '../common/validation.dart';
+
+/// The output formats that can be configured as the default for
+/// `melos list` and `melos changed`.
+const _configurableListFormats = {
+  'column': ListOutputKind.column,
+  'parsable': ListOutputKind.parsable,
+  'json': ListOutputKind.json,
+  'graph': ListOutputKind.graph,
+  'gviz': ListOutputKind.gviz,
+  'mermaid': ListOutputKind.mermaid,
+};
+
+/// Configurations for `melos list` and `melos changed`.
+@immutable
+class ListCommandConfigs {
+  const ListCommandConfigs({
+    this.long,
+    this.relativePaths,
+    this.format,
+  });
+
+  factory ListCommandConfigs.fromYaml(Map<Object?, Object?> yaml) {
+    final long = assertKeyIsA<bool?>(
+      key: 'long',
+      map: yaml,
+      path: 'command/list',
+    );
+
+    final relativePaths = assertKeyIsA<bool?>(
+      key: 'relativePaths',
+      map: yaml,
+      path: 'command/list',
+    );
+
+    final formatName = assertKeyIsA<String?>(
+      key: 'format',
+      map: yaml,
+      path: 'command/list',
+    );
+    final format = formatName == null
+        ? null
+        : _configurableListFormats[formatName] ??
+              (throw MelosConfigException(
+                'The value at "command/list/format" must be one of '
+                '${_configurableListFormats.keys.join(', ')} '
+                'but got "$formatName".',
+              ));
+
+    return ListCommandConfigs(
+      long: long,
+      relativePaths: relativePaths,
+      format: format,
+    );
+  }
+
+  static const ListCommandConfigs empty = ListCommandConfigs();
+
+  /// Whether to show extended information.
+  ///
+  /// The default is `false`.
+  final bool? long;
+
+  /// Whether to print package paths relative to the root of the workspace.
+  ///
+  /// The default is `false`.
+  final bool? relativePaths;
+
+  /// The output format to use.
+  ///
+  /// The default is [ListOutputKind.column].
+  final ListOutputKind? format;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (long != null) 'long': long,
+      if (relativePaths != null) 'relativePaths': relativePaths,
+      if (format != null) 'format': format!.name,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ListCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.long == long &&
+      other.relativePaths == relativePaths &&
+      other.format == format;
+
+  @override
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    long,
+    relativePaths,
+    format,
+  ]);
+
+  @override
+  String toString() {
+    return '''
+ListCommandConfigs(
+  long: $long,
+  relativePaths: $relativePaths,
+  format: ${format?.name},
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/publish.dart
+++ b/packages/melos/lib/src/command_configs/publish.dart
@@ -23,6 +23,10 @@ class PublishCommandConfigs {
     this.fetchTags = true,
     this.hooks = PublishLifecycleHooks.empty,
     this.pubServer,
+    this.dryRun,
+    this.gitTagVersion,
+    this.force,
+    this.skipValidation,
   }) : _aggregateChangelogs = aggregateChangelogs;
 
   factory PublishCommandConfigs.fromYaml(
@@ -131,6 +135,30 @@ class PublishCommandConfigs {
       path: 'command/publish',
     );
 
+    final dryRun = assertKeyIsA<bool?>(
+      key: 'dryRun',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final gitTagVersion = assertKeyIsA<bool?>(
+      key: 'gitTagVersion',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final force = assertKeyIsA<bool?>(
+      key: 'force',
+      map: yaml,
+      path: 'command/publish',
+    );
+
+    final skipValidation = assertKeyIsA<bool?>(
+      key: 'skipValidation',
+      map: yaml,
+      path: 'command/publish',
+    );
+
     final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'hooks',
       map: yaml,
@@ -178,6 +206,10 @@ class PublishCommandConfigs {
       fetchTags: fetchTags ?? true,
       hooks: hooks,
       pubServer: pubServer,
+      dryRun: dryRun,
+      gitTagVersion: gitTagVersion,
+      force: force,
+      skipValidation: skipValidation,
     );
   }
 
@@ -232,6 +264,26 @@ class PublishCommandConfigs {
   /// the per-package `publish_to` field in `pubspec.yaml` is used.
   final String? pubServer;
 
+  /// Whether packages are validated but not actually published.
+  ///
+  /// The default is `true`.
+  final bool? dryRun;
+
+  /// Whether missing tags are added for the published releases.
+  ///
+  /// Tags are only created when [dryRun] is disabled. The default is `false`.
+  final bool? gitTagVersion;
+
+  /// Whether the confirmation prompt is skipped when [dryRun] is disabled.
+  ///
+  /// The default is `false`.
+  final bool? force;
+
+  /// Whether packages are published without validation and resolution.
+  ///
+  /// The default is `false`.
+  final bool? skipValidation;
+
   Map<String, Object?> toJson() {
     return {
       if (branch != null) 'branch': branch,
@@ -246,6 +298,10 @@ class PublishCommandConfigs {
       'fetchTags': fetchTags,
       'hooks': hooks.toJson(),
       if (pubServer != null) 'pubServer': pubServer,
+      if (dryRun != null) 'dryRun': dryRun,
+      if (gitTagVersion != null) 'gitTagVersion': gitTagVersion,
+      if (force != null) 'force': force,
+      if (skipValidation != null) 'skipValidation': skipValidation,
     };
   }
 
@@ -257,6 +313,8 @@ class PublishCommandConfigs {
       other.message == message &&
       other.includeScopes == includeScopes &&
       other.includeCommitId == includeCommitId &&
+      other.includeCommitBody == includeCommitBody &&
+      other.commitBodyOnlyBreaking == commitBodyOnlyBreaking &&
       other.linkToCommits == linkToCommits &&
       other.updateGitTagRefs == updateGitTagRefs &&
       other.releaseUrl == releaseUrl &&
@@ -266,22 +324,33 @@ class PublishCommandConfigs {
       ) &&
       other.fetchTags == fetchTags &&
       other.hooks == hooks &&
-      other.pubServer == pubServer;
+      other.pubServer == pubServer &&
+      other.dryRun == dryRun &&
+      other.gitTagVersion == gitTagVersion &&
+      other.force == force &&
+      other.skipValidation == skipValidation;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      branch.hashCode ^
-      message.hashCode ^
-      includeScopes.hashCode ^
-      includeCommitId.hashCode ^
-      linkToCommits.hashCode ^
-      updateGitTagRefs.hashCode ^
-      releaseUrl.hashCode ^
-      const DeepCollectionEquality().hash(aggregateChangelogs) ^
-      fetchTags.hashCode ^
-      hooks.hashCode ^
-      pubServer.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    branch,
+    message,
+    includeScopes,
+    includeCommitId,
+    includeCommitBody,
+    commitBodyOnlyBreaking,
+    linkToCommits,
+    updateGitTagRefs,
+    releaseUrl,
+    const DeepCollectionEquality().hash(aggregateChangelogs),
+    fetchTags,
+    hooks,
+    pubServer,
+    dryRun,
+    gitTagVersion,
+    force,
+    skipValidation,
+  ]);
 
   @override
   String toString() {
@@ -298,6 +367,10 @@ PublishCommandConfigs(
   fetchTags: $fetchTags,
   hooks: $hooks,
   pubServer: $pubServer,
+  dryRun: $dryRun,
+  gitTagVersion: $gitTagVersion,
+  force: $force,
+  skipValidation: $skipValidation,
 )''';
   }
 }

--- a/packages/melos/lib/src/command_configs/run.dart
+++ b/packages/melos/lib/src/command_configs/run.dart
@@ -1,0 +1,55 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+
+/// Configurations for `melos run`.
+@immutable
+class RunCommandConfigs {
+  const RunCommandConfigs({
+    this.noSelect,
+  });
+
+  factory RunCommandConfigs.fromYaml(Map<Object?, Object?> yaml) {
+    final noSelect = assertKeyIsA<bool?>(
+      key: 'noSelect',
+      map: yaml,
+      path: 'command/run',
+    );
+
+    return RunCommandConfigs(
+      noSelect: noSelect,
+    );
+  }
+
+  static const RunCommandConfigs empty = RunCommandConfigs();
+
+  /// Whether to skip the prompt that asks for the package to run a script in,
+  /// when the script defines `packageFilters`. The filters themselves are
+  /// still applied.
+  ///
+  /// The default is `false`.
+  final bool? noSelect;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (noSelect != null) 'noSelect': noSelect,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is RunCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.noSelect == noSelect;
+
+  @override
+  int get hashCode => Object.hashAll([runtimeType, noSelect]);
+
+  @override
+  String toString() {
+    return '''
+RunCommandConfigs(
+  noSelect: $noSelect,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/test.dart
+++ b/packages/melos/lib/src/command_configs/test.dart
@@ -1,0 +1,70 @@
+import 'package:meta/meta.dart';
+
+import '../common/validation.dart';
+
+/// Configurations for `melos test`.
+@immutable
+class TestCommandConfigs {
+  const TestCommandConfigs({
+    this.concurrency,
+    this.noPub,
+  });
+
+  factory TestCommandConfigs.fromYaml(Map<Object?, Object?> yaml) {
+    final concurrency = assertKeyIsA<int?>(
+      key: 'concurrency',
+      map: yaml,
+      path: 'command/test',
+    );
+
+    final noPub = assertKeyIsA<bool?>(
+      key: 'noPub',
+      map: yaml,
+      path: 'command/test',
+    );
+
+    return TestCommandConfigs(
+      concurrency: concurrency,
+      noPub: noPub,
+    );
+  }
+
+  static const TestCommandConfigs empty = TestCommandConfigs();
+
+  /// The number of packages to run tests in concurrently.
+  ///
+  /// The default is `1`.
+  final int? concurrency;
+
+  /// Whether `--no-pub` is passed to `flutter test`, to skip the implicit
+  /// `pub get`. Has no effect on `dart test`.
+  ///
+  /// The default is `false`.
+  final bool? noPub;
+
+  Map<String, Object?> toJson() {
+    return {
+      if (concurrency != null) 'concurrency': concurrency,
+      if (noPub != null) 'noPub': noPub,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is TestCommandConfigs &&
+      other.runtimeType == runtimeType &&
+      other.concurrency == concurrency &&
+      other.noPub == noPub;
+
+  @override
+  int get hashCode => Object.hashAll([runtimeType, concurrency, noPub]);
+
+  @override
+  String toString() {
+    return '''
+TestCommandConfigs(
+  concurrency: $concurrency,
+  noPub: $noPub,
+)''';
+  }
+}

--- a/packages/melos/lib/src/command_configs/version.dart
+++ b/packages/melos/lib/src/command_configs/version.dart
@@ -39,6 +39,15 @@ class VersionCommandConfigs {
     this.includeDateInChangelogEntry = false,
     this.groupChangelogEntriesByType = false,
     this.smartDependents = false,
+    this.updateChangelog,
+    this.updateDependentsConstraints,
+    this.updateDependentsVersions,
+    this.gitTagVersion,
+    this.gitCommitVersion,
+    this.force,
+    this.versionPrivatePackages,
+    this.preid,
+    this.dependentPreid,
   }) : _aggregateChangelogs = aggregateChangelogs;
 
   factory VersionCommandConfigs.fromYaml(
@@ -166,6 +175,60 @@ class VersionCommandConfigs {
       path: 'command/version',
     );
 
+    final updateChangelog = assertKeyIsA<bool?>(
+      key: 'updateChangelog',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final updateDependentsConstraints = assertKeyIsA<bool?>(
+      key: 'updateDependentsConstraints',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final updateDependentsVersions = assertKeyIsA<bool?>(
+      key: 'updateDependentsVersions',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final gitTagVersion = assertKeyIsA<bool?>(
+      key: 'gitTagVersion',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final gitCommitVersion = assertKeyIsA<bool?>(
+      key: 'gitCommitVersion',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final force = assertKeyIsA<bool?>(
+      key: 'force',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final versionPrivatePackages = assertKeyIsA<bool?>(
+      key: 'versionPrivatePackages',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final preid = assertKeyIsA<String?>(
+      key: 'preid',
+      map: yaml,
+      path: 'command/version',
+    );
+
+    final dependentPreid = assertKeyIsA<String?>(
+      key: 'dependentPreid',
+      map: yaml,
+      path: 'command/version',
+    );
+
     final hooksMap = assertKeyIsA<Map<Object?, Object?>?>(
       key: 'hooks',
       map: yaml,
@@ -237,6 +300,15 @@ class VersionCommandConfigs {
       includeDateInChangelogEntry: includeDate ?? false,
       groupChangelogEntriesByType: groupByType ?? false,
       smartDependents: smartDependents ?? false,
+      updateChangelog: updateChangelog,
+      updateDependentsConstraints: updateDependentsConstraints,
+      updateDependentsVersions: updateDependentsVersions,
+      gitTagVersion: gitTagVersion,
+      gitCommitVersion: gitCommitVersion,
+      force: force,
+      versionPrivatePackages: versionPrivatePackages,
+      preid: preid,
+      dependentPreid: dependentPreid,
     );
   }
 
@@ -313,6 +385,53 @@ class VersionCommandConfigs {
   /// "Bug Fixes" header) instead of listing them in a single flat list.
   final bool groupChangelogEntriesByType;
 
+  /// Whether to update the `CHANGELOG.md` files of versioned packages.
+  ///
+  /// The default is `true`.
+  final bool? updateChangelog;
+
+  /// Whether to update the dependency version constraints of packages that
+  /// depend on any of the packages that are versioned.
+  ///
+  /// The default is `true`.
+  final bool? updateDependentsConstraints;
+
+  /// Whether to make a new patch version and changelog entry in packages that
+  /// are updated because of [updateDependentsConstraints].
+  ///
+  /// The default is `true`.
+  final bool? updateDependentsVersions;
+
+  /// Whether to tag the release.
+  ///
+  /// The default is `true`.
+  final bool? gitTagVersion;
+
+  /// Whether to commit the changes made to `pubspec.yaml` and changelog files.
+  ///
+  /// Disabling this also disables [gitTagVersion]. The default is `true`.
+  final bool? gitCommitVersion;
+
+  /// Whether to skip the confirmation prompt.
+  ///
+  /// The default is `false`.
+  final bool? force;
+
+  /// Whether to also version private packages, which are skipped by default.
+  ///
+  /// The default is `false`.
+  final bool? versionPrivatePackages;
+
+  /// The prerelease identifier to use when versioning packages as a
+  /// prerelease, e.g. `nullsafety` for a `1.0.0-1.0.nullsafety.0` version.
+  final String? preid;
+
+  /// The prerelease identifier to use for packages that are versioned because
+  /// of a change in a dependency version.
+  ///
+  /// Falls back to [preid] when not set.
+  final String? dependentPreid;
+
   Map<String, Object?> toJson() {
     return {
       if (branch != null) 'branch': branch,
@@ -333,6 +452,18 @@ class VersionCommandConfigs {
         'includeDate': includeDateInChangelogEntry,
         'groupByType': groupChangelogEntriesByType,
       },
+      if (updateChangelog != null) 'updateChangelog': updateChangelog,
+      if (updateDependentsConstraints != null)
+        'updateDependentsConstraints': updateDependentsConstraints,
+      if (updateDependentsVersions != null)
+        'updateDependentsVersions': updateDependentsVersions,
+      if (gitTagVersion != null) 'gitTagVersion': gitTagVersion,
+      if (gitCommitVersion != null) 'gitCommitVersion': gitCommitVersion,
+      if (force != null) 'force': force,
+      if (versionPrivatePackages != null)
+        'versionPrivatePackages': versionPrivatePackages,
+      if (preid != null) 'preid': preid,
+      if (dependentPreid != null) 'dependentPreid': dependentPreid,
     };
   }
 
@@ -344,6 +475,8 @@ class VersionCommandConfigs {
       other.message == message &&
       other.includeScopes == includeScopes &&
       other.includeCommitId == includeCommitId &&
+      other.includeCommitBody == includeCommitBody &&
+      other.commitBodyOnlyBreaking == commitBodyOnlyBreaking &&
       other.linkToCommits == linkToCommits &&
       other.updateGitTagRefs == updateGitTagRefs &&
       other.releaseUrl == releaseUrl &&
@@ -357,26 +490,47 @@ class VersionCommandConfigs {
       other.fetchTags == fetchTags &&
       other.hooks == hooks &&
       other.includeDateInChangelogEntry == includeDateInChangelogEntry &&
-      other.groupChangelogEntriesByType == groupChangelogEntriesByType;
+      other.groupChangelogEntriesByType == groupChangelogEntriesByType &&
+      other.updateChangelog == updateChangelog &&
+      other.updateDependentsConstraints == updateDependentsConstraints &&
+      other.updateDependentsVersions == updateDependentsVersions &&
+      other.gitTagVersion == gitTagVersion &&
+      other.gitCommitVersion == gitCommitVersion &&
+      other.force == force &&
+      other.versionPrivatePackages == versionPrivatePackages &&
+      other.preid == preid &&
+      other.dependentPreid == dependentPreid;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      branch.hashCode ^
-      message.hashCode ^
-      includeScopes.hashCode ^
-      includeCommitId.hashCode ^
-      linkToCommits.hashCode ^
-      updateGitTagRefs.hashCode ^
-      releaseUrl.hashCode ^
-      smartDependents.hashCode ^
-      mode.hashCode ^
-      workspaceTag.hashCode ^
-      const DeepCollectionEquality().hash(aggregateChangelogs) ^
-      fetchTags.hashCode ^
-      hooks.hashCode ^
-      includeDateInChangelogEntry.hashCode ^
-      groupChangelogEntriesByType.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    branch,
+    message,
+    includeScopes,
+    includeCommitId,
+    includeCommitBody,
+    commitBodyOnlyBreaking,
+    linkToCommits,
+    updateGitTagRefs,
+    releaseUrl,
+    smartDependents,
+    mode,
+    workspaceTag,
+    const DeepCollectionEquality().hash(aggregateChangelogs),
+    fetchTags,
+    hooks,
+    includeDateInChangelogEntry,
+    groupChangelogEntriesByType,
+    updateChangelog,
+    updateDependentsConstraints,
+    updateDependentsVersions,
+    gitTagVersion,
+    gitCommitVersion,
+    force,
+    versionPrivatePackages,
+    preid,
+    dependentPreid,
+  ]);
 
   @override
   String toString() {
@@ -397,6 +551,15 @@ VersionCommandConfigs(
   hooks: $hooks,
   includeDateInChangelogEntry: $includeDateInChangelogEntry,
   groupChangelogEntriesByType: $groupChangelogEntriesByType,
+  updateChangelog: $updateChangelog,
+  updateDependentsConstraints: $updateDependentsConstraints,
+  updateDependentsVersions: $updateDependentsVersions,
+  gitTagVersion: $gitTagVersion,
+  gitCommitVersion: $gitCommitVersion,
+  force: $force,
+  versionPrivatePackages: $versionPrivatePackages,
+  preid: $preid,
+  dependentPreid: $dependentPreid,
 )''';
   }
 }

--- a/packages/melos/lib/src/command_runner/analyze.dart
+++ b/packages/melos/lib/src/command_runner/analyze.dart
@@ -42,17 +42,16 @@ class AnalyzeCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final fatalInfos = argResults?['fatal-infos'] as bool;
+    final fatalInfos = argResults!.optional('fatal-infos') as bool?;
     final fatalWarnings = argResults!.optional('fatal-warnings') as bool?;
-    final concurrency = int.parse(argResults!['concurrency'] as String);
-    final noPub = argResults!['no-pub'] as bool;
+    final noPub = argResults!.optional('no-pub') as bool?;
 
     final melos = Melos(logger: logger, config: config);
 
     return melos.analyze(
       global: global,
       packageFilters: parsePackageFilters(config.path),
-      concurrency: concurrency,
+      concurrency: concurrencyOption,
       fatalInfos: fatalInfos,
       fatalWarnings: fatalWarnings,
       noPub: noPub,

--- a/packages/melos/lib/src/command_runner/base.dart
+++ b/packages/melos/lib/src/command_runner/base.dart
@@ -166,6 +166,13 @@ abstract class MelosCommand extends Command<void> {
     );
   }
 
+  /// The `--concurrency` option, or `null` when it was not passed on the
+  /// command line and the configured default should be used instead.
+  int? get concurrencyOption {
+    final value = argResults!.optional('concurrency') as String?;
+    return value == null ? null : int.parse(value);
+  }
+
   /// Whether any package filter arguments were explicitly provided by the
   /// user on the command line.
   bool get hasPackageFilterArgs {

--- a/packages/melos/lib/src/command_runner/bootstrap.dart
+++ b/packages/melos/lib/src/command_runner/bootstrap.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class BootstrapCommand extends MelosCommand {
@@ -52,10 +53,10 @@ class BootstrapCommand extends MelosCommand {
     return melos.bootstrap(
       global: global,
       packageFilters: parsePackageFilters(config.path),
-      enforceLockfile: argResults?['enforce-lockfile'] as bool?,
-      noExample: argResults?['no-example'] as bool,
-      offline: argResults?['offline'] as bool,
-      noPub: argResults?['no-pub'] as bool,
+      enforceLockfile: argResults!.optional('enforce-lockfile') as bool?,
+      noExample: argResults!.optional('no-example') as bool?,
+      offline: argResults!.optional('offline') as bool?,
+      noPub: argResults!.optional('no-pub') as bool?,
     );
   }
 }

--- a/packages/melos/lib/src/command_runner/exec.dart
+++ b/packages/melos/lib/src/command_runner/exec.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class ExecCommand extends MelosCommand {
@@ -65,14 +66,13 @@ class ExecCommand extends MelosCommand {
     final melos = Melos(logger: logger, config: config);
 
     final packageFilters = parsePackageFilters(config.path);
-    final concurrency = int.parse(argResults!['concurrency'] as String);
-    final failFast = argResults!['fail-fast'] as bool;
-    final orderDependents = argResults!['order-dependents'] as bool;
-    final groupLogs = argResults!['group-logs'] as bool;
+    final failFast = argResults!.optional('fail-fast') as bool?;
+    final orderDependents = argResults!.optional('order-dependents') as bool?;
+    final groupLogs = argResults!.optional('group-logs') as bool?;
 
     return melos.exec(
       execArgs,
-      concurrency: concurrency,
+      concurrency: concurrencyOption,
       failFast: failFast,
       orderDependents: orderDependents,
       groupLogs: groupLogs,

--- a/packages/melos/lib/src/command_runner/format.dart
+++ b/packages/melos/lib/src/command_runner/format.dart
@@ -1,4 +1,5 @@
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class FormatCommand extends MelosCommand {
@@ -35,10 +36,10 @@ class FormatCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final setExitIfChanged = argResults?['set-exit-if-changed'] as bool?;
-    final output = argResults?['output'] as String?;
-    final concurrency = int.parse(argResults!['concurrency'] as String);
-    final lineLength = switch (argResults?['line-length']) {
+    final setExitIfChanged =
+        argResults!.optional('set-exit-if-changed') as bool?;
+    final output = argResults!.optional('output') as String?;
+    final lineLength = switch (argResults!.optional('line-length')) {
       final int length => length,
       final String length => int.tryParse(length),
       _ => null,
@@ -49,7 +50,7 @@ class FormatCommand extends MelosCommand {
     return melos.format(
       global: global,
       packageFilters: parsePackageFilters(config.path),
-      concurrency: concurrency,
+      concurrency: concurrencyOption,
       setExitIfChanged: setExitIfChanged,
       output: output,
       lineLength: lineLength,

--- a/packages/melos/lib/src/command_runner/list.dart
+++ b/packages/melos/lib/src/command_runner/list.dart
@@ -1,4 +1,6 @@
 import '../commands/runner.dart';
+import '../common/list_output_kind.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 /// Command line options for commands that print a list of packages.
@@ -46,11 +48,13 @@ mixin PackageListOutputOptions on MelosCommand {
     );
   }
 
-  bool get long => argResults!['long'] as bool;
+  bool? get long => argResults!.optional('long') as bool?;
 
-  bool get relativePaths => argResults!['relative'] as bool;
+  bool? get relativePaths => argResults!.optional('relative') as bool?;
 
-  ListOutputKind get outputKind {
+  /// The output format requested on the command line, or `null` when none was
+  /// requested and the one configured in `command/list` should be used.
+  ListOutputKind? get outputKind {
     if (argResults!['mermaid'] as bool) {
       return ListOutputKind.mermaid;
     }
@@ -66,7 +70,7 @@ mixin PackageListOutputOptions on MelosCommand {
     if (argResults!['parsable'] as bool) {
       return ListOutputKind.parsable;
     }
-    return ListOutputKind.column;
+    return null;
   }
 }
 
@@ -96,7 +100,7 @@ class ListCommand extends MelosCommand with PackageListOutputOptions {
   final String invocation = 'melos list';
 
   @override
-  ListOutputKind get outputKind =>
+  ListOutputKind? get outputKind =>
       argResults!['cycles'] as bool ? ListOutputKind.cycles : super.outputKind;
 
   @override

--- a/packages/melos/lib/src/command_runner/publish.dart
+++ b/packages/melos/lib/src/command_runner/publish.dart
@@ -49,11 +49,13 @@ class PublishCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final dryRun = argResults![publishOptionDryRun] as bool;
-    final gitTagVersion = argResults![publishOptionGitTagVersion] as bool;
-    final yes = argResults![publishOptionYes] as bool;
-    final pubServer = argResults![publishOptionServer] as String?;
-    final skipValidation = argResults![publishOptionSkipValidation] as bool;
+    final dryRun = argResults!.optional(publishOptionDryRun) as bool?;
+    final gitTagVersion =
+        argResults!.optional(publishOptionGitTagVersion) as bool?;
+    final yes = argResults!.optional(publishOptionYes) as bool?;
+    final pubServer = argResults!.optional(publishOptionServer) as String?;
+    final skipValidation =
+        argResults!.optional(publishOptionSkipValidation) as bool?;
 
     final melos = Melos(logger: logger, config: config);
     final packageFilters = parsePackageFilters(config.path);

--- a/packages/melos/lib/src/command_runner/run.dart
+++ b/packages/melos/lib/src/command_runner/run.dart
@@ -1,4 +1,5 @@
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class RunCommand extends MelosCommand {
@@ -55,7 +56,7 @@ class RunCommand extends MelosCommand {
   Future<void> run() async {
     final melos = Melos(logger: logger, config: config);
 
-    final noSelect = argResults!['no-select'] as bool;
+    final noSelect = argResults!.optional('no-select') as bool?;
     final scriptName = argResults!.rest.isEmpty ? null : argResults!.rest.first;
     final extraArgs = scriptName != null
         ? argResults!.rest.skip(1).toList()

--- a/packages/melos/lib/src/command_runner/script.dart
+++ b/packages/melos/lib/src/command_runner/script.dart
@@ -1,4 +1,5 @@
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import '../workspace_config.dart';
 import 'base.dart';
 
@@ -53,7 +54,7 @@ class ScriptCommand extends MelosCommand {
     final melos = Melos(logger: logger, config: config);
 
     final scriptName = argResults!.name;
-    final noSelect = argResults!['no-select'] as bool;
+    final noSelect = argResults!.optional('no-select') as bool?;
 
     final packageFilters = hasPackageFilterArgs
         ? parsePackageFilters(config.path, includeConfigIgnore: false)

--- a/packages/melos/lib/src/command_runner/test.dart
+++ b/packages/melos/lib/src/command_runner/test.dart
@@ -1,4 +1,5 @@
 import '../commands/runner.dart';
+import '../common/utils.dart';
 import 'base.dart';
 
 class TestCommand extends MelosCommand {
@@ -25,15 +26,14 @@ class TestCommand extends MelosCommand {
 
   @override
   Future<void> run() async {
-    final concurrency = int.parse(argResults!['concurrency'] as String);
-    final noPub = argResults!['no-pub'] as bool;
+    final noPub = argResults!.optional('no-pub') as bool?;
 
     final melos = Melos(logger: logger, config: config);
 
     return melos.test(
       global: global,
       packageFilters: parsePackageFilters(config.path),
-      concurrency: concurrency,
+      concurrency: concurrencyOption,
       noPub: noPub,
     );
   }

--- a/packages/melos/lib/src/command_runner/version.dart
+++ b/packages/melos/lib/src/command_runner/version.dart
@@ -175,19 +175,17 @@ class VersionCommand extends MelosCommand {
   Future<void> run() async {
     final melos = Melos(logger: logger, config: config);
 
-    final force = argResults!['yes'] as bool;
+    final force = argResults!.optional('yes') as bool?;
     final updateDependentsConstraints =
-        argResults!['dependent-constraints'] as bool;
-    final tag = argResults!['git-tag-version'] as bool;
-    final commit = argResults!['git-commit-version'] as bool;
+        argResults!.optional('dependent-constraints') as bool?;
+    final tag = argResults!.optional('git-tag-version') as bool?;
+    final commit = argResults!.optional('git-commit-version') as bool?;
     final releaseUrl = argResults!.optional('release-url') as bool?;
     final groupCommits = argResults!.optional('group-commits') as bool?;
     final smartDependents = argResults!.optional('smart-dependents') as bool?;
-    final changelog = argResults!['changelog'] as bool;
-    final commitMessage = (argResults!['message'] as String?)?.replaceAll(
-      r'\n',
-      '\n',
-    );
+    final changelog = argResults!.optional('changelog') as bool?;
+    final commitMessage = (argResults!.optional('message') as String?)
+        ?.replaceAll(r'\n', '\n');
 
     if (argResults!.rest.isNotEmpty) {
       if (argResults!.rest.length != 2) {
@@ -219,17 +217,17 @@ class VersionCommand extends MelosCommand {
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: false,
-        smartDependents:
-            smartDependents ?? config.commands.version.smartDependents,
+        smartDependents: smartDependents,
         message: commitMessage,
       );
     } else {
       var asStableRelease = argResults!['graduate'] as bool;
       final asPrerelease = argResults!['prerelease'] as bool;
-      var updateDependentsVersions = argResults!['dependent-versions'] as bool;
-      final versionPrivatePackages = argResults!['all'] as bool;
-      final preid = argResults!['preid'] as String?;
-      final dependentPreid = argResults!['dependent-preid'] as String?;
+      var updateDependentsVersions =
+          argResults!.optional('dependent-versions') as bool?;
+      final versionPrivatePackages = argResults!.optional('all') as bool?;
+      final preid = argResults!.optional('preid') as String?;
+      final dependentPreid = argResults!.optional('dependent-preid') as String?;
       final manualVersionArgs = argResults!['manual-version'] as List<String>;
 
       final manualVersions = _parseManualVersions(manualVersionArgs);
@@ -245,7 +243,8 @@ class VersionCommand extends MelosCommand {
         asStableRelease = false;
       }
 
-      if (updateDependentsVersions && !updateDependentsConstraints) {
+      if ((updateDependentsVersions ?? false) &&
+          !(updateDependentsConstraints ?? true)) {
         logger.warning(
           'The setting --dependent-versions is turned on but '
           '--dependent-constraints is turned off. Versioning will continue '
@@ -265,8 +264,7 @@ class VersionCommand extends MelosCommand {
         updateChangelog: changelog,
         updateDependentsConstraints: updateDependentsConstraints,
         updateDependentsVersions: updateDependentsVersions,
-        smartDependents:
-            smartDependents ?? config.commands.version.smartDependents,
+        smartDependents: smartDependents,
         preid: preid,
         dependentPreid: dependentPreid,
         asPrerelease: asPrerelease,

--- a/packages/melos/lib/src/commands/analyze.dart
+++ b/packages/melos/lib/src/commands/analyze.dart
@@ -4,24 +4,25 @@ mixin _AnalyzeMixin on _Melos {
   Future<void> analyze({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    bool fatalInfos = true,
+    bool? fatalInfos,
     bool? fatalWarnings,
-    int concurrency = 1,
-    bool noPub = false,
+    int? concurrency,
+    bool? noPub,
   }) async {
     final workspace = await createWorkspace(
       global: global,
       packageFilters: packageFilters,
     );
     final packages = workspace.filteredPackages.values;
+    final analyzeConfig = workspace.config.commands.analyze;
 
     await _analyzeForAllPackages(
       workspace,
       packages,
-      fatalInfos: fatalInfos,
-      fatalWarnings: fatalWarnings,
-      concurrency: concurrency,
-      noPub: noPub,
+      fatalInfos: fatalInfos ?? analyzeConfig.fatalInfos ?? true,
+      fatalWarnings: fatalWarnings ?? analyzeConfig.fatalWarnings,
+      concurrency: concurrency ?? analyzeConfig.concurrency ?? 1,
+      noPub: noPub ?? analyzeConfig.noPub ?? false,
     );
   }
 

--- a/packages/melos/lib/src/commands/bootstrap.dart
+++ b/packages/melos/lib/src/commands/bootstrap.dart
@@ -4,10 +4,10 @@ mixin _BootstrapMixin on _CleanMixin {
   Future<void> bootstrap({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    bool noExample = false,
+    bool? noExample,
     bool? enforceLockfile,
-    bool offline = false,
-    bool noPub = false,
+    bool? offline,
+    bool? noPub,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -19,7 +19,9 @@ mixin _BootstrapMixin on _CleanMixin {
       CommandWithLifecycle.bootstrap,
       () async {
         final bootstrapCommandConfig = workspace.config.commands.bootstrap;
-        final runOffline = bootstrapCommandConfig.runPubGetOffline || offline;
+        final runOffline = offline ?? bootstrapCommandConfig.runPubGetOffline;
+        final runNoExample = noExample ?? bootstrapCommandConfig.noExample;
+        final skipPub = noPub ?? bootstrapCommandConfig.noPub;
         late final hasLockFile = File(
           p.join(workspace.path, 'pubspec.lock'),
         ).existsSync();
@@ -31,7 +33,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
         final pubCommandForLogging = _buildPubGetCommand(
           workspace: workspace,
-          noExample: noExample,
+          noExample: runNoExample,
           runOffline: runOffline,
           enforceLockfile: shouldEnforceLockfile,
           pubGetArgs: pubGetArgs,
@@ -74,7 +76,7 @@ mixin _BootstrapMixin on _CleanMixin {
             workspace,
           );
 
-          if (noPub) {
+          if (skipPub) {
             logger.log(
               'Skipping "$pubCommandForLogging" in workspace (--no-pub)...',
             );
@@ -85,7 +87,7 @@ mixin _BootstrapMixin on _CleanMixin {
 
             await _runPubGetForWorkspace(
               workspace,
-              noExample: noExample,
+              noExample: runNoExample,
               runOffline: runOffline,
               enforceLockfile: shouldEnforceLockfile,
               pubGetArgs: pubGetArgs,

--- a/packages/melos/lib/src/commands/exec.dart
+++ b/packages/melos/lib/src/commands/exec.dart
@@ -6,22 +6,28 @@ mixin _ExecMixin on _Melos {
     GlobalOptions? global,
     PackageFilters? packageFilters,
     int? concurrency,
-    bool failFast = false,
-    bool orderDependents = false,
-    bool groupLogs = false,
+    bool? failFast,
+    bool? orderDependents,
+    bool? groupLogs,
     Map<String, String> extraEnvironment = const {},
   }) async {
-    concurrency ??= Platform.numberOfProcessors;
     final workspace = await createWorkspace(
       global: global,
       packageFilters: packageFilters,
     );
+    final execConfig = workspace.config.commands.exec;
+    final effectiveConcurrency =
+        concurrency ?? execConfig.concurrency ?? Platform.numberOfProcessors;
+    final effectiveFailFast = failFast ?? execConfig.failFast ?? false;
+    final effectiveOrderDependents =
+        orderDependents ?? execConfig.orderDependents ?? false;
+    final effectiveGroupLogs = groupLogs ?? execConfig.groupLogs ?? false;
     final allPackages = workspace.allPackages.values.toList(growable: false);
     final executablePackages = workspace.filteredPackages.values.toList(
       growable: false,
     );
 
-    if (orderDependents) {
+    if (effectiveOrderDependents) {
       final cycles = findCyclicDependenciesInWorkspace(allPackages);
       if (cycles.isNotEmpty) {
         printCyclesInDependencies(cycles, logger);
@@ -34,10 +40,10 @@ mixin _ExecMixin on _Melos {
       workspace,
       execArgs,
       executablePackages: executablePackages,
-      failFast: failFast,
-      concurrency: concurrency,
-      orderDependents: orderDependents,
-      groupLogs: groupLogs,
+      failFast: effectiveFailFast,
+      concurrency: effectiveConcurrency,
+      orderDependents: effectiveOrderDependents,
+      groupLogs: effectiveGroupLogs,
       additionalEnvironment: extraEnvironment,
     );
   }

--- a/packages/melos/lib/src/commands/format.dart
+++ b/packages/melos/lib/src/commands/format.dart
@@ -4,7 +4,7 @@ mixin _FormatMixin on _Melos {
   Future<void> format({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    int concurrency = 1,
+    int? concurrency,
     bool? setExitIfChanged,
     String? output,
     int? lineLength,
@@ -28,29 +28,31 @@ mixin _FormatMixin on _Melos {
   Future<void> _formatForAllPackages(
     MelosWorkspace workspace,
     Iterable<Package> packages, {
-    required int concurrency,
+    int? concurrency,
     bool? setExitIfChanged,
     String? output,
     int? lineLength,
   }) async {
     final formatConfig = workspace.config.commands.format;
 
+    final effectiveConcurrency = concurrency ?? formatConfig.concurrency ?? 1;
     final effectiveSetExitIfChanged =
         setExitIfChanged ?? formatConfig.setExitIfChanged;
     final effectiveLineLength = lineLength ?? formatConfig.lineLength;
+    final effectiveOutput = output ?? formatConfig.output;
 
     final failures = <String, int?>{};
-    final pool = Pool(concurrency);
+    final pool = Pool(effectiveConcurrency);
     final formatArgs = [
       'dart',
       'format',
       if (effectiveSetExitIfChanged ?? false) '--set-exit-if-changed',
-      if (output != null) '--output $output',
+      if (effectiveOutput != null) '--output $effectiveOutput',
       if (effectiveLineLength != null) '--line-length $effectiveLineLength',
       '.',
     ];
     final formatArgsString = formatArgs.join(' ');
-    final prefixLogs = concurrency != 1 && packages.length != 1;
+    final prefixLogs = effectiveConcurrency != 1 && packages.length != 1;
 
     logger.command('melos format', withDollarSign: true);
 

--- a/packages/melos/lib/src/commands/list.dart
+++ b/packages/melos/lib/src/commands/list.dart
@@ -1,41 +1,43 @@
 part of 'runner.dart';
 
-// TODO find better names
-enum ListOutputKind { json, parsable, graph, gviz, mermaid, column, cycles }
-
 mixin _ListMixin on _Melos {
   Future<void> list({
     GlobalOptions? global,
-    bool long = false,
-    bool relativePaths = false,
+    bool? long,
+    bool? relativePaths,
     PackageFilters? packageFilters,
-    ListOutputKind kind = ListOutputKind.column,
+    ListOutputKind? kind,
   }) async {
     final workspace = await createWorkspace(
       global: global,
       packageFilters: packageFilters,
     );
 
-    switch (kind) {
+    final listConfig = workspace.config.commands.list;
+    final effectiveLong = long ?? listConfig.long ?? false;
+    final effectiveRelativePaths =
+        relativePaths ?? listConfig.relativePaths ?? false;
+
+    switch (kind ?? listConfig.format ?? ListOutputKind.column) {
       case ListOutputKind.graph:
         return _listGraph(workspace);
       case ListOutputKind.parsable:
         return _listParsable(
           workspace,
-          long: long,
-          relativePaths: relativePaths,
+          long: effectiveLong,
+          relativePaths: effectiveRelativePaths,
         );
       case ListOutputKind.column:
         return _listColumn(
           workspace,
-          long: long,
-          relativePaths: relativePaths,
+          long: effectiveLong,
+          relativePaths: effectiveRelativePaths,
         );
       case ListOutputKind.json:
         return _listJson(
           workspace,
-          relativePaths: relativePaths,
-          long: long,
+          relativePaths: effectiveRelativePaths,
+          long: effectiveLong,
         );
       case ListOutputKind.gviz:
         return _listGviz(workspace);

--- a/packages/melos/lib/src/commands/publish.dart
+++ b/packages/melos/lib/src/commands/publish.dart
@@ -4,28 +4,29 @@ mixin _PublishMixin on _ExecMixin {
   Future<void> publish({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    bool dryRun = true,
-    bool gitTagVersion = true,
+    bool? dryRun,
+    bool? gitTagVersion,
     // yes
-    bool force = false,
+    bool? force,
     String? pubServer,
-    bool skipValidation = false,
+    bool? skipValidation,
   }) async {
     final workspace = await createWorkspace(
       global: global,
       packageFilters: packageFilters,
     );
+    final publishConfig = workspace.config.commands.publish;
 
     return _runLifecycle(workspace, CommandWithLifecycle.publish, () {
       return _publish(
         workspace: workspace,
         global: global,
         packageFilters: packageFilters,
-        dryRun: dryRun,
-        gitTagVersion: gitTagVersion,
-        force: force,
-        pubServer: pubServer ?? workspace.config.commands.publish.pubServer,
-        skipValidation: skipValidation,
+        dryRun: dryRun ?? publishConfig.dryRun ?? true,
+        gitTagVersion: gitTagVersion ?? publishConfig.gitTagVersion ?? false,
+        force: force ?? publishConfig.force ?? false,
+        pubServer: pubServer ?? publishConfig.pubServer,
+        skipValidation: skipValidation ?? publishConfig.skipValidation ?? false,
       );
     });
   }
@@ -35,7 +36,7 @@ mixin _PublishMixin on _ExecMixin {
     GlobalOptions? global,
     PackageFilters? packageFilters,
     bool dryRun = true,
-    bool gitTagVersion = true,
+    bool gitTagVersion = false,
     // yes
     bool force = false,
     String? pubServer,

--- a/packages/melos/lib/src/commands/run.dart
+++ b/packages/melos/lib/src/commands/run.dart
@@ -5,7 +5,7 @@ mixin _RunMixin on _Melos {
   Future<void> run({
     GlobalOptions? global,
     String? scriptName,
-    bool noSelect = false,
+    bool? noSelect,
     bool listScripts = false,
     bool listScriptsAsJson = false,
     bool includePrivate = false,
@@ -13,6 +13,7 @@ mixin _RunMixin on _Melos {
     String? group,
     PackageFilters? packageFilters,
   }) async {
+    final skipSelection = noSelect ?? config.commands.run.noSelect ?? false;
     final publicScripts = Map<String, Script>.from(config.scripts);
     if (!includePrivate) {
       publicScripts.removeWhere((_, script) => script.isPrivate);
@@ -62,7 +63,7 @@ mixin _RunMixin on _Melos {
       final exitCode = await _runMultipleScripts(
         script,
         global: global,
-        noSelect: noSelect,
+        noSelect: skipSelection,
         scripts: config.scripts,
         steps: script.steps!,
         packageFilters: packageFilters,
@@ -92,7 +93,7 @@ mixin _RunMixin on _Melos {
     final exitCode = await _runScript(
       script,
       global: global,
-      noSelect: noSelect,
+      noSelect: skipSelection,
       extraArgs: extraArgs,
       packageFilters: packageFilters,
     );

--- a/packages/melos/lib/src/commands/runner.dart
+++ b/packages/melos/lib/src/commands/runner.dart
@@ -33,6 +33,7 @@ import '../common/git_tag_pattern_dependency.dart';
 import '../common/glob.dart';
 import '../common/intellij_project.dart';
 import '../common/io.dart';
+import '../common/list_output_kind.dart';
 import '../common/pending_package_update.dart';
 import '../common/persistent_shell.dart';
 import '../common/platform.dart';
@@ -181,7 +182,7 @@ abstract class _Melos {
 
   Future<void> run({
     String? scriptName,
-    bool noSelect = false,
+    bool? noSelect,
     PackageFilters? packageFilters,
   });
 

--- a/packages/melos/lib/src/commands/test.dart
+++ b/packages/melos/lib/src/commands/test.dart
@@ -4,8 +4,8 @@ mixin _TestMixin on _Melos {
   Future<void> test({
     GlobalOptions? global,
     PackageFilters? packageFilters,
-    int concurrency = 1,
-    bool noPub = false,
+    int? concurrency,
+    bool? noPub,
   }) async {
     final workspace = await createWorkspace(
       global: global,
@@ -14,12 +14,13 @@ mixin _TestMixin on _Melos {
     final packages = workspace.filteredPackages.values.where(
       (pkg) => Directory(p.join(pkg.path, 'test')).existsSync(),
     );
+    final testConfig = workspace.config.commands.test;
 
     await _testForAllPackages(
       workspace,
       packages,
-      concurrency: concurrency,
-      noPub: noPub,
+      concurrency: concurrency ?? testConfig.concurrency ?? 1,
+      noPub: noPub ?? testConfig.noPub ?? false,
     );
   }
 

--- a/packages/melos/lib/src/commands/version.dart
+++ b/packages/melos/lib/src/commands/version.dart
@@ -8,20 +8,20 @@ mixin _VersionMixin on _RunMixin {
     PackageFilters? packageFilters,
     bool asPrerelease = false,
     bool asStableRelease = false,
-    bool updateChangelog = true,
-    bool updateDependentsConstraints = true,
-    bool updateDependentsVersions = true,
-    bool gitTag = true,
-    bool gitCommit = true,
+    bool? updateChangelog,
+    bool? updateDependentsConstraints,
+    bool? updateDependentsVersions,
+    bool? gitTag,
+    bool? gitCommit,
     bool? releaseUrl,
     bool? groupCommits,
     String? message,
-    bool force = false,
+    bool? force,
     // all
     bool showPrivatePackages = false,
     String? preid,
     String? dependentPreid,
-    bool versionPrivatePackages = false,
+    bool? versionPrivatePackages,
     bool? smartDependents,
     Map<String, versioning.ManualVersionChange> manualVersions = const {},
   }) async {
@@ -29,11 +29,32 @@ mixin _VersionMixin on _RunMixin {
       throw ArgumentError('Cannot use both asPrerelease and asStableRelease.');
     }
 
-    if (updateDependentsVersions && !updateDependentsConstraints) {
-      throw ArgumentError(
-        'Cannot use updateDependentsVersions without '
-        'updateDependentsConstraints.',
+    final versionConfig = config.commands.version;
+    final effectiveUpdateDependentsConstraints =
+        updateDependentsConstraints ??
+        versionConfig.updateDependentsConstraints ??
+        true;
+    var effectiveUpdateDependentsVersions =
+        updateDependentsVersions ??
+        versionConfig.updateDependentsVersions ??
+        true;
+
+    if (effectiveUpdateDependentsVersions &&
+        !effectiveUpdateDependentsConstraints) {
+      if ((updateDependentsVersions ?? false) &&
+          !(updateDependentsConstraints ?? true)) {
+        throw ArgumentError(
+          'Cannot use updateDependentsVersions without '
+          'updateDependentsConstraints.',
+        );
+      }
+
+      logger.warning(
+        'updateDependentsVersions is turned on but '
+        'updateDependentsConstraints is turned off. Versioning will continue '
+        'with updateDependentsVersions turned off.',
       );
+      effectiveUpdateDependentsVersions = false;
     }
 
     if ((asPrerelease || asStableRelease) && manualVersions.isNotEmpty) {
@@ -58,20 +79,24 @@ mixin _VersionMixin on _RunMixin {
         packageFilters: packageFilters,
         asPrerelease: asPrerelease,
         asStableRelease: asStableRelease,
-        updateChangelog: updateChangelog,
-        updateDependentsConstraints: updateDependentsConstraints,
-        updateDependentsVersions: updateDependentsVersions,
-        smartDependents: smartDependents,
-        gitTag: gitTag,
-        gitCommit: gitCommit,
+        updateChangelog:
+            updateChangelog ?? versionConfig.updateChangelog ?? true,
+        updateDependentsConstraints: effectiveUpdateDependentsConstraints,
+        updateDependentsVersions: effectiveUpdateDependentsVersions,
+        smartDependents: smartDependents ?? versionConfig.smartDependents,
+        gitTag: gitTag ?? versionConfig.gitTagVersion ?? true,
+        gitCommit: gitCommit ?? versionConfig.gitCommitVersion ?? true,
         releaseUrl: releaseUrl,
         groupCommits: groupCommits,
         message: message,
-        force: force,
+        force: force ?? versionConfig.force ?? false,
         showPrivatePackages: showPrivatePackages,
-        preid: preid,
-        dependentPreid: dependentPreid,
-        versionPrivatePackages: versionPrivatePackages,
+        preid: preid ?? versionConfig.preid,
+        dependentPreid: dependentPreid ?? versionConfig.dependentPreid,
+        versionPrivatePackages:
+            versionPrivatePackages ??
+            versionConfig.versionPrivatePackages ??
+            false,
         manualVersions: manualVersions,
       );
     });

--- a/packages/melos/lib/src/common/git_repository.dart
+++ b/packages/melos/lib/src/common/git_repository.dart
@@ -142,7 +142,7 @@ GitHubRepository(
           other.name == name;
 
   @override
-  int get hashCode => origin.hashCode ^ owner.hashCode ^ name.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, origin, owner, name]);
 }
 
 /// A git repository, hosted by GitLab.
@@ -208,7 +208,7 @@ GitLabRepository(
           other.name == name;
 
   @override
-  int get hashCode => origin.hashCode ^ owner.hashCode ^ name.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, origin, owner, name]);
 }
 
 class BitbucketRepository extends HostedGitRepository {
@@ -335,7 +335,7 @@ AzureDevOpsRepository(
           other.name == name;
 
   @override
-  int get hashCode => origin.hashCode ^ owner.hashCode ^ name.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, origin, owner, name]);
 }
 
 final _hostsToUrlParser = {

--- a/packages/melos/lib/src/common/list_output_kind.dart
+++ b/packages/melos/lib/src/common/list_output_kind.dart
@@ -1,0 +1,2 @@
+// TODO find better names
+enum ListOutputKind { json, parsable, graph, gviz, mermaid, column, cycles }

--- a/packages/melos/lib/src/common/pending_package_update.dart
+++ b/packages/melos/lib/src/common/pending_package_update.dart
@@ -191,7 +191,7 @@ class MelosPendingPackageUpdate {
   }
 
   @override
-  int get hashCode => package.name.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, package.name]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/common/pub_config.dart
+++ b/packages/melos/lib/src/common/pub_config.dart
@@ -111,7 +111,8 @@ class PubClientConfig {
   }
 
   @override
-  int get hashCode => requestTimeout.hashCode ^ retryBackoff.hashCode;
+  int get hashCode =>
+      Object.hashAll([runtimeType, requestTimeout, retryBackoff]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/common/pub_dependency_list.dart
+++ b/packages/melos/lib/src/common/pub_dependency_list.dart
@@ -115,7 +115,7 @@ class VersionedEntry {
       other is VersionedEntry && name == other.name;
 
   @override
-  int get hashCode => name.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, name]);
 
   @override
   String toString() => '$name @ $version';

--- a/packages/melos/lib/src/common/retry_backoff.dart
+++ b/packages/melos/lib/src/common/retry_backoff.dart
@@ -50,12 +50,13 @@ class RetryBackoff {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
+    runtimeType,
     delayFactor,
     randomizationFactor,
     maxDelay,
     maxAttempts,
-  );
+  ]);
 }
 
 final _random = math.Random();

--- a/packages/melos/lib/src/global_options.dart
+++ b/packages/melos/lib/src/global_options.dart
@@ -30,7 +30,7 @@ class GlobalOptions {
           other.sdkPath == sdkPath;
 
   @override
-  int get hashCode => verbose.hashCode ^ sdkPath.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, verbose, sdkPath]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/lifecycle_hooks/lifecycle_hooks.dart
+++ b/packages/melos/lib/src/lifecycle_hooks/lifecycle_hooks.dart
@@ -40,7 +40,7 @@ class LifecycleHooks {
       other.post == post;
 
   @override
-  int get hashCode => runtimeType.hashCode ^ pre.hashCode ^ post.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, pre, post]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/lifecycle_hooks/publish.dart
+++ b/packages/melos/lib/src/lifecycle_hooks/publish.dart
@@ -28,7 +28,7 @@ class PublishLifecycleHooks extends LifecycleHooks {
       other.post == post;
 
   @override
-  int get hashCode => Object.hash(runtimeType, pre, post);
+  int get hashCode => Object.hashAll([runtimeType, pre, post]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/lifecycle_hooks/version.dart
+++ b/packages/melos/lib/src/lifecycle_hooks/version.dart
@@ -42,8 +42,7 @@ class VersionLifecycleHooks extends LifecycleHooks {
       other.preCommit == preCommit;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^ pre.hashCode ^ post.hashCode ^ preCommit.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, pre, post, preCommit]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/package.dart
+++ b/packages/melos/lib/src/package.dart
@@ -424,21 +424,22 @@ class PackageFilters {
       other.diff == diff;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      nullSafe.hashCode ^
-      published.hashCode ^
-      includeDependencies.hashCode ^
-      includeDependents.hashCode ^
-      includePrivatePackages.hashCode ^
-      const DeepCollectionEquality().hash(scope) ^
-      const DeepCollectionEquality().hash(ignore) ^
-      const DeepCollectionEquality().hash(dirExists) ^
-      const DeepCollectionEquality().hash(fileExists) ^
-      const DeepCollectionEquality().hash(dependsOn) ^
-      const DeepCollectionEquality().hash(noDependsOn) ^
-      const DeepCollectionEquality().hash(categories) ^
-      diff.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    nullSafe,
+    published,
+    includeDependencies,
+    includeDependents,
+    includePrivatePackages,
+    const DeepCollectionEquality().hash(scope),
+    const DeepCollectionEquality().hash(ignore),
+    const DeepCollectionEquality().hash(dirExists),
+    const DeepCollectionEquality().hash(fileExists),
+    const DeepCollectionEquality().hash(dependsOn),
+    const DeepCollectionEquality().hash(noDependsOn),
+    const DeepCollectionEquality().hash(categories),
+    diff,
+  ]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/scripts.dart
+++ b/packages/melos/lib/src/scripts.dart
@@ -183,12 +183,13 @@ class ExecOptions {
       groupLogs == other.groupLogs;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      concurrency.hashCode ^
-      failFast.hashCode ^
-      orderDependents.hashCode ^
-      groupLogs.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    concurrency,
+    failFast,
+    orderDependents,
+    groupLogs,
+  ]);
 
   @override
   String toString() =>
@@ -626,18 +627,19 @@ class Script {
       other.stdio == stdio;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      name.hashCode ^
-      run.hashCode ^
-      description.hashCode ^
-      const DeepCollectionEquality().hash(env) ^
-      packageFilters.hashCode ^
-      steps.hashCode ^
-      exec.hashCode ^
-      isPrivate.hashCode ^
-      groups.hashCode ^
-      stdio.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    name,
+    run,
+    description,
+    const DeepCollectionEquality().hash(env),
+    packageFilters,
+    steps,
+    exec,
+    isPrivate,
+    groups,
+    stdio,
+  ]);
 
   @override
   String toString() {

--- a/packages/melos/lib/src/workspace_config.dart
+++ b/packages/melos/lib/src/workspace_config.dart
@@ -9,7 +9,6 @@ import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 import '../melos.dart';
-import 'command_configs/command_configs.dart';
 import 'common/git_repository.dart';
 import 'common/glob.dart';
 import 'common/glob_equality.dart';
@@ -48,7 +47,7 @@ class IDEConfigs {
       other.intelliJ == intelliJ;
 
   @override
-  int get hashCode => runtimeType.hashCode ^ intelliJ.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, intelliJ]);
 
   @override
   String toString() {
@@ -186,14 +185,15 @@ class IntelliJConfig {
       );
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      enabled.hashCode ^
-      moduleNamePrefix.hashCode ^
-      executeInTerminal.hashCode ^
-      generateAppRunConfigs.hashCode ^
-      scriptNamePrefix.hashCode ^
-      const DeepCollectionEquality().hash(runArguments);
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    enabled,
+    moduleNamePrefix,
+    executeInTerminal,
+    generateAppRunConfigs,
+    scriptNamePrefix,
+    const DeepCollectionEquality().hash(runArguments),
+  ]);
 
   @override
   String toString() {
@@ -253,12 +253,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
       other.description == description;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      isWorkspaceChangelog.hashCode ^
-      path.hashCode ^
-      packageFilters.hashCode ^
-      description.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    isWorkspaceChangelog,
+    path,
+    packageFilters,
+    description,
+  ]);
 
   @override
   String toString() {
@@ -723,20 +724,21 @@ class MelosWorkspaceConfig {
       other.pub == pub;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^
-      path.hashCode ^
-      name.hashCode ^
-      repository.hashCode ^
-      sdkPath.hashCode ^
-      useRootAsPackage.hashCode ^
-      discoverNestedWorkspaces.hashCode ^
-      const DeepCollectionEquality(GlobEquality()).hash(packages) &
-          const DeepCollectionEquality(GlobEquality()).hash(ignore) ^
-      scripts.hashCode ^
-      ide.hashCode ^
-      commands.hashCode ^
-      pub.hashCode;
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    path,
+    name,
+    repository,
+    sdkPath,
+    useRootAsPackage,
+    discoverNestedWorkspaces,
+    const DeepCollectionEquality(GlobEquality()).hash(packages),
+    const DeepCollectionEquality(GlobEquality()).hash(ignore),
+    scripts,
+    ide,
+    commands,
+    pub,
+  ]);
 
   Map<String, Object> toJson() {
     return {
@@ -832,6 +834,5 @@ class IdeRunConfiguration {
       other.isDefault == isDefault;
 
   @override
-  int get hashCode =>
-      runtimeType.hashCode ^ name.hashCode ^ args.hashCode ^ isDefault.hashCode;
+  int get hashCode => Object.hashAll([runtimeType, name, args, isDefault]);
 }

--- a/packages/melos/test/commands/analyze_test.dart
+++ b/packages/melos/test/commands/analyze_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:io';
 
 import 'package:melos/melos.dart';
+import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
 import 'package:path/path.dart' as p;
@@ -578,5 +579,70 @@ ${'-' * terminalWidth}
         );
       },
     );
+
+    group('config', () {
+      Future<TestLogger> runAnalyzeWith(
+        AnalyzeCommandConfigs analyzeConfigs, {
+        bool? fatalInfos,
+        int? concurrency,
+      }) async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(analyze: analyzeConfigs),
+          ),
+          workspacePackages: ['a'],
+        );
+        await createProject(workspaceDir, Pubspec('a'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+        await Melos(logger: logger, config: config).analyze(
+          fatalInfos: fatalInfos,
+          concurrency: concurrency,
+        );
+
+        return logger;
+      }
+
+      test('uses the configured fatalInfos and concurrency', () async {
+        final logger = await runAnalyzeWith(
+          const AnalyzeCommandConfigs(fatalInfos: false, concurrency: 2),
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart analyze --concurrency 2'),
+        );
+      });
+
+      test('uses the configured fatalWarnings', () async {
+        final logger = await runAnalyzeWith(
+          const AnalyzeCommandConfigs(fatalWarnings: true),
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart analyze --fatal-infos --fatal-warnings'),
+        );
+      });
+
+      test('command line options take precedence over the config', () async {
+        final logger = await runAnalyzeWith(
+          const AnalyzeCommandConfigs(fatalInfos: false, concurrency: 2),
+          fatalInfos: true,
+          concurrency: 3,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart analyze --fatal-infos --concurrency 3'),
+        );
+      });
+    });
   });
 }

--- a/packages/melos/test/commands/bootstrap_test.dart
+++ b/packages/melos/test/commands/bootstrap_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:melos/melos.dart';
-import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
@@ -836,6 +835,46 @@ Generating IntelliJ IDE files...
       );
     });
 
+    test('can run pub get without the example directory', () async {
+      final workspaceDir = await createTemporaryWorkspace(
+        workspacePackages: [],
+        configBuilder: (path) => MelosWorkspaceConfig.fromYaml(
+          createYamlMap(
+            {
+              'melos': {
+                'command': {
+                  'bootstrap': {
+                    'noExample': true,
+                  },
+                },
+              },
+            },
+            defaults: configMapDefaults,
+          ),
+          path: path,
+        ),
+      );
+
+      final logger = TestLogger();
+      final config = await MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      final workspace = await MelosWorkspace.fromConfig(
+        config,
+        logger: logger.toMelosLogger(),
+      );
+      final melos = Melos(logger: logger, config: config);
+      final pubExecArgs = pubCommandExecArgs(
+        useFlutter: workspace.isFlutterWorkspace,
+        workspace: workspace,
+      );
+
+      await runMelosBootstrap(melos, logger);
+
+      expect(
+        logger.output.normalizeLines(),
+        contains('Running "${pubExecArgs.join(' ')} get --no-example"'),
+      );
+    });
+
     test('can run pub get --enforce-lockfile', () async {
       final workspaceDir = await createTemporaryWorkspace(
         workspacePackages: [],
@@ -1617,8 +1656,8 @@ Future<void> runMelosBootstrap(
   Melos melos,
   TestLogger logger, {
   bool? enforceLockfile,
-  bool offline = false,
-  bool noPub = false,
+  bool? offline,
+  bool? noPub,
 }) async {
   try {
     await melos.bootstrap(

--- a/packages/melos/test/commands/exec_test.dart
+++ b/packages/melos/test/commands/exec_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:glob/glob.dart';
 import 'package:melos/melos.dart';
+import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
 import 'package:path/path.dart' as p;
@@ -1203,6 +1204,80 @@ ${'-' * terminalWidth}
      └> SUCCESS
 ''',
           ),
+        );
+      });
+    });
+
+    group('config', () {
+      void createDelayedExitFile(Directory dir, {int delay = 0}) {
+        File('${dir.path}/delayed_exit.dart').writeAsStringSync('''
+        import 'dart:io';
+        Future<void> main() async {
+          await Future.delayed(Duration(milliseconds: $delay));
+          exit(1);
+        }
+        ''');
+      }
+
+      Future<TestLogger> runExecWith(
+        ExecCommandConfigs execConfigs, {
+        bool? failFast,
+      }) async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(exec: execConfigs),
+          ),
+          workspacePackages: ['a', 'b', 'c'],
+        );
+
+        createDelayedExitFile(
+          await createProject(workspaceDir, Pubspec('a')),
+          delay: 1000,
+        );
+        createDelayedExitFile(
+          await createProject(workspaceDir, Pubspec('b')),
+          delay: 500,
+        );
+        createDelayedExitFile(await createProject(workspaceDir, Pubspec('c')));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await Melos(logger: logger, config: config).exec(
+          ['dart', 'delayed_exit.dart'],
+          concurrency: 3,
+          orderDependents: true,
+          failFast: failFast,
+        );
+
+        return logger;
+      }
+
+      test('uses the configured failFast', () async {
+        final logger = await runExecWith(
+          const ExecCommandConfigs(failFast: true),
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('CANCELED (in 2 packages)'),
+        );
+      });
+
+      test('command line options take precedence over the config', () async {
+        final logger = await runExecWith(
+          const ExecCommandConfigs(failFast: true),
+          failFast: false,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          isNot(contains('CANCELED')),
         );
       });
     });

--- a/packages/melos/test/commands/format_test.dart
+++ b/packages/melos/test/commands/format_test.dart
@@ -2,8 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:melos/melos.dart';
-import 'package:melos/src/command_configs/command_configs.dart';
-import 'package:melos/src/command_configs/format.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:melos/src/common/utils.dart';
@@ -431,6 +429,72 @@ $ melos format
      └> FAILED (in 1 packages)
         └> a (with exit code 1)''',
           ),
+        );
+      });
+
+      test('should run format with output configValue', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              format: FormatCommandConfigs(output: 'none'),
+            ),
+          ),
+          workspacePackages: ['a'],
+        );
+
+        await createProject(workspaceDir, Pubspec('a'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await Melos(logger: logger, config: config).format();
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart format --output none .'),
+        );
+      });
+
+      test('command line options take precedence over the config', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              format: FormatCommandConfigs(
+                output: 'none',
+                lineLength: 150,
+              ),
+            ),
+          ),
+          workspacePackages: ['a'],
+        );
+
+        await createProject(workspaceDir, Pubspec('a'));
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await Melos(
+          logger: logger,
+          config: config,
+        ).format(output: 'show', lineLength: 100);
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart format --output show --line-length 100 .'),
         );
       });
     });

--- a/packages/melos/test/commands/list_test.dart
+++ b/packages/melos/test/commands/list_test.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
+import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/commands/runner.dart';
 import 'package:melos/src/common/glob.dart';
+import 'package:melos/src/common/list_output_kind.dart';
 import 'package:melos/src/package.dart';
 import 'package:melos/src/workspace_config.dart';
 import 'package:path/path.dart' as p;
@@ -483,6 +485,67 @@ graph TD
 ''');
         },
       );
+    });
+
+    group('config', () {
+      Future<MelosWorkspaceConfig> workspaceWith(
+        ListCommandConfigs listConfigs,
+      ) async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(list: listConfigs),
+          ),
+          workspacePackages: ['a'],
+        );
+        await createProject(workspaceDir, Pubspec('a'));
+
+        return MelosWorkspaceConfig.fromWorkspaceRoot(workspaceDir);
+      }
+
+      test('uses the configured format', () async {
+        final config = await workspaceWith(
+          const ListCommandConfigs(format: ListOutputKind.json),
+        );
+
+        await Melos(logger: logger, config: config).list();
+
+        expect(
+          (jsonDecode(logger.output) as List).single,
+          containsPair('name', 'a'),
+        );
+      });
+
+      test('uses the configured long and relativePaths', () async {
+        final config = await workspaceWith(
+          const ListCommandConfigs(long: true, relativePaths: true),
+        );
+
+        await Melos(logger: logger, config: config).list(
+          kind: ListOutputKind.parsable,
+        );
+
+        expect(logger.output, ignoringAnsii('packages/a:a:0.0.0:PRIVATE\n'));
+      });
+
+      test('command line options take precedence over the config', () async {
+        final config = await workspaceWith(
+          const ListCommandConfigs(
+            long: true,
+            relativePaths: true,
+            format: ListOutputKind.json,
+          ),
+        );
+
+        await Melos(logger: logger, config: config).list(
+          kind: ListOutputKind.parsable,
+          long: false,
+        );
+
+        expect(logger.output, ignoringAnsii('packages/a\n'));
+      });
     });
   });
 }

--- a/packages/melos/test/commands/publish_test.dart
+++ b/packages/melos/test/commands/publish_test.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 
 import 'package:melos/melos.dart';
-import 'package:melos/src/command_configs/command_configs.dart';
-import 'package:melos/src/command_configs/publish.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/topology.dart';
 import 'package:melos/src/lifecycle_hooks/publish.dart';
@@ -281,6 +279,67 @@ void main() {
           );
         },
       );
+    });
+
+    group('config', () {
+      Future<TestLogger> runPublishWith(
+        PublishCommandConfigs publishConfigs, {
+        bool? skipValidation,
+      }) async {
+        final logger = TestLogger();
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: CommandConfigs(publish: publishConfigs),
+          ),
+          workspacePackages: const ['a'],
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 2, 3)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await expectLater(
+          Melos(
+            logger: logger,
+            config: config,
+          ).publish(skipValidation: skipValidation),
+          completes,
+        );
+
+        return logger;
+      }
+
+      test('uses the configured force and skipValidation', () async {
+        // `force` skips the confirmation prompt, which would otherwise make
+        // this test hang.
+        final logger = await runPublishWith(
+          const PublishCommandConfigs(force: true, skipValidation: true),
+        );
+
+        expect(logger.output.normalizeLines(), contains('--skip-validation'));
+      });
+
+      test('command line options take precedence over the config', () async {
+        final logger = await runPublishWith(
+          const PublishCommandConfigs(force: true, skipValidation: true),
+          skipValidation: false,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          isNot(contains('--skip-validation')),
+        );
+      });
     });
 
     test(

--- a/packages/melos/test/commands/run_test.dart
+++ b/packages/melos/test/commands/run_test.dart
@@ -1698,4 +1698,58 @@ ${'-' * terminalWidth}
       },
     );
   });
+
+  group('config', () {
+    test(
+      'noSelect skips the package selection prompt for filtered scripts',
+      () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_package',
+            packages: [
+              createGlob('packages/**', currentDirectoryPath: path),
+            ],
+            commands: const CommandConfigs(
+              run: RunCommandConfigs(noSelect: true),
+            ),
+            scripts: Scripts({
+              'test_script': Script(
+                name: 'test_script',
+                run: 'melos exec -- "echo hello"',
+                packageFilters: PackageFilters(
+                  scope: [
+                    createGlob('*', currentDirectoryPath: path),
+                  ],
+                ),
+              ),
+            }),
+          ),
+          workspacePackages: ['a', 'b'],
+        );
+
+        await createProject(workspaceDir, Pubspec('a'));
+        await createProject(workspaceDir, Pubspec('b'));
+        await runPubGet(workspaceDir.path);
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await Melos(logger: logger, config: config).run(
+          scriptName: 'test_script',
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          isNot(contains('Select a package to run')),
+        );
+        expect(
+          logger.output.normalizeLines(),
+          contains('RUNNING (in 2 packages)'),
+        );
+      },
+    );
+  });
 }

--- a/packages/melos/test/commands/test_test.dart
+++ b/packages/melos/test/commands/test_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:melos/melos.dart';
+import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/io.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -173,5 +174,64 @@ void main() {
         expect(package.isFlutterPackage, isTrue);
       },
     );
+
+    group('config', () {
+      Future<TestLogger> runTestWith(
+        TestCommandConfigs testConfigs, {
+        int? concurrency,
+      }) async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: (path) => MelosWorkspaceConfig(
+            path: path,
+            name: 'test_workspace',
+            packages: [createGlob('packages/**', currentDirectoryPath: path)],
+            commands: CommandConfigs(test: testConfigs),
+          ),
+          workspacePackages: ['a'],
+        );
+
+        final aDir = await createProject(workspaceDir, Pubspec('a'));
+        writeTextFile(
+          p.join(aDir.path, 'test', 'a_test.dart'),
+          'void main() {}',
+          recursive: true,
+        );
+
+        final logger = TestLogger();
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await Melos(
+          logger: logger,
+          config: config,
+        ).test(concurrency: concurrency);
+
+        return logger;
+      }
+
+      test('uses the configured concurrency', () async {
+        final logger = await runTestWith(
+          const TestCommandConfigs(concurrency: 2),
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart test --concurrency=2'),
+        );
+      });
+
+      test('command line options take precedence over the config', () async {
+        final logger = await runTestWith(
+          const TestCommandConfigs(concurrency: 2),
+          concurrency: 3,
+        );
+
+        expect(
+          logger.output.normalizeLines(),
+          contains('dart test --concurrency=3'),
+        );
+      });
+    });
   });
 }

--- a/packages/melos/test/commands/version_test.dart
+++ b/packages/melos/test/commands/version_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:ansi_styles/ansi_styles.dart';
 import 'package:glob/glob.dart';
 import 'package:melos/melos.dart';
-import 'package:melos/src/command_configs/command_configs.dart';
 import 'package:melos/src/command_runner.dart';
 import 'package:melos/src/common/git_tag_pattern_dependency.dart';
 import 'package:melos/src/common/glob.dart';
@@ -2559,6 +2558,72 @@ dev_dependencies:
         },
       );
     });
+
+    group('config', () {
+      Version pubspecVersion(Directory workspaceDir, String packageName) {
+        return Pubspec.parse(
+          File(
+            p.join(workspaceDir.path, 'packages', packageName, 'pubspec.yaml'),
+          ).readAsStringSync(),
+        ).version!;
+      }
+
+      bool hasChangelog(Directory workspaceDir, String packageName) {
+        return File(
+          p.join(workspaceDir.path, 'packages', packageName, 'CHANGELOG.md'),
+        ).existsSync();
+      }
+
+      test(
+        'CLI runner respects the versioning defaults from melos.yaml',
+        () async {
+          final workspaceDir = await createTemporaryWorkspace(
+            configBuilder: _versionDefaultsWorkspaceConfigBuilder,
+            workspacePackages: ['a'],
+            useLocalTmpDirectory: true,
+          );
+
+          await createProject(
+            workspaceDir,
+            Pubspec('a', version: Version(1, 0, 0)),
+          );
+
+          final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+            workspaceDir,
+          );
+
+          // Neither --yes, --all, --no-changelog, --no-git-tag-version nor
+          // --no-git-commit-version is passed, they all come from the config.
+          await MelosCommandRunner(config).run(['version', '-V', 'a:1.0.1']);
+
+          expect(pubspecVersion(workspaceDir, 'a'), Version(1, 0, 1));
+          expect(hasChangelog(workspaceDir, 'a'), isFalse);
+        },
+      );
+
+      test('command line options take precedence over the config', () async {
+        final workspaceDir = await createTemporaryWorkspace(
+          configBuilder: _versionDefaultsWorkspaceConfigBuilder,
+          workspacePackages: ['a'],
+          useLocalTmpDirectory: true,
+        );
+
+        await createProject(
+          workspaceDir,
+          Pubspec('a', version: Version(1, 0, 0)),
+        );
+
+        final config = await MelosWorkspaceConfig.fromWorkspaceRoot(
+          workspaceDir,
+        );
+
+        await MelosCommandRunner(
+          config,
+        ).run(['version', '--changelog', '-V', 'a:1.0.1']);
+
+        expect(hasChangelog(workspaceDir, 'a'), isTrue);
+      });
+    });
   });
 }
 
@@ -2696,6 +2761,26 @@ MelosWorkspaceConfig _workspaceConfigBuilder(String path) {
       version: VersionCommandConfigs(
         fetchTags: false,
         updateGitTagRefs: true,
+      ),
+    ),
+  );
+}
+
+MelosWorkspaceConfig _versionDefaultsWorkspaceConfigBuilder(String path) {
+  return MelosWorkspaceConfig(
+    path: path,
+    name: 'test_workspace',
+    packages: [
+      createGlob('packages/**', currentDirectoryPath: path),
+    ],
+    commands: const CommandConfigs(
+      version: VersionCommandConfigs(
+        fetchTags: false,
+        force: true,
+        versionPrivatePackages: true,
+        updateChangelog: false,
+        gitTagVersion: false,
+        gitCommitVersion: false,
       ),
     ),
   );

--- a/packages/melos/test/workspace_config_test.dart
+++ b/packages/melos/test/workspace_config_test.dart
@@ -1,6 +1,4 @@
 import 'package:melos/melos.dart';
-import 'package:melos/src/command_configs/command_configs.dart';
-import 'package:melos/src/command_configs/publish.dart';
 import 'package:melos/src/common/git_repository.dart';
 import 'package:melos/src/common/glob.dart';
 import 'package:melos/src/common/platform.dart';
@@ -48,6 +46,8 @@ void main() {
               'runPubGetInParallel': false,
               'runPubGetOffline': true,
               'enforceLockfile': true,
+              'noExample': true,
+              'noPub': true,
               'dependencyOverridePaths': ['a'],
             },
             workspacePath: '.',
@@ -56,6 +56,8 @@ void main() {
             runPubGetInParallel: false,
             runPubGetOffline: true,
             enforceLockfile: true,
+            noExample: true,
+            noPub: true,
             dependencyOverridePaths: [
               createGlob('a', currentDirectoryPath: '.'),
             ],
@@ -204,6 +206,46 @@ void main() {
             path: workspace.path,
           ).commands.version.workspaceTag,
           isTrue,
+        );
+      });
+
+      test('can decode the command line option defaults', () {
+        expect(
+          VersionCommandConfigs.fromYaml(
+            const {
+              'updateChangelog': false,
+              'updateDependentsConstraints': false,
+              'updateDependentsVersions': false,
+              'gitTagVersion': false,
+              'gitCommitVersion': false,
+              'force': true,
+              'versionPrivatePackages': true,
+              'preid': 'nullsafety',
+              'dependentPreid': 'dev',
+            },
+            workspacePath: '.',
+          ),
+          const VersionCommandConfigs(
+            updateChangelog: false,
+            updateDependentsConstraints: false,
+            updateDependentsVersions: false,
+            gitTagVersion: false,
+            gitCommitVersion: false,
+            force: true,
+            versionPrivatePackages: true,
+            preid: 'nullsafety',
+            dependentPreid: 'dev',
+          ),
+        );
+      });
+
+      test('throws if updateChangelog is not a bool', () {
+        expect(
+          () => VersionCommandConfigs.fromYaml(
+            const {'updateChangelog': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
         );
       });
 
@@ -453,6 +495,38 @@ void main() {
         );
       });
 
+      test('can decode the sections of the remaining commands', () {
+        expect(
+          CommandConfigs.fromYaml(
+            const {
+              'analyze': {'fatalInfos': false},
+              'exec': {'failFast': true},
+              'list': {'format': 'parsable'},
+              'run': {'noSelect': true},
+              'test': {'concurrency': 3},
+            },
+            workspacePath: '.',
+          ),
+          const CommandConfigs(
+            analyze: AnalyzeCommandConfigs(fatalInfos: false),
+            exec: ExecCommandConfigs(failFast: true),
+            list: ListCommandConfigs(format: ListOutputKind.parsable),
+            run: RunCommandConfigs(noSelect: true),
+            test: TestCommandConfigs(concurrency: 3),
+          ),
+        );
+      });
+
+      test('throws if `exec` is not a map', () {
+        expect(
+          () => CommandConfigs.fromYaml(
+            const {'exec': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+
       test('can decode publish pubServer', () {
         expect(
           CommandConfigs.fromYaml(
@@ -500,6 +574,234 @@ void main() {
             const {'pubServer': 42},
             workspacePath: '.',
           ),
+          throwsMelosConfigException(),
+        );
+      });
+
+      test('can decode the command line option defaults', () {
+        expect(
+          PublishCommandConfigs.fromYaml(
+            const {
+              'dryRun': false,
+              'gitTagVersion': true,
+              'force': true,
+              'skipValidation': true,
+            },
+            workspacePath: '.',
+          ),
+          const PublishCommandConfigs(
+            dryRun: false,
+            gitTagVersion: true,
+            force: true,
+            skipValidation: true,
+          ),
+        );
+      });
+
+      test('throws if dryRun is not a bool', () {
+        expect(
+          () => PublishCommandConfigs.fromYaml(
+            const {'dryRun': 42},
+            workspacePath: '.',
+          ),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('FormatCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          FormatCommandConfigs.fromYaml(const {}),
+          FormatCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          FormatCommandConfigs.fromYaml(
+            const {
+              'concurrency': 2,
+              'setExitIfChanged': true,
+              'output': 'none',
+              'lineLength': 120,
+            },
+          ),
+          const FormatCommandConfigs(
+            concurrency: 2,
+            setExitIfChanged: true,
+            output: 'none',
+            lineLength: 120,
+          ),
+        );
+      });
+
+      test('throws if output is not a string', () {
+        expect(
+          () => FormatCommandConfigs.fromYaml(const {'output': 42}),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('AnalyzeCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          AnalyzeCommandConfigs.fromYaml(const {}),
+          AnalyzeCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          AnalyzeCommandConfigs.fromYaml(
+            const {
+              'concurrency': 4,
+              'fatalInfos': false,
+              'fatalWarnings': true,
+              'noPub': true,
+            },
+          ),
+          const AnalyzeCommandConfigs(
+            concurrency: 4,
+            fatalInfos: false,
+            fatalWarnings: true,
+            noPub: true,
+          ),
+        );
+      });
+
+      test('throws if concurrency is not an int', () {
+        expect(
+          () => AnalyzeCommandConfigs.fromYaml(const {'concurrency': 'many'}),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('ExecCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          ExecCommandConfigs.fromYaml(const {}),
+          ExecCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          ExecCommandConfigs.fromYaml(
+            const {
+              'concurrency': 2,
+              'failFast': true,
+              'orderDependents': true,
+              'groupLogs': true,
+            },
+          ),
+          const ExecCommandConfigs(
+            concurrency: 2,
+            failFast: true,
+            orderDependents: true,
+            groupLogs: true,
+          ),
+        );
+      });
+
+      test('throws if failFast is not a bool', () {
+        expect(
+          () => ExecCommandConfigs.fromYaml(const {'failFast': 42}),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('ListCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          ListCommandConfigs.fromYaml(const {}),
+          ListCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          ListCommandConfigs.fromYaml(
+            const {
+              'long': true,
+              'relativePaths': true,
+              'format': 'json',
+            },
+          ),
+          const ListCommandConfigs(
+            long: true,
+            relativePaths: true,
+            format: ListOutputKind.json,
+          ),
+        );
+      });
+
+      test('throws if format is not a known output format', () {
+        expect(
+          () => ListCommandConfigs.fromYaml(const {'format': 'cycles'}),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('RunCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          RunCommandConfigs.fromYaml(const {}),
+          RunCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          RunCommandConfigs.fromYaml(const {'noSelect': true}),
+          const RunCommandConfigs(noSelect: true),
+        );
+      });
+
+      test('throws if noSelect is not a bool', () {
+        expect(
+          () => RunCommandConfigs.fromYaml(const {'noSelect': 42}),
+          throwsMelosConfigException(),
+        );
+      });
+    });
+  });
+
+  group('TestCommandConfigs', () {
+    group('fromYaml', () {
+      test('accepts empty object', () {
+        expect(
+          TestCommandConfigs.fromYaml(const {}),
+          TestCommandConfigs.empty,
+        );
+      });
+
+      test('can decode values', () {
+        expect(
+          TestCommandConfigs.fromYaml(
+            const {'concurrency': 3, 'noPub': true},
+          ),
+          const TestCommandConfigs(concurrency: 3, noPub: true),
+        );
+      });
+
+      test('throws if concurrency is not an int', () {
+        expect(
+          () => TestCommandConfigs.fromYaml(const {'concurrency': true}),
           throwsMelosConfigException(),
         );
       });


### PR DESCRIPTION
## Description

Closes #148.

Each Melos command now reads its defaults from its own `command/<name>` section, so options no longer have to be typed out on every run. The snippet from the issue works, with the keys spelled out:

```yaml
melos:
  command:
    version:
      updateChangelog: false
      gitTagVersion: false
```

**New sections:** `analyze` (`concurrency`, `fatalInfos`, `fatalWarnings`, `noPub`), `exec` (`concurrency`, `failFast`, `orderDependents`, `groupLogs`), `list` (`long`, `relativePaths`, `format`, also used by `changed`), `run` (`noSelect`), `test` (`concurrency`, `noPub`).

**Extended sections:**

| Section | New keys |
| --- | --- |
| `bootstrap` | `noExample`, `noPub` |
| `format` | `concurrency`, `output` |
| `publish` | `dryRun`, `gitTagVersion`, `force`, `skipValidation` |
| `version` | `updateChangelog`, `updateDependentsConstraints`, `updateDependentsVersions`, `gitTagVersion`, `gitCommitVersion`, `force`, `versionPrivatePackages`, `preid`, `dependentPreid` |

Values resolve as `command line ?? config ?? built-in default`. The resolution happens in the `Melos` API layer, so programmatic callers get the same defaults, and it leans on the existing `ArgResults.optional` extension to tell "not passed" apart from "passed the default value".

The options that pick what a single invocation does, rather than tune how the command behaves, stay command line only, and this is documented: the [package filters](https://melos.invertase.dev/filters), `melos init`, `melos run --list/--json/--group`, `melos list --cycles`, and `melos version --prerelease/--graduate/--manual-version`.

`melos.yaml.schema.json` is updated for all of the above. It uses `additionalProperties: false` and was already missing `bootstrap/pubGetArgs` and `publish/pubServer`, so those are added too.

## Behaviour changes worth a second look

Both fall out of the resolution order and are called out in case you would rather they went the other way:

- `Melos.publish()` now defaults `gitTagVersion` to `false`. The API default was `true` while the `--git-tag-version` flag it mirrors defaults to `false`, and config resolution had to pick one. The command line is unaffected.
- Bootstrap resolved offline mode as `config.runPubGetOffline || offline` and now uses `offline ?? config.runPubGetOffline`. Every command line path behaves the same, but an explicit `offline: false` from a programmatic caller now wins over the config. The test helper in `bootstrap_test.dart` relied on the old OR and takes `bool? offline` now.

## Drive-by: `Object.hashAll`

Every `hashCode` getter in `packages/melos/lib` now uses `Object.hashAll`. XOR is commutative, so hash codes collided whenever two field values were swapped. Two bugs surfaced during the rewrite:

- `MelosWorkspaceConfig.hashCode` combined the `packages` and `ignore` hashes with `&` where every other operator was `^`.
- `includeCommitBody` and `commitBodyOnlyBreaking` were missing from both `==` and `hashCode` in the version and publish command configs.

## Rebase note

Rebased on `main` after #1079 landed. The `--no-pub` flag it added to `bootstrap`, `test` and `analyze` is configurable here too, as `command/bootstrap/noPub`, `command/test/noPub` and `command/analyze/noPub`, so the "every command line option" claim still holds.

## Checklist

- [x] `dart analyze packages` is clean
- [x] `dart format` is clean
- [x] Tests pass: 554 (up from 512 on `main`), 1 skipped, run with `dart test -j 1`

`dart test -j 4` fails about 15 version tests with `PathNotFoundException` on a `melos_init_test_*` temp directory. That is a pre-existing race between `init_test` changing the working directory and the other suites, it reproduces the same way on `main`, and everything passes serially.
